### PR TITLE
[ADD] KeywordLabel 컴포넌트화 완료

### DIFF
--- a/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
+++ b/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		395C7E1328F9841A00FC2FCA /* SizeLiteral.swift in Sources */ = {isa = PBXBuildFile; fileRef = 395C7E1228F9841A00FC2FCA /* SizeLiteral.swift */; };
 		395C7E1628F984B300FC2FCA /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 395C7E1528F984B300FC2FCA /* SnapKit */; };
 		395C7E1828F9912700FC2FCA /* UIButton+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 395C7E1728F9912700FC2FCA /* UIButton+Extension.swift */; };
+		3E557FC328FE7BBC00714E46 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E557FC228FE7BBC00714E46 /* HomeViewController.swift */; };
+		3E557FC528FE854600714E46 /* KeywordLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E557FC428FE854600714E46 /* KeywordLabel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -51,6 +53,8 @@
 		395C7E1028F9834A00FC2FCA /* SampleDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleDTO.swift; sourceTree = "<group>"; };
 		395C7E1228F9841A00FC2FCA /* SizeLiteral.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SizeLiteral.swift; sourceTree = "<group>"; };
 		395C7E1728F9912700FC2FCA /* UIButton+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+Extension.swift"; sourceTree = "<group>"; };
+		3E557FC228FE7BBC00714E46 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
+		3E557FC428FE854600714E46 /* KeywordLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordLabel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -102,6 +106,7 @@
 		39257DD928F90EB100201E0B /* Screen */ = {
 			isa = PBXGroup;
 			children = (
+				3E557FC128FE7B9200714E46 /* View */,
 				39257DDF28F90F3B00201E0B /* Main */,
 			);
 			path = Screen;
@@ -160,6 +165,7 @@
 			isa = PBXGroup;
 			children = (
 				395C7E0C28F959A500FC2FCA /* MainButton.swift */,
+				3E557FC428FE854600714E46 /* KeywordLabel.swift */,
 			);
 			path = UIComponent;
 			sourceTree = "<group>";
@@ -210,6 +216,14 @@
 				39257DDD28F90EF900201E0B /* Sample.swift */,
 			);
 			path = Response;
+			sourceTree = "<group>";
+		};
+		3E557FC128FE7B9200714E46 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				3E557FC228FE7BBC00714E46 /* HomeViewController.swift */,
+			);
+			path = View;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -293,11 +307,13 @@
 				39257DEB28F9373900201E0B /* BaseViewController.swift in Sources */,
 				39257DDE28F90EF900201E0B /* Sample.swift in Sources */,
 				395C7E1828F9912700FC2FCA /* UIButton+Extension.swift in Sources */,
+				3E557FC328FE7BBC00714E46 /* HomeViewController.swift in Sources */,
 				395C7E1328F9841A00FC2FCA /* SizeLiteral.swift in Sources */,
 				39257DC528F8FEBD00201E0B /* AppDelegate.swift in Sources */,
 				39257DC728F8FEBD00201E0B /* SceneDelegate.swift in Sources */,
 				395C7E0B28F9550A00FC2FCA /* NSObject+Extension.swift in Sources */,
 				39257DEF28F937A500201E0B /* BaseTableViewCell.swift in Sources */,
+				3E557FC528FE854600714E46 /* KeywordLabel.swift in Sources */,
 				39257DF128F93C2A00201E0B /* ImageLiteral.swift in Sources */,
 				39257DE228F90F5C00201E0B /* MainViewController.swift in Sources */,
 				39257DED28F9378D00201E0B /* BaseCollectionViewCell.swift in Sources */,

--- a/Maddori.Apple/Maddori.Apple/Global/Supports/SceneDelegate.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Supports/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        let rootViewController = UINavigationController(rootViewController: MainViewController())
+        let rootViewController = UINavigationController(rootViewController: HomeViewController())
         window?.rootViewController = rootViewController
         window?.makeKeyAndVisible()
     }

