### PR TITLE
[FEAT] 팀생성 UI 구현

### DIFF
--- a/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
+++ b/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
@@ -40,8 +40,8 @@
 		525E721728FEF2C500EF3FCB /* ExitButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525E721628FEF2C500EF3FCB /* ExitButton.swift */; };
 		525E721A28FF0F1900EF3FCB /* MemberCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525E721928FF0F1900EF3FCB /* MemberCollectionViewCell.swift */; };
 		525E721C28FF0F5B00EF3FCB /* MemberCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525E721B28FF0F5B00EF3FCB /* MemberCollectionView.swift */; };
-		525E722128FFC9A800EF3FCB /* BackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525E722028FFC9A800EF3FCB /* BackButton.swift */; };
 		525E721F28FFC89800EF3FCB /* AddFeedbackContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525E721E28FFC89800EF3FCB /* AddFeedbackContentViewController.swift */; };
+		525E722128FFC9A800EF3FCB /* BackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525E722028FFC9A800EF3FCB /* BackButton.swift */; };
 		525E722528FFCFA600EF3FCB /* FeedbackTypeButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525E722428FFCFA600EF3FCB /* FeedbackTypeButtonView.swift */; };
 		7E2ECA102901136700A4D65C /* SetupNicknameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E2ECA0F2901136700A4D65C /* SetupNicknameViewController.swift */; };
 		7E6B662F28FE887300C3BEEF /* UILabel+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6B662E28FE887300C3BEEF /* UILabel+Extension.swift */; };
@@ -49,6 +49,7 @@
 		D724790C28FEC8C900D67B50 /* BaseTextFieldViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D724790B28FEC8C900D67B50 /* BaseTextFieldViewController.swift */; };
 		D724790E28FEEEC300D67B50 /* KigoTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D724790D28FEEEC300D67B50 /* KigoTextField.swift */; };
 		D79D908C2903B6B1004DDC4A /* LabelButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D79D908B2903B6B1004DDC4A /* LabelButtonView.swift */; };
