### PR TITLE
[ADD] 회고내용 View 완료

### DIFF
--- a/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
+++ b/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		391596622904176500A432D9 /* UIView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 391596612904176500A432D9 /* UIView+Extension.swift */; };
+		391CBA19290580460044CA30 /* ReflectionInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 391CBA18290580460044CA30 /* ReflectionInfoViewController.swift */; };
+		391CBA1C290582130044CA30 /* ReflectionInfoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 391CBA1B290582130044CA30 /* ReflectionInfoModel.swift */; };
 		39257DC528F8FEBD00201E0B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39257DC428F8FEBD00201E0B /* AppDelegate.swift */; };
 		39257DC728F8FEBD00201E0B /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39257DC628F8FEBD00201E0B /* SceneDelegate.swift */; };
 		39257DCE28F8FEBE00201E0B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 39257DCD28F8FEBE00201E0B /* Assets.xcassets */; };
@@ -55,6 +57,8 @@
 
 /* Begin PBXFileReference section */
 		391596612904176500A432D9 /* UIView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extension.swift"; sourceTree = "<group>"; };
+		391CBA18290580460044CA30 /* ReflectionInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReflectionInfoViewController.swift; sourceTree = "<group>"; };
+		391CBA1B290582130044CA30 /* ReflectionInfoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReflectionInfoModel.swift; sourceTree = "<group>"; };
 		39257DC128F8FEBD00201E0B /* Maddori.Apple.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Maddori.Apple.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		39257DC428F8FEBD00201E0B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		39257DC628F8FEBD00201E0B /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -113,6 +117,22 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		391CBA17290580360044CA30 /* ReflectionInfo */ = {
+			isa = PBXGroup;
+			children = (
+				391CBA18290580460044CA30 /* ReflectionInfoViewController.swift */,
+			);
+			path = ReflectionInfo;
+			sourceTree = "<group>";
+		};
+		391CBA1A290582030044CA30 /* ReflectionInfo */ = {
+			isa = PBXGroup;
+			children = (
+				391CBA1B290582130044CA30 /* ReflectionInfoModel.swift */,
+			);
+			path = ReflectionInfo;
+			sourceTree = "<group>";
+		};
 		39257DB828F8FEBD00201E0B = {
 			isa = PBXGroup;
 			children = (
@@ -151,6 +171,7 @@
 		39257DD928F90EB100201E0B /* Screen */ = {
 			isa = PBXGroup;
 			children = (
+				391CBA17290580360044CA30 /* ReflectionInfo */,
 				525E721328FE9C5600EF3FCB /* AddFeedbackMember */,
 				395C7E1928FEC3FB00FC2FCA /* AddReflection */,
 				3E557FC128FE7B9200714E46 /* Home */,
@@ -274,6 +295,7 @@
 		395C7E0F28F9833C00FC2FCA /* Response */ = {
 			isa = PBXGroup;
 			children = (
+				391CBA1A290582030044CA30 /* ReflectionInfo */,
 				3E557FFB2901CD6600714E46 /* Keyword */,
 				39257DDD28F90EF900201E0B /* Sample.swift */,
 			);
@@ -435,6 +457,7 @@
 				525E721C28FF0F5B00EF3FCB /* MemberCollectionView.swift in Sources */,
 				395C7E2028FED7B500FC2FCA /* ReflectionNameView.swift in Sources */,
 				395C7E1128F9834A00FC2FCA /* SampleDTO.swift in Sources */,
+				391CBA1C290582130044CA30 /* ReflectionInfoModel.swift in Sources */,
 				3E557FFA2901CD4200714E46 /* KeywordCollectionViewCell.swift in Sources */,
 				395C7E0528F953D200FC2FCA /* UIViewController+Extension.swift in Sources */,
 				39257DEB28F9373900201E0B /* BaseViewController.swift in Sources */,
@@ -465,6 +488,7 @@
 				7EB4D58229011EF7001FC396 /* JoinTeamViewController.swift in Sources */,
 				39257DE228F90F5C00201E0B /* MainViewController.swift in Sources */,
 				39257DED28F9378D00201E0B /* BaseCollectionViewCell.swift in Sources */,
+				391CBA19290580460044CA30 /* ReflectionInfoViewController.swift in Sources */,
 				525E721A28FF0F1900EF3FCB /* MemberCollectionViewCell.swift in Sources */,
 				395C7E2228FEDB6500FC2FCA /* UITextField+Extension.swift in Sources */,
 				39257DF328F93D8900201E0B /* TextLiteral.swift in Sources */,

--- a/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
+++ b/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		395C7E1D28FEC8C400FC2FCA /* CloseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 395C7E1C28FEC8C400FC2FCA /* CloseButton.swift */; };
 		395C7E2028FED7B500FC2FCA /* ReflectionNameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 395C7E1F28FED7B500FC2FCA /* ReflectionNameView.swift */; };
 		395C7E2228FEDB6500FC2FCA /* UITextField+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 395C7E2128FEDB6500FC2FCA /* UITextField+Extension.swift */; };
+		39A64ACE2905885F001DB020 /* StartSuggestionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39A64ACD2905885F001DB020 /* StartSuggestionView.swift */; };
 		3E557FC328FE7BBC00714E46 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E557FC228FE7BBC00714E46 /* HomeViewController.swift */; };
 		3E557FC528FE854600714E46 /* KeywordLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E557FC428FE854600714E46 /* KeywordLabel.swift */; };
 		3E557FF82901CD3400714E46 /* KeywordCollectionViewFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E557FF72901CD3400714E46 /* KeywordCollectionViewFlowLayout.swift */; };