--- a/Maddori.Apple/Maddori.Apple/Global/Supports/SceneDelegate.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Supports/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        let rootViewController = UINavigationController(rootViewController: HomeViewController())
+        let rootViewController = UINavigationController(rootViewController: MainViewController())
         window?.rootViewController = rootViewController
         window?.makeKeyAndVisible()
     }

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/KeywordLabel.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/KeywordLabel.swift
@@ -41,8 +41,10 @@ class KeywordLabel: UILabel {
     
     private var customTextColor: UIColor {
         switch keywordType {
-        case .defaultKeyword, .disabledKeyword:
+        case .defaultKeyword:
             return .white100
+        case .disabledKeyword:
+            return .gray300
         default:
             return .gray600
         }

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/KeywordLabel.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/KeywordLabel.swift
@@ -1,0 +1,42 @@
+//
+//  KeywordLabel.swift
+//  Maddori.Apple
+//
+//  Created by 이성민 on 2022/10/18.
+//
+
+import UIKit
+
+enum KeywordType {
+    case blueLabel
+    case whiteLabel
+}
+
+class KeywordLabel: UILabel {
+    
+    private let horizontalInset: CGFloat = 16.0
+    private let verticalInset: CGFloat = 13.0
+    
+    override func drawText(in rect: CGRect) {
+        let insets = UIEdgeInsets(top: verticalInset, left: horizontalInset, bottom: verticalInset, right: horizontalInset)
+        super.drawText(in: rect.inset(by: insets))
+        setCornerRadius()
+    }
+    
+    override var intrinsicContentSize: CGSize {
+        let size = super.intrinsicContentSize
+        return CGSize(width: size.width + 2 * horizontalInset, height: size.height + 2 * verticalInset)
+    }
+    
+    override var bounds: CGRect {
+        didSet {
+            preferredMaxLayoutWidth = bounds.width - 2 * horizontalInset
+        }
+    }
+    
+    private func setCornerRadius() {
+        self.layer.masksToBounds = true
+        self.layer.cornerRadius = 24
+        self.layer.maskedCorners = [.layerMaxXMaxYCorner, .layerMaxXMinYCorner, .layerMinXMinYCorner]
+    }
+}

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/KeywordLabel.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/KeywordLabel.swift
@@ -52,12 +52,13 @@ final class KeywordLabel: UILabel {
     
     override var intrinsicContentSize: CGSize {
         let size = super.intrinsicContentSize
-        return CGSize(width: size.width + 2 * horizontalInset, height: size.height + 2 * verticalInset)
+        return CGSize(width: (horizontalInset * 2) + size.width,
+                      height: (verticalInset * 2) + size.height)
     }
     
     override var bounds: CGRect {
         didSet {
-            preferredMaxLayoutWidth = bounds.width - 2 * horizontalInset
+            preferredMaxLayoutWidth = (horizontalInset * (-2)) + bounds.width 
         }
     }
     

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/KeywordLabel.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/KeywordLabel.swift
@@ -14,7 +14,7 @@ enum KeywordType {
     case previewKeyword
 }
 
-class KeywordLabel: UILabel {
+final class KeywordLabel: UILabel {
     
     private let horizontalInset: CGFloat = 16.0
     private let verticalInset: CGFloat = 13.0

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/KeywordLabel.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/KeywordLabel.swift
@@ -20,7 +20,7 @@ class KeywordLabel: UILabel {
     private let verticalInset: CGFloat = 13.0
     
     var keywordType: KeywordType?
-    // enum으로 간략화 시켰는데 default를 그냥 중복되는게 제일 많은걸로 설정함 -> 이게 옳은 방법일지, 아니면 defaultKeyword를 default로 해야할지?
+    
     private var maskedCorners: CACornerMask {
         switch keywordType {
         case .previewKeyword:
@@ -30,7 +30,7 @@ class KeywordLabel: UILabel {
         }
     }
     
-    private var labelColor: [UIColor] {
+    var labelColor: [UIColor] {
         switch keywordType {
         case .defaultKeyword:
             return [.gradientBlueTop, .gradientBlueBottom]
@@ -39,7 +39,7 @@ class KeywordLabel: UILabel {
         }
     }
     
-    private var fontColor: UIColor {
+    private var customTextColor: UIColor {
         switch keywordType {
         case .defaultKeyword, .disabledKeyword:
             return .white100
@@ -61,10 +61,21 @@ class KeywordLabel: UILabel {
     
     override func drawText(in rect: CGRect) {
         let insets = UIEdgeInsets(top: verticalInset, left: horizontalInset, bottom: verticalInset, right: horizontalInset)
+        self.font = UIFont.main
         setCornerRadius()
+        setTextColor()
         setLabelColor()
-        setFontColor()
         super.drawText(in: rect.inset(by: insets))
+//        TODO: 2차 스프린트 때 그라디언트 넣기
+//        let textLayer = CATextLayer()
+//        textLayer.frame = self.bounds
+//        textLayer.alignmentMode = .center
+//        textLayer.position = CGPoint(x: 0, y: intrinsicContentSize.height * 0.5)
+//        textLayer.fontSize = 18.0
+//        textLayer.font = UIFont.main
+//        textLayer.foregroundColor = fontColor.cgColor
+//        textLayer.string = self.text
+//        self.layer.addSublayer(textLayer)
     }
     
     private func setCornerRadius() {
@@ -74,10 +85,12 @@ class KeywordLabel: UILabel {
     }
     
     private func setLabelColor() {
-        self.setGradient(colorTop: labelColor[0], colorBottom: labelColor[1])
+        self.backgroundColor = labelColor[0]
+//         TODO: 2차 스프린트 때 그라디언트 넣기
+//         self.setGradient(colorTop: labelColor[0], colorBottom: labelColor[1])
     }
     
-    private func setFontColor() {
-        self.textColor = .black
+    private func setTextColor() {
+        self.textColor = customTextColor
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Screen/View/HomeViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/View/HomeViewController.swift
@@ -15,16 +15,14 @@ class HomeViewController: UIViewController {
     
     private let firstLabel: KeywordLabel = {
         let keyword = KeywordLabel()
-        keyword.text = "첫 번째"
         keyword.keywordType = .defaultKeyword
-        keyword.font = UIFont.main
+        keyword.text = "첫 djdkdkdk번째"
         return keyword
     }()
     private let secondLabel: KeywordLabel = {
         let keyword = KeywordLabel()
         keyword.text = "첫 번째"
-        keyword.keywordType = .defaultKeyword
-        keyword.font = UIFont.main
+        keyword.keywordType = .previewKeyword
         return keyword
     }()
     
@@ -39,7 +37,7 @@ class HomeViewController: UIViewController {
     // MARK: - func
     
     private func configUI() {
-        view.backgroundColor = .backgroundWhite
+        view.backgroundColor = .black
     }
     
     private func render() {

--- a/Maddori.Apple/Maddori.Apple/Screen/View/HomeViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/View/HomeViewController.swift
@@ -43,15 +43,14 @@ class HomeViewController: UIViewController {
     private func render() {
         view.addSubview(firstLabel)
         firstLabel.snp.makeConstraints {
-            $0.left.equalTo(view.safeAreaLayoutGuide).inset(24)
+            $0.leading.equalTo(view.safeAreaLayoutGuide).inset(24)
             $0.top.equalTo(view.safeAreaLayoutGuide).inset(24)
         }
+        
         view.addSubview(secondLabel)
         secondLabel.snp.makeConstraints {
-            $0.left.equalTo(firstLabel.snp.right).inset(-10)
+            $0.leading.equalTo(firstLabel.snp.trailing).offset(10)
             $0.top.equalTo(view.safeAreaLayoutGuide).inset(24)
         }
     }
-    
-    // MARK: - selector
 }

--- a/Maddori.Apple/Maddori.Apple/Screen/View/HomeViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/View/HomeViewController.swift
@@ -1,0 +1,58 @@
+//
+//  HomeViewController.swift
+//  Maddori.Apple
+//
+//  Created by 이성민 on 2022/10/18.
+//
+
+import UIKit
+
+import SnapKit
+
+class HomeViewController: UIViewController {
+    
+    // MARK: - property
+    
+    private let first: KeywordLabel = {
+        let keyword = KeywordLabel()
+        keyword.text = "첫 번째"
+        keyword.font = UIFont.systemFont(ofSize: 18)
+        keyword.textColor = .white
+        keyword.backgroundColor = UIColor(hex: "4776FB")
+        return keyword
+    }()
+    private let second: KeywordLabel = {
+        let keyword = KeywordLabel()
+        keyword.text = "첫 번째"
+        keyword.font = UIFont.systemFont(ofSize: 18)
+        keyword.textColor = .white
+        keyword.backgroundColor = UIColor(hex: "4776FB")
+        return keyword
+    }()
+    
+    
+    // MARK: - life cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configUI()
+        render()
+    }
+    
+    
+    // MARK: - func
+    
+    private func configUI() {
+        view.backgroundColor = .backgroundWhite
+    }
+    
+    private func render() {
+        view.addSubview(first)
+        first.snp.makeConstraints {
+            $0.left.equalTo(view.safeAreaLayoutGuide).inset(24)
+            $0.top.equalTo(view.safeAreaLayoutGuide).inset(24)
+        }
+    }
+    
+    // MARK: - selector
+}


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
자주 쓰이게 될 키워드를 UIComponent로 빼뒀습니다!

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
처음에 UIView 위에 UILabel을 씌우는걸 생각해봤는데, @dangsal 호야가 좋은 방법을 알려줘서 그대로 했습니다
UILabel 을 그릴 때 주변에 패딩을 주어 사이즈도 알아서 맞춰주는..!
참고 사이트는 하단에 넣어뒀습니다~

저희가 키워드가 총 4종류가 있는데요
(네이밍은 피그마에 지정해둔걸로 따랐습니다(preview는 그냥 제가 알아서 함..))
- defaultKeyword
- subKeyword
- disabledKeyword
- previewKeyword
키워드 레이블 넣을 때 keywordType을 위 4가지 중 하나로 지정해주면 디자인에 맞게 변경됩니당

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
현재 HomeViewController를 만들어서 내부에서 테스트 중이었습니당
해당 파일 안에 firstLabel과 secondLabel 프로퍼티를 조절해보면 됩니당

예를 들어서
```swift
private let firstLabel: KeywordLabel = {
    let keyword = KeywordLabel()
    keyword.keywordType = .disabledKeyword // -> .defaultKeyword 로 바꿔보시면 됩니다
    keyword.text = "첫 djdkdkdk번째"
    return keyword
}()
```

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<img src="https://user-images.githubusercontent.com/72431640/196590353-858d611c-d9c0-4a79-8c95-518781cc1ab4.png" width="300">


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
원래 디자인은 defaultKeyword는 gradient가 들어가야 하는데, 
이걸 넣게 되면 UILabel 위에 gradient layer를 덧씌우게 됩니다

여기서 문제가 발생하는데, UILabel 위에 덧씌우게 되면 텍스트가 보이지 않게 됩니다
<img src="https://user-images.githubusercontent.com/72431640/196590637-63978834-b5b7-4b5f-a876-57f764fc54a8.png" width="300">
놀랍게도 저 그라디언트 아래에 텍스트가 있답니다..👀

저 gradient layer 위에 textlayer를 덧씌우는 방법을 찾긴 했는데.. 
(이게 KeywordLabel.swift 파일의 TODO로 주석처리 해둔 부분입니다)
y축 방향으로 이동하는건 해결이 안돼서 개발 후딱 해야 하기 때문에...
일단은 1차 스프린트 동안은 defaultKeyword의 색을 mainColor로 가져가면 좋을 것 같습니다

키워드 뒤에 shadow 넣는것도.. 해두긴 해야하는데 이건 디테일한 부분 만질 때 같이 넣어보겠습니다!


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #8


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
https://jeonyeohun.tistory.com/m/248
