### PR TITLE
[FEAT] 닉네임 생성 UI 구현

### DIFF
--- a/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
+++ b/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		395C7E1628F984B300FC2FCA /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 395C7E1528F984B300FC2FCA /* SnapKit */; };
 		395C7E1828F9912700FC2FCA /* UIButton+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 395C7E1728F9912700FC2FCA /* UIButton+Extension.swift */; };
 		7E6B662F28FE887300C3BEEF /* UILabel+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6B662E28FE887300C3BEEF /* UILabel+Extension.swift */; };
+		D724790C28FEC8C900D67B50 /* SignupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D724790B28FEC8C900D67B50 /* SignupViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -53,6 +54,7 @@
 		395C7E1228F9841A00FC2FCA /* SizeLiteral.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SizeLiteral.swift; sourceTree = "<group>"; };
 		395C7E1728F9912700FC2FCA /* UIButton+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+Extension.swift"; sourceTree = "<group>"; };
 		7E6B662E28FE887300C3BEEF /* UILabel+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+Extension.swift"; sourceTree = "<group>"; };
+		D724790B28FEC8C900D67B50 /* SignupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -104,6 +106,7 @@
 		39257DD928F90EB100201E0B /* Screen */ = {
 			isa = PBXGroup;
 			children = (
+				D724790A28FEC8A800D67B50 /* Signup */,
 				39257DDF28F90F3B00201E0B /* Main */,
 			);
 			path = Screen;
@@ -215,6 +218,14 @@
 			path = Response;
 			sourceTree = "<group>";
 		};
+		D724790A28FEC8A800D67B50 /* Signup */ = {
+			isa = PBXGroup;
+			children = (
+				D724790B28FEC8C900D67B50 /* SignupViewController.swift */,
+			);
+			path = Signup;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -299,6 +310,7 @@
 				395C7E1328F9841A00FC2FCA /* SizeLiteral.swift in Sources */,
 				39257DC528F8FEBD00201E0B /* AppDelegate.swift in Sources */,
 				39257DC728F8FEBD00201E0B /* SceneDelegate.swift in Sources */,
+				D724790C28FEC8C900D67B50 /* SignupViewController.swift in Sources */,
 				7E6B662F28FE887300C3BEEF /* UILabel+Extension.swift in Sources */,
 				395C7E0B28F9550A00FC2FCA /* NSObject+Extension.swift in Sources */,
 				39257DEF28F937A500201E0B /* BaseTableViewCell.swift in Sources */,

--- a/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
+++ b/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		395C7E1828F9912700FC2FCA /* UIButton+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 395C7E1728F9912700FC2FCA /* UIButton+Extension.swift */; };
 		7E6B662F28FE887300C3BEEF /* UILabel+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6B662E28FE887300C3BEEF /* UILabel+Extension.swift */; };
 		D724790C28FEC8C900D67B50 /* SignupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D724790B28FEC8C900D67B50 /* SignupViewController.swift */; };
+		D724790E28FEEEC300D67B50 /* KigoTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D724790D28FEEEC300D67B50 /* KigoTextField.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -55,6 +56,7 @@
 		395C7E1728F9912700FC2FCA /* UIButton+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+Extension.swift"; sourceTree = "<group>"; };
 		7E6B662E28FE887300C3BEEF /* UILabel+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+Extension.swift"; sourceTree = "<group>"; };
 		D724790B28FEC8C900D67B50 /* SignupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupViewController.swift; sourceTree = "<group>"; };
+		D724790D28FEEEC300D67B50 /* KigoTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KigoTextField.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -165,6 +167,7 @@
 			isa = PBXGroup;
 			children = (
 				395C7E0C28F959A500FC2FCA /* MainButton.swift */,
+				D724790D28FEEEC300D67B50 /* KigoTextField.swift */,
 			);
 			path = UIComponent;
 			sourceTree = "<group>";
@@ -315,6 +318,7 @@
 				395C7E0B28F9550A00FC2FCA /* NSObject+Extension.swift in Sources */,
 				39257DEF28F937A500201E0B /* BaseTableViewCell.swift in Sources */,
 				39257DF128F93C2A00201E0B /* ImageLiteral.swift in Sources */,
+				D724790E28FEEEC300D67B50 /* KigoTextField.swift in Sources */,
 				39257DE228F90F5C00201E0B /* MainViewController.swift in Sources */,
 				39257DED28F9378D00201E0B /* BaseCollectionViewCell.swift in Sources */,
 				39257DF328F93D8900201E0B /* TextLiteral.swift in Sources */,