+		D79D908E29041F42004DDC4A /* CreateTeamViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D79D908D29041F42004DDC4A /* CreateTeamViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -95,6 +96,7 @@
 		D724790B28FEC8C900D67B50 /* BaseTextFieldViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTextFieldViewController.swift; sourceTree = "<group>"; };
 		D724790D28FEEEC300D67B50 /* KigoTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KigoTextField.swift; sourceTree = "<group>"; };
 		D79D908B2903B6B1004DDC4A /* LabelButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelButtonView.swift; sourceTree = "<group>"; };
+		D79D908D29041F42004DDC4A /* CreateTeamViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateTeamViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -310,14 +312,6 @@
 			path = UIComponent;
 			sourceTree = "<group>";
 		};
-		525E721D28FFC85200EF3FCB /* AddFeedbackContent */ = {
-			isa = PBXGroup;
-			children = (
-				525E721E28FFC89800EF3FCB /* AddFeedbackContentViewController.swift */,
-			);
-			path = AddFeedbackContent;
-			sourceTree = "<group>";
-		};
 		3E557FFB2901CD6600714E46 /* Keyword */ = {
 			isa = PBXGroup;
 			children = (
@@ -341,11 +335,20 @@
 			path = AddFeedbackMember;
 			sourceTree = "<group>";
 		};
+		525E721D28FFC85200EF3FCB /* AddFeedbackContent */ = {
+			isa = PBXGroup;
+			children = (
+				525E721E28FFC89800EF3FCB /* AddFeedbackContentViewController.swift */,
+			);
+			path = AddFeedbackContent;
+			sourceTree = "<group>";
+		};
 		D724790A28FEC8A800D67B50 /* Setup */ = {
 			isa = PBXGroup;
 			children = (
 				7E2ECA0F2901136700A4D65C /* SetupNicknameViewController.swift */,
 				7EB4D58129011EF7001FC396 /* JoinTeamViewController.swift */,
+				D79D908D29041F42004DDC4A /* CreateTeamViewController.swift */,
 			);
 			path = Setup;
 			sourceTree = "<group>";
@@ -445,6 +448,7 @@
 				D724790C28FEC8C900D67B50 /* BaseTextFieldViewController.swift in Sources */,
 				7E6B662F28FE887300C3BEEF /* UILabel+Extension.swift in Sources */,
 				395C7E0B28F9550A00FC2FCA /* NSObject+Extension.swift in Sources */,
+				D79D908E29041F42004DDC4A /* CreateTeamViewController.swift in Sources */,
 				3E557FFD2901CD7400714E46 /* Keyword.swift in Sources */,
 				395C7E1D28FEC8C400FC2FCA /* CloseButton.swift in Sources */,
 				D79D908C2903B6B1004DDC4A /* LabelButtonView.swift in Sources */,

--- a/Maddori.Apple/Maddori.Apple/Global/Base/BaseTextFieldViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Base/BaseTextFieldViewController.swift
@@ -12,7 +12,7 @@ import SnapKit
 class BaseTextFieldViewController: BaseViewController {
     
     private let minLength: Int = 0
-    private let maxLength: Int = 6
+    var maxLength: Int = 0
     private var nickname: String = ""
     
     var titleText: String = ""

--- a/Maddori.Apple/Maddori.Apple/Global/Literal/TextLiteral.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Literal/TextLiteral.swift
@@ -44,4 +44,9 @@ enum TextLiteral {
     static let joinTeamViewControllerNicknameTextFieldPlaceHolder = "초대코드"
     static let joinTeamViewControllerSubText = "팀이 없나요?"
     static let joinTeamViewControllerSubButtonText = "팀 생성하기"
+    
+    // MARK: - CreateTeamViewController
+    
+    static let createTeamViewControllerTitleLabel = "팀 이름을 입력해주세요"
+    static let createTeamViewControllerTextFieldPlaceHolder = "예) 맛쟁이 사과처럼"
 }

--- a/Maddori.Apple/Maddori.Apple/Global/Supports/SceneDelegate.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Supports/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        let rootViewController = UINavigationController(rootViewController: CreateTeamViewController())
+        let rootViewController = UINavigationController(rootViewController: MainViewController())
         window?.rootViewController = rootViewController
         window?.makeKeyAndVisible()
     }

--- a/Maddori.Apple/Maddori.Apple/Global/Supports/SceneDelegate.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Supports/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        let rootViewController = UINavigationController(rootViewController: MainViewController())
+        let rootViewController = UINavigationController(rootViewController: CreateTeamViewController())
         window?.rootViewController = rootViewController
         window?.makeKeyAndVisible()
     }

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/CreateTeamViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/CreateTeamViewController.swift
@@ -1,0 +1,53 @@
+//
+//  CreateTeamViewController.swift
+//  Maddori.Apple
+//
+//  Created by 이성호 on 2022/10/22.
+//
+
+import UIKit
+
+import SnapKit
+
+final class CreateTeamViewController: BaseTextFieldViewController {
+    
+    override var titleText: String {
+        get {
+            return TextLiteral.createTeamViewControllerTitleLabel
+        }
+        
+        set {
+            super.titleText = newValue
+        }
+    }
+    
+    override var placeholderText: String {
+        get {
+            return TextLiteral.createTeamViewControllerTextFieldPlaceHolder
+        }
+        
+        set {
+            super.placeholderText = newValue
+        }
+    }
+    
+    override var buttonText: String {
+        get {
+            return TextLiteral.joinTeamViewControllerSubButtonText
+        }
+        
+        set {
+            super.buttonText = newValue
+        }
+    }
+    
+    override var maxLength: Int {
+        get {
+            return 10
+        }
+        
+        set {
+            super.maxLength = newValue
+        }
+    }
+}

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/JoinTeamViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/JoinTeamViewController.swift
@@ -33,6 +33,16 @@ final class JoinTeamViewController: BaseTextFieldViewController {
         }
     }
     
+    override var maxLength: Int {
+        get {
+            return 6
+        }
+        
+        set {
+            super.maxLength = newValue
+        }
+    }
+    
     override var buttonText: String {
         get {
             return TextLiteral.doneButtonTitle

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/SetupNicknameViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/SetupNicknameViewController.swift
@@ -29,6 +29,16 @@ final class SetupNicknameViewController: BaseTextFieldViewController {
         }
     }
     
+    override var maxLength: Int {
+        get {
+            return 6
+        }
+        
+        set {
+            super.maxLength = newValue
+        }
+    }
+    
     override var buttonText: String {
         get {
             return TextLiteral.doneButtonTitle


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
- 팀 생성하기 버튼으로 나오는 화면입니다.
- 이전 pr 에서 연결되는 pr이라 이전께 머지되면 파일 체인지가 줄어들겁니다
- 여기서 추가한 부분은 CreateTeam 이라는 뷰컨이고 이 안에는 타이틀, 플레이스홀더, 버튼 타이틀이 변경되었고
- 텍스트필드의 제한 숫자도 받아줘야겠다 생각이 들어 이것도 받는것으로 변경했습니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- CreateTeamViewController 생성
- 타이틀, 플레이스홀터, 버튼 타이틀 오버라이드
- 제한 숫자 받는걸로 변경
- 10으로 오버라이드


## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->

feature/22-createTeam 으로 오셔서 신델리게이트는 CreateTeamViewController 로 변경하시면 됩니다.


## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<img src = "https://user-images.githubusercontent.com/59243274/197340621-256ae3ad-ed2c-4e53-8cbb-db0861b55bbe.png" width = "300">


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- 팀합류 PR 이 머지 된 후 보시는걸 추천드립니다. 
- 여기서는 네비게이션의 x버튼을 하지 않았습니다. 
- 해도 되지만 이부분은 연결할때 뷰들을 확인하면서 한번에 하는게 속도 상 빠를것이라고 판단했습니다.

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #25


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