@@ -84,6 +85,7 @@
 		395C7E1C28FEC8C400FC2FCA /* CloseButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseButton.swift; sourceTree = "<group>"; };
 		395C7E1F28FED7B500FC2FCA /* ReflectionNameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReflectionNameView.swift; sourceTree = "<group>"; };
 		395C7E2128FEDB6500FC2FCA /* UITextField+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+Extension.swift"; sourceTree = "<group>"; };
+		39A64ACD2905885F001DB020 /* StartSuggestionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartSuggestionView.swift; sourceTree = "<group>"; };
 		3E557FC228FE7BBC00714E46 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		3E557FC428FE854600714E46 /* KeywordLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordLabel.swift; sourceTree = "<group>"; };
 		3E557FF72901CD3400714E46 /* KeywordCollectionViewFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordCollectionViewFlowLayout.swift; sourceTree = "<group>"; };
@@ -120,6 +122,7 @@
 		391CBA17290580360044CA30 /* ReflectionInfo */ = {
 			isa = PBXGroup;
 			children = (
+				39A64ACC2905882C001DB020 /* UIComponent */,
 				391CBA18290580460044CA30 /* ReflectionInfoViewController.swift */,
 			);
 			path = ReflectionInfo;
@@ -319,6 +322,14 @@
 			path = UIComponent;
 			sourceTree = "<group>";
 		};