--- a/Maddori.Apple/Maddori.Apple/Global/Base/BaseViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Base/BaseViewController.swift
@@ -31,6 +31,7 @@ class BaseViewController: UIViewController {
         configUI()
         setupBackButton()
         setupNavigationBar()
+        hideKeyboardWhenTappedAround()
     }
 
     override func viewDidDisappear(_ animated: Bool) {

--- a/Maddori.Apple/Maddori.Apple/Global/Literal/SizeLiteral.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Literal/SizeLiteral.swift
@@ -9,4 +9,5 @@ import Foundation
 
 enum SizeLiteral {
     static let leadingTrailingPadding: CGFloat = 24
+    static let topPadding: CGFloat = 20
 }

--- a/Maddori.Apple/Maddori.Apple/Global/Literal/SizeLiteral.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Literal/SizeLiteral.swift
@@ -9,5 +9,5 @@ import Foundation
 
 enum SizeLiteral {
     static let leadingTrailingPadding: CGFloat = 24
-    static let topPadding: CGFloat = 20
+    static let topPadding: CGFloat = 12
 }

--- a/Maddori.Apple/Maddori.Apple/Global/Literal/TextLiteral.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Literal/TextLiteral.swift
@@ -12,4 +12,10 @@ enum TextLiteral {
     // MARK: - MainViewController
     
     static let mainViewControllerTitle = "예시입니다...람쥐"
+    
+    // MARK: - SignupViewController
+    
+    static let signupViewControllerTitleLabel = "키고에서 사용할 \n닉네임을 입력해주세요"
+    static let signupViewControllerNicknameTextFieldPlaceHolder = "예) 진저, 호야, 성민"
+    static let signupViewControllerDoneButtonTitle = "입력완료"
 }

--- a/Maddori.Apple/Maddori.Apple/Global/Supports/SceneDelegate.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Supports/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        let rootViewController = UINavigationController(rootViewController: SignupViewController())
+        let rootViewController = UINavigationController(rootViewController: MainViewController())
         window?.rootViewController = rootViewController
         window?.makeKeyAndVisible()
     }

--- a/Maddori.Apple/Maddori.Apple/Global/Supports/SceneDelegate.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Supports/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        let rootViewController = UINavigationController(rootViewController: MainViewController())
+        let rootViewController = UINavigationController(rootViewController: SignupViewController())
         window?.rootViewController = rootViewController
         window?.makeKeyAndVisible()
     }

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/KigoTextField.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/KigoTextField.swift
@@ -44,7 +44,7 @@ final class KigoTextField: UITextField {
         self.autocorrectionType = .no
         self.autocapitalizationType = .none
         
-        let leftPaddingView = UIView(frame: CGRect(x: 0, y: 0, width: 16, height: 0))
+        let leftPaddingView = UIView(frame: CGRect(x: 0, y: 0, width: 18, height: 0))
         self.leftView = leftPaddingView
         self.leftViewMode = .always
     }

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/KigoTextField.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/KigoTextField.swift
@@ -39,6 +39,7 @@ final class KigoTextField: UITextField {
         self.layer.masksToBounds = true
         self.layer.borderWidth = 1
         self.layer.borderColor = UIColor.white300.cgColor
+        self.layer.cornerRadius = 10
         self.textAlignment = .left
         self.returnKeyType = .done
         self.autocorrectionType = .no

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/KigoTextField.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/KigoTextField.swift
@@ -1,0 +1,67 @@
+//
+//  KigoTextField.swift
+//  Maddori.Apple
+//
+//  Created by 이성호 on 2022/10/18.
+//
+
+import UIKit
+
+import SnapKit
+
+final class KigoTextField: UITextField {
+    private enum Size {
+        static let width: CGFloat = UIScreen.main.bounds.width - (SizeLiteral.leadingTrailingPadding * 2)
+        static let height: CGFloat = 56
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configUI()
+        render()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - property
+    
+    var inText: String? {
+        didSet { setupAttribute() }
+    }
+    
+    // MARK: - function
+    
+    private func configUI() {
+        self.backgroundColor = .white300
+        self.font = .body1
+        self.layer.masksToBounds = true
+        self.layer.borderWidth = 1
+        self.layer.borderColor = UIColor.white300.cgColor
+        self.textAlignment = .left
+        self.returnKeyType = .done
+        self.autocorrectionType = .no
+        self.autocapitalizationType = .none
+        
+        let leftPaddingView = UIView(frame: CGRect(x: 0, y: 0, width: 16, height: 0))
+        self.leftView = leftPaddingView
+        self.leftViewMode = .always
+    }
+    
+    private func render() {
+        self.snp.makeConstraints {
+            $0.width.equalTo(Size.width)
+            $0.height.equalTo(Size.height)
+        }
+    }
+    
+    private func setupAttribute() {
+        let attributes = [
+            NSAttributedString.Key.font : UIFont.body1,
+            NSAttributedString.Key.foregroundColor : UIColor.gray500
+        ]
+        self.attributedPlaceholder = NSAttributedString(string: inText ?? "", attributes: attributes)
+        
+    }
+}

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/KigoTextField.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/KigoTextField.swift
@@ -27,7 +27,7 @@ final class KigoTextField: UITextField {
     
     // MARK: - property
     
-    var inText: String? {
+    var placeHolderText: String? {
         didSet { setupAttribute() }
     }
     
@@ -61,7 +61,7 @@ final class KigoTextField: UITextField {
             NSAttributedString.Key.font : UIFont.body1,
             NSAttributedString.Key.foregroundColor : UIColor.gray500
         ]
-        self.attributedPlaceholder = NSAttributedString(string: inText ?? "", attributes: attributes)
+        self.attributedPlaceholder = NSAttributedString(string: placeHolderText ?? "", attributes: attributes)
         
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Screen/Signup/SignupViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Signup/SignupViewController.swift
@@ -66,6 +66,7 @@ final class SignupViewController: BaseViewController {
         super.viewDidLoad()
         configUI()
         render()
+        setupNotificationCenter()
     }
     
     override func configUI() {
@@ -99,8 +100,31 @@ final class SignupViewController: BaseViewController {
         }
     }
     // MARK: - function
+    private func setupNotificationCenter() {
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+    
+    override func endEditingView() {
+        if !doneButton.isTouchInside {
+            view.endEditing(true)
+        }
+    }
     
     // MARK: - selector
+    @objc private func keyboardWillShow(notification:NSNotification) {
+        if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
+            UIView.animate(withDuration: 0.2, animations: {
+                self.doneButton.transform = CGAffineTransform(translationX: 0, y: -keyboardSize.height + 30)
+            })
+        }
+    }
+    
+    @objc private func keyboardWillHide(notification:NSNotification) {
+        UIView.animate(withDuration: 0.2, animations: {
+            self.doneButton.transform = .identity
+        })
+    }
 }
 
 

--- a/Maddori.Apple/Maddori.Apple/Screen/Signup/SignupViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Signup/SignupViewController.swift
@@ -75,7 +75,7 @@ final class SignupViewController: BaseViewController {
         view.addSubview(doneButton)
         doneButton.snp.makeConstraints {
             $0.centerX.equalToSuperview()
-            $0.bottom.equalTo(view.safeAreaLayoutGuide)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(2)
         }
     }
     // MARK: - function
@@ -125,7 +125,7 @@ final class SignupViewController: BaseViewController {
     @objc private func keyboardWillShow(notification:NSNotification) {
         if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
             UIView.animate(withDuration: 0.2, animations: {
-                self.doneButton.transform = CGAffineTransform(translationX: 0, y: -keyboardSize.height)
+                self.doneButton.transform = CGAffineTransform(translationX: 0, y: -keyboardSize.height + 10)
             })
         }
     }

--- a/Maddori.Apple/Maddori.Apple/Screen/Signup/SignupViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Signup/SignupViewController.swift
@@ -51,10 +51,6 @@ final class SignupViewController: BaseViewController {
         setupDelegate()
     }
     
-    override func configUI() {
-        super.configUI()
-    }
-    
     override func render() {
         view.addSubview(titleLabel)
         titleLabel.snp.makeConstraints {
@@ -64,7 +60,7 @@ final class SignupViewController: BaseViewController {
         
         view.addSubview(nicknameTextField)
         nicknameTextField.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(39)
+            $0.top.equalTo(titleLabel.snp.bottom).offset(40)
             $0.centerX.equalToSuperview()
         }
         

--- a/Maddori.Apple/Maddori.Apple/Screen/Signup/SignupViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Signup/SignupViewController.swift
@@ -16,6 +16,7 @@ final class SignupViewController: BaseViewController {
     private var nickname: String = ""
     
     // MARK: - property
+    
     private let titleLabel: UILabel = {
         let label = UILabel()
         label.text = TextLiteral.signupViewControllerTitleLabel
@@ -30,7 +31,7 @@ final class SignupViewController: BaseViewController {
     }()
     private lazy var textLimitLabel: UILabel = {
         let label = UILabel()
-        label.text = "\(minLength)/\(maxLength)"
+        label.setTextWithLineHeight(text: "\(minLength)/\(maxLength)", lineHeight: 22)
         label.font = .body2
         label.textColor = .gray500
         return label
@@ -43,6 +44,7 @@ final class SignupViewController: BaseViewController {
     }()
     
     // MARK: - life cycle
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         configUI()
@@ -54,7 +56,7 @@ final class SignupViewController: BaseViewController {
     override func render() {
         view.addSubview(titleLabel)
         titleLabel.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide).inset(SizeLiteral.leadingTrailingPadding)
+            $0.top.equalTo(view.safeAreaLayoutGuide).inset(SizeLiteral.topPadding)
             $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
         }
         
@@ -77,6 +79,7 @@ final class SignupViewController: BaseViewController {
         }
     }
     // MARK: - function
+    
     private func setupNotificationCenter() {
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
@@ -118,6 +121,7 @@ final class SignupViewController: BaseViewController {
     }
     
     // MARK: - selector
+    
     @objc private func keyboardWillShow(notification:NSNotification) {
         if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
             UIView.animate(withDuration: 0.2, animations: {
@@ -134,6 +138,7 @@ final class SignupViewController: BaseViewController {
 }
 
 // MARK: - Extension
+
 extension SignupViewController: UITextFieldDelegate {
     func textFieldDidChangeSelection(_ textField: UITextField) {
         setCounter(count: textField.text?.count ?? 0)

--- a/Maddori.Apple/Maddori.Apple/Screen/Signup/SignupViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Signup/SignupViewController.swift
@@ -1,0 +1,50 @@
+//
+//  SignupViewController.swift
+//  Maddori.Apple
+//
+//  Created by 이성호 on 2022/10/18.
+//
+
+import UIKit
+
+import SnapKit
+
+final class SignupViewController: BaseViewController {
+    
+    // MARK: - property
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "키고에서 사용할 \n닉네임을 입력해주세요"
+        label.font = .title
+        label.numberOfLines = 2
+        return label
+    }()
+    
+    // MARK: - life cycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configUI()
+        render()
+    }
+    
+    override func configUI() {
+        super.configUI()
+    }
+    
+    override func render() {
+        view.addSubview(titleLabel)
+        titleLabel.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide).inset(Size.topPadding)
+            $0.leading.equalToSuperview().inset(Size.leadingTrailingPadding)
+        }
+    }
+    // MARK: - function
+    
+    // MARK: - selector
+}
+
+
+enum Size {
+    static let leadingTrailingPadding: Int = 24
+    static let topPadding: Int = 20
+}

--- a/Maddori.Apple/Maddori.Apple/Screen/Signup/SignupViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Signup/SignupViewController.swift
@@ -131,7 +131,7 @@ final class SignupViewController: BaseViewController {
                 let fixedText = text[text.startIndex..<endIndex]
                 textField.text = fixedText + " "
                 
-                let when = DispatchTime.now() + 0.01
+                let when = DispatchTime.now()
                 DispatchQueue.main.asyncAfter(deadline: when) {
                     self.nicknameTextField.text = String(fixedText)
                     self.setCounter(count: textField.text?.count ?? 0)

--- a/Maddori.Apple/Maddori.Apple/Screen/Signup/SignupViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Signup/SignupViewController.swift
@@ -55,6 +55,12 @@ final class SignupViewController: BaseViewController {
         return label
     }()
     
+    private let doneButton: MainButton = {
+        let button = MainButton()
+        button.title = "입력완료"
+        return button
+    }()
+    
     // MARK: - life cycle
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -84,6 +90,12 @@ final class SignupViewController: BaseViewController {
         textLimitLabel.snp.makeConstraints {
             $0.top.equalTo(nicknameTextField.snp.bottom).offset(4)
             $0.trailing.equalToSuperview().inset(27)
+        }
+        
+        view.addSubview(doneButton)
+        doneButton.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.bottom.equalTo(view.safeAreaLayoutGuide)
         }
     }
     // MARK: - function

--- a/Maddori.Apple/Maddori.Apple/Screen/Signup/SignupViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Signup/SignupViewController.swift
@@ -110,11 +110,9 @@ final class SignupViewController: BaseViewController {
                 let endIndex = text.index(text.startIndex, offsetBy: maxLength)
                 let fixedText = text[text.startIndex..<endIndex]
                 textField.text = fixedText + " "
-                
-                let when = DispatchTime.now()
-                DispatchQueue.main.asyncAfter(deadline: when) {
+            
+                DispatchQueue.main.async {
                     self.nicknameTextField.text = String(fixedText)
-                    self.setCounter(count: textField.text?.count ?? 0)
                 }
             }
         }

--- a/Maddori.Apple/Maddori.Apple/Screen/Signup/SignupViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Signup/SignupViewController.swift
@@ -23,27 +23,9 @@ final class SignupViewController: BaseViewController {
         label.numberOfLines = 2
         return label
     }()
-    private let nicknameTextField: UITextField = {
-        let textField = UITextField()
-        let attributes = [
-            NSAttributedString.Key.font : UIFont.body1,
-            NSAttributedString.Key.foregroundColor : UIColor.gray500
-        ]
-        textField.backgroundColor = .white300
-        textField.attributedPlaceholder = NSAttributedString(string: "예) 진저, 호야, 성민", attributes: attributes)
-        textField.font = .body1
-        textField.layer.cornerRadius = 10
-        textField.layer.masksToBounds = true
-        textField.layer.borderWidth = 1
-        textField.layer.borderColor = UIColor.white300.cgColor
-        textField.textAlignment = .left
-        textField.returnKeyType = .done
-        textField.autocorrectionType = .no
-        textField.autocapitalizationType = .none
-        
-        let leftPaddingView = UIView(frame: CGRect(x: 0, y: 0, width: 16, height: 0))
-        textField.leftView = leftPaddingView
-        textField.leftViewMode = .always
+    private let nicknameTextField: KigoTextField = {
+        let textField = KigoTextField()
+        textField.inText = "예) 진저, 호야, 성민"
         return textField
     }()
     private lazy var textLimitLabel: UILabel = {
@@ -76,15 +58,14 @@ final class SignupViewController: BaseViewController {
     override func render() {
         view.addSubview(titleLabel)
         titleLabel.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide).inset(Size.topPadding)
-            $0.leading.equalToSuperview().inset(Size.leadingTrailingPadding)
+            $0.top.equalTo(view.safeAreaLayoutGuide).inset(SizeLiteral.leadingTrailingPadding)
+            $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
         }
         
         view.addSubview(nicknameTextField)
         nicknameTextField.snp.makeConstraints {
             $0.top.equalTo(titleLabel.snp.bottom).offset(39)
-            $0.leading.trailing.equalToSuperview().inset(Size.leadingTrailingPadding)
-            $0.height.equalTo(56)
+            $0.centerX.equalToSuperview()
         }
         
         view.addSubview(textLimitLabel)
@@ -165,10 +146,4 @@ extension SignupViewController: UITextFieldDelegate {
         let hasText = nicknameTextField.hasText
         doneButton.isDisabled = !hasText
     }
-}
-
-
-enum Size {
-    static let leadingTrailingPadding: Int = 24
-    static let topPadding: Int = 20
 }

--- a/Maddori.Apple/Maddori.Apple/Screen/Signup/SignupViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Signup/SignupViewController.swift
@@ -18,14 +18,14 @@ final class SignupViewController: BaseViewController {
     // MARK: - property
     private let titleLabel: UILabel = {
         let label = UILabel()
-        label.text = "키고에서 사용할 \n닉네임을 입력해주세요"
+        label.text = TextLiteral.signupViewControllerTitleLabel
         label.font = .title
         label.numberOfLines = 2
         return label
     }()
     private let nicknameTextField: KigoTextField = {
         let textField = KigoTextField()
-        textField.inText = "예) 진저, 호야, 성민"
+        textField.inText = TextLiteral.signupViewControllerNicknameTextFieldPlaceHolder
         return textField
     }()
     private lazy var textLimitLabel: UILabel = {
@@ -37,7 +37,7 @@ final class SignupViewController: BaseViewController {
     }()
     private let doneButton: MainButton = {
         let button = MainButton()
-        button.title = "입력완료"
+        button.title = TextLiteral.signupViewControllerDoneButtonTitle
         button.isDisabled = true
         return button
     }()

--- a/Maddori.Apple/Maddori.Apple/Screen/Signup/SignupViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Signup/SignupViewController.swift
@@ -26,7 +26,7 @@ final class SignupViewController: BaseViewController {
     }()
     private let nicknameTextField: KigoTextField = {
         let textField = KigoTextField()
-        textField.inText = TextLiteral.signupViewControllerNicknameTextFieldPlaceHolder
+        textField.placeHolderText = TextLiteral.signupViewControllerNicknameTextFieldPlaceHolder
         return textField
     }()
     private lazy var textLimitLabel: UILabel = {
@@ -125,7 +125,7 @@ final class SignupViewController: BaseViewController {
     @objc private func keyboardWillShow(notification:NSNotification) {
         if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
             UIView.animate(withDuration: 0.2, animations: {
-                self.doneButton.transform = CGAffineTransform(translationX: 0, y: -keyboardSize.height + 30)
+                self.doneButton.transform = CGAffineTransform(translationX: 0, y: -keyboardSize.height)
             })
         }
     }

--- a/Maddori.Apple/Maddori.Apple/Screen/Signup/SignupViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Signup/SignupViewController.swift
@@ -11,12 +11,47 @@ import SnapKit
 
 final class SignupViewController: BaseViewController {
     
+    private let minNum: Int = 0
+    private let maxNum: Int = 6
+    
     // MARK: - property
     private let titleLabel: UILabel = {
         let label = UILabel()
         label.text = "키고에서 사용할 \n닉네임을 입력해주세요"
         label.font = .title
         label.numberOfLines = 2
+        return label
+    }()
+    
+    private let nicknameTextField: UITextField = {
+        let textField = UITextField()
+        let attributes = [
+            NSAttributedString.Key.font : UIFont.body1,
+            NSAttributedString.Key.foregroundColor : UIColor.gray500
+        ]
+        textField.backgroundColor = .white300
+        textField.attributedPlaceholder = NSAttributedString(string: "예) 진저, 호야, 성민", attributes: attributes)
+        textField.font = .body1
+        textField.layer.cornerRadius = 10
+        textField.layer.masksToBounds = true
+        textField.layer.borderWidth = 1
+        textField.layer.borderColor = UIColor.white300.cgColor
+        textField.textAlignment = .left
+        textField.returnKeyType = .done
+        textField.autocorrectionType = .no
+        textField.autocapitalizationType = .none
+        
+        let leftPaddingView = UIView(frame: CGRect(x: 0, y: 0, width: 16, height: 0))
+        textField.leftView = leftPaddingView
+        textField.leftViewMode = .always
+        return textField
+    }()
+    
+    private lazy var textLimitLabel: UILabel = {
+        let label = UILabel()
+        label.text = "\(minNum)/\(maxNum)"
+        label.font = .body2
+        label.textColor = .gray500
         return label
     }()
     
@@ -36,6 +71,19 @@ final class SignupViewController: BaseViewController {
         titleLabel.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide).inset(Size.topPadding)
             $0.leading.equalToSuperview().inset(Size.leadingTrailingPadding)
+        }
+        
+        view.addSubview(nicknameTextField)
+        nicknameTextField.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(39)
+            $0.leading.trailing.equalToSuperview().inset(Size.leadingTrailingPadding)
+            $0.height.equalTo(56)
+        }
+        
+        view.addSubview(textLimitLabel)
+        textLimitLabel.snp.makeConstraints {
+            $0.top.equalTo(nicknameTextField.snp.bottom).offset(4)
+            $0.trailing.equalToSuperview().inset(27)
         }
     }
     // MARK: - function


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
닉네임 생성 UI 구현입니다. 

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 닉네임 뷰 라벨 생성
- 텍스트필드 생성
- 텍스트필드 제한 구현
- 키보드 위치에 따라 애니메이션 
- 메인버튼 생성
- 메인버튼 활성화 비활성화
- 텍스트 필드 컴포넌트화 하기

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
- 11번 브랜치로 이동해 오셔서 보고 가셔요~~!!


## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->

https://user-images.githubusercontent.com/59243274/196462305-afceacd6-6c0c-4ebb-b0c7-ebe54b02057c.mp4



## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
한 화면에 대한 pr을 한번에 날리게 됐는데 이것도 하나하나 나눠서 하는게 좋을지 궁금합니다. 
사실 제가 맡은 화면은 내용이 많지 않아서 하나로 해도 되겠다고 판단했지만 막상 UI구현하고 나니 아무래도 없던 파일이 생성되는것이다보니 리뷰가 많네요.

다음 pr 부터는 컴포넌트 하나하나에 pr로 해볼까? 라는 생각인데 어떻게 생각하시는지 의견 주시면 감사하겠습니다



## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #11 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