+		39A64ACC2905882C001DB020 /* UIComponent */ = {
+			isa = PBXGroup;
+			children = (
+				39A64ACD2905885F001DB020 /* StartSuggestionView.swift */,
+			);
+			path = UIComponent;
+			sourceTree = "<group>";
+		};
 		3E557FC128FE7B9200714E46 /* Home */ = {
 			isa = PBXGroup;
 			children = (
@@ -471,6 +482,7 @@
 				39257DC528F8FEBD00201E0B /* AppDelegate.swift in Sources */,
 				39257DC728F8FEBD00201E0B /* SceneDelegate.swift in Sources */,
 				525E722528FFCFA600EF3FCB /* FeedbackTypeButtonView.swift in Sources */,
+				39A64ACE2905885F001DB020 /* StartSuggestionView.swift in Sources */,
 				525E721F28FFC89800EF3FCB /* AddFeedbackContentViewController.swift in Sources */,
 				D724790C28FEC8C900D67B50 /* BaseTextFieldViewController.swift in Sources */,
 				7E6B662F28FE887300C3BEEF /* UILabel+Extension.swift in Sources */,

--- a/Maddori.Apple/Maddori.Apple/Global/Literal/TextLiteral.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Literal/TextLiteral.swift
@@ -49,4 +49,8 @@ enum TextLiteral {
     
     static let createTeamViewControllerTitleLabel = "팀 이름을 입력해주세요"
     static let createTeamViewControllerTextFieldPlaceHolder = "예) 맛쟁이 사과처럼"
+    
+    // MARK: - StartSuggestionView
+    
+    static let startSuggestionViewStartText = "⭐️ Start"
 }

--- a/Maddori.Apple/Maddori.Apple/Network/Model/Response/ReflectionInfo/ReflectionInfoModel.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/Model/Response/ReflectionInfo/ReflectionInfoModel.swift
@@ -15,10 +15,10 @@ enum FeedBackType: String {
 
 struct ReflectionInfoModel {
     let nickname: String
-    let type: FeedBackType
-    let title: String
+    let feedbackType: FeedBackType
+    let keyword: String
     let info: String
     let start: String
     
-    static let mockData = ReflectionInfoModel(nickname: "곰민", type: .continueType, title: "정리정돈", info: "이번 스프린트 때 유독 행사가 많았는데 그때마다 행사 전후로 정리정돈 잘 해주셔서 감사해요 ! 특히 행사 끝나고 분리수거 깔끔해주신 게 인상 깊어요 ㅋㅋ 앞으로 우리 팀의 청결 지킴이 해주실거죠? 잘 부탁드립니다 ~", start: "새로운 제안이라고 하면 좀 이상할 수도 있지만 앞으로도 계속 청결함을 지켜주는 역할 해주시길.. 최고의 선생님 !!!!")
+    static let mockData = ReflectionInfoModel(nickname: "곰민", feedbackType: .continueType, keyword: "정리정돈", info: "이번 스프린트 때 유독 행사가 많았는데 그때마다 행사 전후로 정리정돈 잘 해주셔서 감사해요 ! 특히 행사 끝나고 분리수거 깔끔해주신 게 인상 깊어요 ㅋㅋ 앞으로 우리 팀의 청결 지킴이 해주실거죠? 잘 부탁드립니다 ~", start: "새로운 제안이라고 하면 좀 이상할 수도 있지만 앞으로도 계속 청결함을 지켜주는 역할 해주시길.. 최고의 선생님 !!!!")
 }

--- a/Maddori.Apple/Maddori.Apple/Network/Model/Response/ReflectionInfo/ReflectionInfoModel.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/Model/Response/ReflectionInfo/ReflectionInfoModel.swift
@@ -1,0 +1,24 @@
+//
+//  ReflectionInfoModel.swift
+//  Maddori.Apple
+//
+//  Created by Mingwan Choi on 2022/10/23.
+//
+
+import Foundation
+
+enum FeedBackType: String {
+    case continueType = "continue"
+    case stopType = "stop"
+    case startType = "start"
+}
+
+struct ReflectionInfoModel {
+    let nickname: String
+    let type: FeedBackType
+    let title: String
+    let info: String
+    let start: String
+    
+    static let mockData = ReflectionInfoModel(nickname: "곰민", type: .continueType, title: "정리정돈", info: "이번 스프린트 때 유독 행사가 많았는데 그때마다 행사 전후로 정리정돈 잘 해주셔서 감사해요 ! 특히 행사 끝나고 분리수거 깔끔해주신 게 인상 깊어요 ㅋㅋ 앞으로 우리 팀의 청결 지킴이 해주실거죠? 잘 부탁드립니다 ~", start: "새로운 제안이라고 하면 좀 이상할 수도 있지만 앞으로도 계속 청결함을 지켜주는 역할 해주시길.. 최고의 선생님 !!!!")
+}

--- a/Maddori.Apple/Maddori.Apple/Screen/Main/MainViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Main/MainViewController.swift
@@ -16,7 +16,7 @@ final class MainViewController: BaseViewController {
     private lazy var mainButton: MainButton = {
         let button = MainButton()
         let action = UIAction { [weak self] _ in
-            self?.presentAddReflectionView()
+            self?.presentReflectionInfoView()
         }
         button.title = "예시"
         button.addAction(action, for: .touchUpInside)
@@ -47,5 +47,10 @@ final class MainViewController: BaseViewController {
         let viewController = UINavigationController(rootViewController: AddReflectionViewController())
         viewController.modalPresentationStyle = .fullScreen
         present(viewController, animated: true)
+    }
+    
+    private func presentReflectionInfoView() {
+        let viewController = ReflectionInfoViewController()
+        self.present(viewController, animated: true)
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Screen/ReflectionInfo/ReflectionInfoViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/ReflectionInfo/ReflectionInfoViewController.swift
@@ -29,6 +29,16 @@ final class ReflectionInfoViewController: BaseViewController {
         label.textColor = .black100
         return label
     }()
+    private lazy var infoLabel: UILabel = {
+        let label = UILabel()
+        label.text = viewModel.info
+        label.font = .body1
+        label.textColor = .gray400
+        label.numberOfLines = 100
+//        label.setLineSpacing()
+        label.setTextWithLineHeight(text: label.text, lineHeight: 24)
+        return label
+    }()
     
     // MARK: - life cycle
     
@@ -51,6 +61,12 @@ final class ReflectionInfoViewController: BaseViewController {
         keywordLabel.snp.makeConstraints {
             $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
             $0.top.equalTo(sendFromLabel.snp.bottom).offset(10)
+        }
+        
+        view.addSubview(infoLabel)
+        infoLabel.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+            $0.top.equalTo(keywordLabel.snp.bottom).offset(32)
         }
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Screen/ReflectionInfo/ReflectionInfoViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/ReflectionInfo/ReflectionInfoViewController.swift
@@ -5,4 +5,39 @@
 //  Created by Mingwan Choi on 2022/10/23.
 //
 
-import Foundation
+import UIKit
+
+import SnapKit
+
+final class ReflectionInfoViewController: BaseViewController {
+    let viewModel: ReflectionInfoModel
+    
+    // MARK: - property
+    
+    private lazy var titleText: UILabel = {
+        let label = UILabel()
+        label.text = "\(viewModel.nickname)님이 보낸 \(viewModel.type.rawValue)"
+        label.textColor = .gray400
+        label.applyColor(to: "\(viewModel.type.rawValue)", with: .blue200)
+        label.font = .caption1
+        return label
+    }()
+    
+    // MARK: - life cycle
+    
+    init(viewModel: ReflectionInfoModel) {
+        self.viewModel = viewModel
+        super.init()
+    }
+    
+    required init?(coder: NSCoder) { nil }
+    
+    override func render() {
+        view.addSubview(titleText)
+        titleText.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+            $0.top.equalTo(view.safeAreaLayoutGuide
+                .snp.top).inset(55)
+        }
+    }
+}

--- a/Maddori.Apple/Maddori.Apple/Screen/ReflectionInfo/ReflectionInfoViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/ReflectionInfo/ReflectionInfoViewController.swift
@@ -14,12 +14,19 @@ final class ReflectionInfoViewController: BaseViewController {
     
     // MARK: - property
     
-    private lazy var titleText: UILabel = {
+    private lazy var sendFromLabel: UILabel = {
         let label = UILabel()
         label.text = "\(viewModel.nickname)님이 보낸 \(viewModel.feedbackType.rawValue)"
         label.textColor = .gray400
         label.applyColor(to: "\(viewModel.feedbackType.rawValue)", with: .blue200)
         label.font = .caption1
+        return label
+    }()
+    private lazy var keywordLabel: UILabel = {
+        let label = UILabel()
+        label.text = viewModel.keyword
+        label.font = .title
+        label.textColor = .black100
         return label
     }()
     
@@ -33,11 +40,17 @@ final class ReflectionInfoViewController: BaseViewController {
     required init?(coder: NSCoder) { nil }
     
     override func render() {
-        view.addSubview(titleText)
-        titleText.snp.makeConstraints {
+        view.addSubview(sendFromLabel)
+        sendFromLabel.snp.makeConstraints {
             $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
             $0.top.equalTo(view.safeAreaLayoutGuide
                 .snp.top).inset(55)
+        }
+        
+        view.addSubview(keywordLabel)
+        keywordLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+            $0.top.equalTo(sendFromLabel.snp.bottom).offset(10)
         }
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Screen/ReflectionInfo/ReflectionInfoViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/ReflectionInfo/ReflectionInfoViewController.swift
@@ -1,0 +1,8 @@
+//
+//  ReflectionInfoViewController.swift
+//  Maddori.Apple
+//
+//  Created by Mingwan Choi on 2022/10/23.
+//
+
+import Foundation

--- a/Maddori.Apple/Maddori.Apple/Screen/ReflectionInfo/ReflectionInfoViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/ReflectionInfo/ReflectionInfoViewController.swift
@@ -16,9 +16,9 @@ final class ReflectionInfoViewController: BaseViewController {
     
     private lazy var titleText: UILabel = {
         let label = UILabel()
-        label.text = "\(viewModel.nickname)님이 보낸 \(viewModel.type.rawValue)"
+        label.text = "\(viewModel.nickname)님이 보낸 \(viewModel.feedbackType.rawValue)"
         label.textColor = .gray400
-        label.applyColor(to: "\(viewModel.type.rawValue)", with: .blue200)
+        label.applyColor(to: "\(viewModel.feedbackType.rawValue)", with: .blue200)
         label.font = .caption1
         return label
     }()

--- a/Maddori.Apple/Maddori.Apple/Screen/ReflectionInfo/ReflectionInfoViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/ReflectionInfo/ReflectionInfoViewController.swift
@@ -10,45 +10,45 @@ import UIKit
 import SnapKit
 
 final class ReflectionInfoViewController: BaseViewController {
-    let viewModel: ReflectionInfoModel
+    let model = ReflectionInfoModel.mockData
     
     // MARK: - property
     
     private lazy var sendFromLabel: UILabel = {
         let label = UILabel()
-        label.text = "\(viewModel.nickname)님이 보낸 \(viewModel.feedbackType.rawValue)"
+        label.text = "\(model.nickname)님이 보낸 \(model.feedbackType.rawValue)"
         label.textColor = .gray400
-        label.applyColor(to: "\(viewModel.feedbackType.rawValue)", with: .blue200)
+        label.applyColor(to: "\(model.feedbackType.rawValue)", with: .blue200)
         label.font = .caption1
         return label
     }()
     private lazy var keywordLabel: UILabel = {
         let label = UILabel()
-        label.text = viewModel.keyword
+        label.text = model.keyword
         label.font = .title
         label.textColor = .black100
         return label
     }()
     private lazy var infoLabel: UILabel = {
         let label = UILabel()
-        label.text = viewModel.info
+        label.text = model.info
         label.font = .body1
         label.textColor = .gray400
-        label.numberOfLines = 100
-//        label.setLineSpacing()
+        label.numberOfLines = 0
         label.setTextWithLineHeight(text: label.text, lineHeight: 24)
         return label
     }()
+    private lazy var startView: StartSuggestionView = {
+        let view = StartSuggestionView()
+        view.backgroundColor = .blue100
+        view.clipsToBounds = true
+        view.layer.cornerRadius = 10
+        view.setStartInfoLabel(info: model.start)
+        return view
+    }()
     
     // MARK: - life cycle
-    
-    init(viewModel: ReflectionInfoModel) {
-        self.viewModel = viewModel
-        super.init()
-    }
-    
-    required init?(coder: NSCoder) { nil }
-    
+        
     override func render() {
         view.addSubview(sendFromLabel)
         sendFromLabel.snp.makeConstraints {
@@ -67,6 +67,12 @@ final class ReflectionInfoViewController: BaseViewController {
         infoLabel.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
             $0.top.equalTo(keywordLabel.snp.bottom).offset(32)
+        }
+        
+        view.addSubview(startView)
+        startView.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+            $0.top.equalTo(infoLabel.snp.bottom).offset(28)
         }
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Screen/ReflectionInfo/UIComponent/StartSuggestionView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/ReflectionInfo/UIComponent/StartSuggestionView.swift
@@ -1,0 +1,61 @@
+//
+//  StartSuggestionView.swift
+//  Maddori.Apple
+//
+//  Created by Mingwan Choi on 2022/10/23.
+//
+
+import UIKit
+
+import SnapKit
+
+final class StartSuggestionView: UIStackView {
+        
+    // MARK: - property
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = TextLiteral.startSuggestionViewStartText
+        label.textColor = .gray600
+        label.font = .label2
+        return label
+    }()
+    private let startInfoLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .gray600
+        label.font = .body2
+        label.numberOfLines = 0
+        return label
+    }()
+    
+    // MARK: - life cycle
+        
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        render()
+    }
+    
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+        
+    private func render() {
+        self.addSubview(titleLabel)
+        titleLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(22)
+            $0.leading.equalToSuperview().inset(16)
+        }
+        
+        self.addSubview(startInfoLabel)
+        startInfoLabel.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(16)
+            $0.top.equalTo(titleLabel.snp.bottom).offset(12)
+            $0.bottom.equalToSuperview().inset(22)
+        }
+    }
+    
+    func setStartInfoLabel(info: String) {
+        startInfoLabel.text = info
+        startInfoLabel.setTextWithLineHeight(text: startInfoLabel.text, lineHeight: 22)
+    }
+}


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
🆘가 붙어있는 view를 만들었습니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
회고에서 받은 내용을 자세히 볼 수 있는 view를 구현했습니다

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
feature/44-reflection-info-view에 들어가서 run 후 예시 버튼을 누르면 됩니다

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<img width="441" alt="image" src="https://user-images.githubusercontent.com/78677571/197426736-0684e9b0-22ee-4d2c-9424-503d16d33020.png">


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
크게 어려운 부분은 없었는데, 각 내용들이 길어진다면 어떻게 보여주는게 좋을지 고민해봐야할 것 같습니다. max line을 설정해야한다던지 내부에서 스크롤이 되어야 한다던지에 대한 방식은 고민해보면 좋을 것 같습니다 ! 현재는 무한정 늘어나게끔 설정해뒀습니다 !

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #44 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
