### PR TITLE
[FEAT] Start 피드백 추가하기 구현

### DIFF
--- a/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
+++ b/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		525E721F28FFC89800EF3FCB /* AddFeedbackContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525E721E28FFC89800EF3FCB /* AddFeedbackContentViewController.swift */; };
 		525E722128FFC9A800EF3FCB /* BackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525E722028FFC9A800EF3FCB /* BackButton.swift */; };
 		525E722528FFCFA600EF3FCB /* FeedbackTypeButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525E722428FFCFA600EF3FCB /* FeedbackTypeButtonView.swift */; };
+		52FA42A02906608E00C35824 /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52FA429F2906608E00C35824 /* Date+Extension.swift */; };
 		7E2ECA102901136700A4D65C /* SetupNicknameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E2ECA0F2901136700A4D65C /* SetupNicknameViewController.swift */; };
 		7E6B662F28FE887300C3BEEF /* UILabel+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6B662E28FE887300C3BEEF /* UILabel+Extension.swift */; };
 		7EB4D58229011EF7001FC396 /* JoinTeamViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EB4D58129011EF7001FC396 /* JoinTeamViewController.swift */; };
@@ -91,6 +92,7 @@
 		525E721E28FFC89800EF3FCB /* AddFeedbackContentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddFeedbackContentViewController.swift; sourceTree = "<group>"; };
 		525E722028FFC9A800EF3FCB /* BackButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackButton.swift; sourceTree = "<group>"; };
 		525E722428FFCFA600EF3FCB /* FeedbackTypeButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackTypeButtonView.swift; sourceTree = "<group>"; };
+		52FA429F2906608E00C35824 /* Date+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extension.swift"; sourceTree = "<group>"; };
 		7E2ECA0F2901136700A4D65C /* SetupNicknameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupNicknameViewController.swift; sourceTree = "<group>"; };
 		7E6B662E28FE887300C3BEEF /* UILabel+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+Extension.swift"; sourceTree = "<group>"; };
 		7EB4D58129011EF7001FC396 /* JoinTeamViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinTeamViewController.swift; sourceTree = "<group>"; };
@@ -236,6 +238,7 @@
 				395C7E0A28F9550A00FC2FCA /* NSObject+Extension.swift */,
 				395C7E1728F9912700FC2FCA /* UIButton+Extension.swift */,
 				395C7E2128FEDB6500FC2FCA /* UITextField+Extension.swift */,
+				52FA429F2906608E00C35824 /* Date+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -441,6 +444,7 @@
 				395C7E1828F9912700FC2FCA /* UIButton+Extension.swift in Sources */,
 				525E721728FEF2C500EF3FCB /* ExitButton.swift in Sources */,
 				3E557FC328FE7BBC00714E46 /* HomeViewController.swift in Sources */,
+				52FA42A02906608E00C35824 /* Date+Extension.swift in Sources */,
 				395C7E1328F9841A00FC2FCA /* SizeLiteral.swift in Sources */,
 				39257DC528F8FEBD00201E0B /* AppDelegate.swift in Sources */,
 				39257DC728F8FEBD00201E0B /* SceneDelegate.swift in Sources */,

--- a/Maddori.Apple/Maddori.Apple/Global/Extension/Date+Extension.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Extension/Date+Extension.swift
@@ -1,0 +1,16 @@
+//
+//  Date+Extension.swift
+//  Maddori.Apple
+//
+//  Created by 김유나 on 2022/10/24.
+//
+
+import UIKit
+
+extension Date {
+    var dateToMonthDayString: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "M월 d일"
+        return formatter.string(from: self)
+    }
+}

--- a/Maddori.Apple/Maddori.Apple/Global/Literal/TextLiteral.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Literal/TextLiteral.swift
@@ -40,9 +40,11 @@ enum TextLiteral {
     static let addFeedbackContentViewControllerFeedbackTypeLabel = "피드백 종류"
     static let addFeedbackContentViewControllerFeedbackKeywordLabel = "키워드"
     static let addFeedbackContentViewControllerFeedbackKeywordTextFieldPlaceholder = "피드백을 한 단어로 작성해주세요"
-    static let addFeedbackContentViewControllerFeedbackContentLabel = "내용"
+    static let addFeedbackContentViewControllerFeedbackTextViewLabel = "내용"
     static let addFeedbackContentViewControllerFeedbackContentTextViewPlaceholder = "키워드에 대한 자세한 내용을 작성해주세요"
     static let addFeedbackContentViewControllerDoneButtonTitle = "완료"
+    static let addFeedbackContentViewControllerFeedbackStartLabel = "Start 제안하기"
+    static let addFeedbackContentViewControllerStartTextViewPlaceholder = "제안하고 싶은 Start를 작성해주세요"
 
     // MARK: - JoinTeamViewController
     

--- a/Maddori.Apple/Maddori.Apple/Global/Literal/TextLiteral.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Literal/TextLiteral.swift
@@ -45,6 +45,7 @@ enum TextLiteral {
     static let addFeedbackContentViewControllerDoneButtonTitle = "완료"
     static let addFeedbackContentViewControllerFeedbackStartLabel = "Start 제안하기"
     static let addFeedbackContentViewControllerStartTextViewPlaceholder = "제안하고 싶은 Start를 작성해주세요"
+    static let addFeedbackContentViewControllerFeedbackSendTimeLabel = "작성한 피드백은 회고 시간에 자동 제출됩니다"
 
     // MARK: - JoinTeamViewController
     

--- a/Maddori.Apple/Maddori.Apple/Global/Supports/SceneDelegate.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Supports/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        let rootViewController = UINavigationController(rootViewController: MainViewController())
+        let rootViewController = UINavigationController(rootViewController: AddFeedbackContentViewController())
         window?.rootViewController = rootViewController
         window?.makeKeyAndVisible()
     }

--- a/Maddori.Apple/Maddori.Apple/Global/Supports/SceneDelegate.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Supports/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        let rootViewController = UINavigationController(rootViewController: AddFeedbackContentViewController())
+        let rootViewController = UINavigationController(rootViewController: MainViewController())
         window?.rootViewController = rootViewController
         window?.makeKeyAndVisible()
     }

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/FeedbackTextView.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/FeedbackTextView.swift
@@ -32,7 +32,6 @@ final class FeedbackTextView: UITextView {
         self.font = .body1
         self.textContainerInset = .init(top: 18, left: 12, bottom: 18, right: 12)
         self.textColor = .gray500
-        self.isScrollEnabled = false
     }
     
     // MARK: - func

--- a/Maddori.Apple/Maddori.Apple/Screen/AddFeedbackContent/AddFeedbackContentViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/AddFeedbackContent/AddFeedbackContentViewController.swift
@@ -98,7 +98,7 @@ final class AddFeedbackContentViewController: BaseViewController {
         return label
     }()
     private let feedbackStartTextView: FeedbackTextView = {
-        let textView = FeedbackTextView(frame: CGRect(x: 0, y: 0, width: 327, height: 150))
+        let textView = FeedbackTextView()
         textView.placeholder = TextLiteral.addFeedbackContentViewControllerStartTextViewPlaceholder
         textView.isHidden = true
         return textView
@@ -222,27 +222,26 @@ final class AddFeedbackContentViewController: BaseViewController {
         addFeedbackContentView.addSubview(feedbackStartTextView)
         feedbackStartTextView.snp.makeConstraints {
             $0.top.equalTo(feedbackStartTextViewLabel.snp.bottom).offset(SizeLiteral.labelComponentPadding)
-            $0.centerX.equalTo(addFeedbackContentView.snp.centerX)
-            $0.width.equalTo(addFeedbackContentView.snp.width).inset(SizeLiteral.leadingTrailingPadding)
+            $0.leading.equalTo(addFeedbackContentView.snp.leading).inset(SizeLiteral.leadingTrailingPadding)
+            $0.trailing.equalTo(addFeedbackContentView.snp.trailing).inset(SizeLiteral.leadingTrailingPadding)
             $0.height.equalTo(150)
         }
         
-        addFeedbackContentView.addSubview(feedbackDoneButtonView)
+        view.addSubview(feedbackDoneButtonView)
         feedbackDoneButtonView.snp.makeConstraints {
-            $0.bottom.equalTo(view.safeAreaLayoutGuide)
-            $0.centerX.equalTo(addFeedbackContentView.snp.centerX)
-            $0.width.equalTo(addFeedbackContentView.snp.width)
-            $0.height.equalTo(100)
+            $0.bottom.equalToSuperview()
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(134)
         }
         
-        addFeedbackContentView.addSubview(feedbackDoneButton)
+        feedbackDoneButtonView.addSubview(feedbackDoneButton)
         feedbackDoneButton.snp.makeConstraints {
-            $0.bottom.equalTo(feedbackDoneButtonView.snp.bottom).inset(2)
+            $0.bottom.equalTo(feedbackDoneButtonView.snp.bottom).inset(36)
             $0.centerX.equalTo(feedbackDoneButtonView.snp.centerX)
             $0.width.equalTo(feedbackDoneButtonView.snp.width).inset(SizeLiteral.leadingTrailingPadding)
         }
         
-        addFeedbackContentView.addSubview(feedbackSendTimeLabel)
+        feedbackDoneButtonView.addSubview(feedbackSendTimeLabel)
         feedbackSendTimeLabel.snp.makeConstraints {
             $0.bottom.equalTo(feedbackDoneButton.snp.top).inset(-11)
             $0.centerX.equalTo(feedbackDoneButtonView.snp.centerX)

--- a/Maddori.Apple/Maddori.Apple/Screen/AddFeedbackContent/AddFeedbackContentViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/AddFeedbackContent/AddFeedbackContentViewController.swift
@@ -309,7 +309,7 @@ final class AddFeedbackContentViewController: BaseViewController {
         feedbackStartTextViewLabel.isHidden.toggle()
         feedbackStartTextView.isHidden.toggle()
         
-        if feedbackStartSwitch.isOn == true {
+        if feedbackStartSwitch.isOn {
             addFeedbackScrollView.scrollRectToVisible(CGRect(x: 0.0, y: 0.0, width: 375.0, height: 1100.0), animated: true)
         }
     }

--- a/Maddori.Apple/Maddori.Apple/Screen/AddFeedbackContent/AddFeedbackContentViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/AddFeedbackContent/AddFeedbackContentViewController.swift
@@ -68,6 +68,23 @@ final class AddFeedbackContentViewController: BaseViewController {
         textView.placeholder = TextLiteral.addFeedbackContentViewControllerFeedbackContentTextViewPlaceholder
         return textView
     }()
+    private lazy var feedbackStartSwitch: UISwitch = {
+        let toggle = UISwitch()
+        toggle.onTintColor = .blue200
+        toggle.isOn = false
+        let action = UIAction { [weak self] _ in
+            self?.didTappedSwitch()
+        }
+        toggle.addAction(action, for: .touchUpInside)
+        return toggle
+    }()
+    private let feedbackStartLabel: UILabel = {
+        let label = UILabel()
+        label.text = "Start 제안하기"
+        label.textColor = .black100
+        label.font = .label2
+        return label
+    }()
     private lazy var feedbackDoneButton: MainButton = {
         let button = MainButton()
         button.title = TextLiteral.addFeedbackContentViewControllerDoneButtonTitle
@@ -155,6 +172,20 @@ final class AddFeedbackContentViewController: BaseViewController {
             $0.height.greaterThanOrEqualTo(150)
         }
         
+        addFeedbackContentView.addSubview(feedbackStartSwitch)
+        feedbackStartSwitch.snp.makeConstraints {
+            $0.top.equalTo(feedbackContentTextView.snp.bottom).offset(SizeLiteral.componentIntervalPadding)
+            $0.trailing.equalTo(addFeedbackContentView.snp.trailing).inset(SizeLiteral.leadingTrailingPadding)
+            $0.width.equalTo(51)
+            $0.height.equalTo(31)
+        }
+        
+        addFeedbackContentView.addSubview(feedbackStartLabel)
+        feedbackStartLabel.snp.makeConstraints {
+            $0.centerY.equalTo(feedbackStartSwitch.snp.centerY)
+            $0.leading.equalTo(addFeedbackContentView.snp.leading).inset(SizeLiteral.leadingTrailingPadding)
+        }
+        
         addFeedbackContentView.addSubview(feedbackDoneButton)
         feedbackDoneButton.snp.makeConstraints {
             $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(2)
@@ -215,6 +246,10 @@ final class AddFeedbackContentViewController: BaseViewController {
                 }
             }
         }
+    }
+    
+    private func didTappedSwitch() {
+        
     }
     
     private func didTappedDoneButton() {

--- a/Maddori.Apple/Maddori.Apple/Screen/AddFeedbackContent/AddFeedbackContentViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/AddFeedbackContent/AddFeedbackContentViewController.swift
@@ -238,7 +238,7 @@ final class AddFeedbackContentViewController: BaseViewController {
     override func configUI() {
         super.configUI()
         if feedbackDate != nil {
-            feedbackSendTimeLabel.text = "작성한 피드백은 \(feedbackDate!)에 자동으로 제출됩니다"
+            feedbackSendTimeLabel.text = "작성한 피드백은 \(feedbackDate!.dateToMonthDayString)에 자동으로 제출됩니다"
         }
     }
     

--- a/Maddori.Apple/Maddori.Apple/Screen/AddFeedbackContent/AddFeedbackContentViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/AddFeedbackContent/AddFeedbackContentViewController.swift
@@ -102,9 +102,14 @@ final class AddFeedbackContentViewController: BaseViewController {
         textView.isHidden = true
         return textView
     }()
+    private let feedbackDoneButtonView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .white200
+        return view
+    }()
     private lazy var feedbackSendTimeLabel: UILabel = {
         let label = UILabel()
-        label.text = "작성한 피드백은 회고 시간에 자동 제출됩니다"
+        label.text = TextLiteral.addFeedbackContentViewControllerFeedbackSendTimeLabel
         label.textColor = .gray400
         label.font = .body2
         return label
@@ -221,17 +226,25 @@ final class AddFeedbackContentViewController: BaseViewController {
             $0.height.equalTo(150)
         }
         
+        addFeedbackContentView.addSubview(feedbackDoneButtonView)
+        feedbackDoneButtonView.snp.makeConstraints {
+            $0.bottom.equalTo(view.safeAreaLayoutGuide)
+            $0.centerX.equalTo(addFeedbackContentView.snp.centerX)
+            $0.width.equalTo(addFeedbackContentView.snp.width)
+            $0.height.equalTo(100)
+        }
+        
         addFeedbackContentView.addSubview(feedbackDoneButton)
         feedbackDoneButton.snp.makeConstraints {
-            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(2)
-            $0.centerX.equalTo(addFeedbackContentView.snp.centerX)
-            $0.width.equalTo(addFeedbackContentView.snp.width).inset(SizeLiteral.leadingTrailingPadding)
+            $0.bottom.equalTo(feedbackDoneButtonView.snp.bottom).inset(2)
+            $0.centerX.equalTo(feedbackDoneButtonView.snp.centerX)
+            $0.width.equalTo(feedbackDoneButtonView.snp.width).inset(SizeLiteral.leadingTrailingPadding)
         }
         
         addFeedbackContentView.addSubview(feedbackSendTimeLabel)
         feedbackSendTimeLabel.snp.makeConstraints {
             $0.bottom.equalTo(feedbackDoneButton.snp.top).inset(-11)
-            $0.centerX.equalTo(addFeedbackContentView.snp.centerX)
+            $0.centerX.equalTo(feedbackDoneButtonView.snp.centerX)
         }
     }
     

--- a/Maddori.Apple/Maddori.Apple/Screen/AddFeedbackContent/AddFeedbackContentViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/AddFeedbackContent/AddFeedbackContentViewController.swift
@@ -58,7 +58,7 @@ final class AddFeedbackContentViewController: BaseViewController {
     }()
     private let feedbackContentLabel: UILabel = {
         let label = UILabel()
-        label.text = TextLiteral.addFeedbackContentViewControllerFeedbackContentLabel
+        label.text = TextLiteral.addFeedbackContentViewControllerFeedbackTextViewLabel
         label.textColor = .black100
         label.font = .label2
         return label
@@ -80,14 +80,14 @@ final class AddFeedbackContentViewController: BaseViewController {
     }()
     private let feedbackStartLabel: UILabel = {
         let label = UILabel()
-        label.text = "Start 제안하기"
+        label.text = TextLiteral.addFeedbackContentViewControllerFeedbackStartLabel
         label.textColor = .black100
         label.font = .label2
         return label
     }()
     private let feedbackStartTextViewLabel: UILabel = {
         let label = UILabel()
-        label.text = "내용"
+        label.text = TextLiteral.addFeedbackContentViewControllerFeedbackTextViewLabel
         label.textColor = .black100
         label.font = .label2
         label.isHidden = true
@@ -95,7 +95,7 @@ final class AddFeedbackContentViewController: BaseViewController {
     }()
     private let feedbackStartTextView: FeedbackTextView = {
         let textView = FeedbackTextView(frame: CGRect(x: 0, y: 0, width: 327, height: 150))
-        textView.placeholder = "제안하고 싶은 Start를 작성해주세요"
+        textView.placeholder = TextLiteral.addFeedbackContentViewControllerStartTextViewPlaceholder
         textView.isHidden = true
         return textView
     }()
@@ -128,9 +128,6 @@ final class AddFeedbackContentViewController: BaseViewController {
         addFeedbackContentView.snp.makeConstraints {
             $0.edges.equalTo(addFeedbackScrollView.snp.edges)
             $0.width.equalTo(addFeedbackScrollView.snp.width)
-            
-            // FIXME: - height 를 필수로 지정해야 함 -> 현재 임의로 줌
-            
             $0.height.equalTo(1180)
         }
         
@@ -328,7 +325,7 @@ extension AddFeedbackContentViewController: UITextFieldDelegate {
 
 extension AddFeedbackContentViewController: UITextViewDelegate {
     func textViewDidBeginEditing(_ textView: UITextView) {
-        if textView.text == TextLiteral.addFeedbackContentViewControllerFeedbackContentTextViewPlaceholder || textView.text == "제안하고 싶은 Start를 작성해주세요" {
+        if textView.text == TextLiteral.addFeedbackContentViewControllerFeedbackContentTextViewPlaceholder || textView.text == TextLiteral.addFeedbackContentViewControllerStartTextViewPlaceholder {
             textView.text = nil
             textView.textColor = .black100
         }
@@ -340,7 +337,7 @@ extension AddFeedbackContentViewController: UITextViewDelegate {
     
     func textViewDidEndEditing(_ textView: UITextView) {
         if textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            textView.text = textView == feedbackContentTextView ? TextLiteral.addFeedbackContentViewControllerFeedbackContentTextViewPlaceholder : "제안하고 싶은 Start를 작성해주세요"
+            textView.text = textView == feedbackContentTextView ? TextLiteral.addFeedbackContentViewControllerFeedbackContentTextViewPlaceholder : TextLiteral.addFeedbackContentViewControllerStartTextViewPlaceholder
             textView.textColor = .gray500
         }
     }

--- a/Maddori.Apple/Maddori.Apple/Screen/AddFeedbackContent/AddFeedbackContentViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/AddFeedbackContent/AddFeedbackContentViewController.swift
@@ -131,7 +131,7 @@ final class AddFeedbackContentViewController: BaseViewController {
             
             // FIXME: - height 를 필수로 지정해야 함 -> 현재 임의로 줌
             
-            $0.height.equalTo(1000)
+            $0.height.equalTo(1180)
         }
         
         addFeedbackContentView.addSubview(addFeedbackTitleLabel)
@@ -183,7 +183,7 @@ final class AddFeedbackContentViewController: BaseViewController {
             $0.top.equalTo(feedbackContentLabel.snp.bottom).offset(SizeLiteral.labelComponentPadding)
             $0.centerX.equalTo(addFeedbackContentView.snp.centerX)
             $0.width.equalTo(addFeedbackContentView.snp.width).inset(SizeLiteral.leadingTrailingPadding)
-            $0.height.greaterThanOrEqualTo(150)
+            $0.height.equalTo(150)
         }
         
         addFeedbackContentView.addSubview(feedbackStartSwitch)
@@ -211,7 +211,7 @@ final class AddFeedbackContentViewController: BaseViewController {
             $0.top.equalTo(feedbackStartTextViewLabel.snp.bottom).offset(SizeLiteral.labelComponentPadding)
             $0.centerX.equalTo(addFeedbackContentView.snp.centerX)
             $0.width.equalTo(addFeedbackContentView.snp.width).inset(SizeLiteral.leadingTrailingPadding)
-            $0.height.greaterThanOrEqualTo(150)
+            $0.height.equalTo(150)
         }
         
         addFeedbackContentView.addSubview(feedbackDoneButton)
@@ -245,6 +245,7 @@ final class AddFeedbackContentViewController: BaseViewController {
     private func setupDelegate() {
         feedbackKeywordTextField.delegate = self
         feedbackContentTextView.delegate = self
+        feedbackStartTextView.delegate = self
     }
     
     override func endEditingView() {
@@ -279,6 +280,10 @@ final class AddFeedbackContentViewController: BaseViewController {
     private func didTappedSwitch() {
         feedbackStartTextViewLabel.isHidden.toggle()
         feedbackStartTextView.isHidden.toggle()
+        
+        if feedbackStartSwitch.isOn == true {
+            addFeedbackScrollView.scrollRectToVisible(CGRect(x: 0.0, y: 0.0, width: 375.0, height: 1100.0), animated: true)
+        }
     }
     
     private func didTappedDoneButton() {
@@ -315,19 +320,27 @@ extension AddFeedbackContentViewController: UITextFieldDelegate {
         let hasText = feedbackKeywordTextField.hasText
         feedbackDoneButton.isDisabled = !hasText
     }
+    
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+        addFeedbackScrollView.scrollRectToVisible(CGRect(x: 0.0, y: 0.0, width: 375.0, height: 850.0), animated: true)
+    }
 }
 
 extension AddFeedbackContentViewController: UITextViewDelegate {
     func textViewDidBeginEditing(_ textView: UITextView) {
-        if textView.text == TextLiteral.addFeedbackContentViewControllerFeedbackContentTextViewPlaceholder {
+        if textView.text == TextLiteral.addFeedbackContentViewControllerFeedbackContentTextViewPlaceholder || textView.text == "제안하고 싶은 Start를 작성해주세요" {
             textView.text = nil
             textView.textColor = .black100
+        }
+                
+        if textView == feedbackContentTextView {
+            addFeedbackScrollView.scrollRectToVisible(CGRect(x: 0.0, y: 0.0, width: 375.0, height: 920.0), animated: true)
         }
     }
     
     func textViewDidEndEditing(_ textView: UITextView) {
         if textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            textView.text = TextLiteral.addFeedbackContentViewControllerFeedbackContentTextViewPlaceholder
+            textView.text = textView == feedbackContentTextView ? TextLiteral.addFeedbackContentViewControllerFeedbackContentTextViewPlaceholder : "제안하고 싶은 Start를 작성해주세요"
             textView.textColor = .gray500
         }
     }

--- a/Maddori.Apple/Maddori.Apple/Screen/AddFeedbackContent/AddFeedbackContentViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/AddFeedbackContent/AddFeedbackContentViewController.swift
@@ -16,6 +16,9 @@ final class AddFeedbackContentViewController: BaseViewController {
     private let textViewMaxLength: Int = 200
     private var nickname: String = "진저"
     
+    // FIXME: - 회고 날짜 받아오기 / 현재는 있는 상태
+    private let feedbackDate: Date? = Date()
+    
     // MARK: - property
     
     private let backButton = BackButton(type: .system)
@@ -98,6 +101,13 @@ final class AddFeedbackContentViewController: BaseViewController {
         textView.placeholder = TextLiteral.addFeedbackContentViewControllerStartTextViewPlaceholder
         textView.isHidden = true
         return textView
+    }()
+    private lazy var feedbackSendTimeLabel: UILabel = {
+        let label = UILabel()
+        label.text = "작성한 피드백은 회고 시간에 자동 제출됩니다"
+        label.textColor = .gray400
+        label.font = .body2
+        return label
     }()
     private lazy var feedbackDoneButton: MainButton = {
         let button = MainButton()
@@ -217,6 +227,19 @@ final class AddFeedbackContentViewController: BaseViewController {
             $0.centerX.equalTo(addFeedbackContentView.snp.centerX)
             $0.width.equalTo(addFeedbackContentView.snp.width).inset(SizeLiteral.leadingTrailingPadding)
         }
+        
+        addFeedbackContentView.addSubview(feedbackSendTimeLabel)
+        feedbackSendTimeLabel.snp.makeConstraints {
+            $0.bottom.equalTo(feedbackDoneButton.snp.top).inset(-11)
+            $0.centerX.equalTo(addFeedbackContentView.snp.centerX)
+        }
+    }
+    
+    override func configUI() {
+        super.configUI()
+        if feedbackDate != nil {
+            feedbackSendTimeLabel.text = "작성한 피드백은 \(feedbackDate!)에 자동으로 제출됩니다"
+        }
     }
     
     // MARK: - func
@@ -298,12 +321,16 @@ final class AddFeedbackContentViewController: BaseViewController {
                 self.feedbackDoneButton.transform = CGAffineTransform(translationX: 0, y: -keyboardSize.height + 25)
             })
         }
+        
+        feedbackSendTimeLabel.isHidden = true
     }
     
     @objc private func keyboardWillHide(notification:NSNotification) {
         UIView.animate(withDuration: 0.2, animations: {
             self.feedbackDoneButton.transform = .identity
         })
+        
+        feedbackSendTimeLabel.isHidden = false
     }
 }
 
@@ -329,9 +356,11 @@ extension AddFeedbackContentViewController: UITextViewDelegate {
             textView.text = nil
             textView.textColor = .black100
         }
-                
+        
         if textView == feedbackContentTextView {
             addFeedbackScrollView.scrollRectToVisible(CGRect(x: 0.0, y: 0.0, width: 375.0, height: 920.0), animated: true)
+        } else {
+            addFeedbackScrollView.scrollRectToVisible(CGRect(x: 0.0, y: 0.0, width: 375.0, height: 1100.0), animated: true)
         }
     }
     

--- a/Maddori.Apple/Maddori.Apple/Screen/AddFeedbackContent/AddFeedbackContentViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/AddFeedbackContent/AddFeedbackContentViewController.swift
@@ -238,7 +238,7 @@ final class AddFeedbackContentViewController: BaseViewController {
         
         feedbackDoneButtonView.addSubview(feedbackSendTimeLabel)
         feedbackSendTimeLabel.snp.makeConstraints {
-            $0.bottom.equalTo(feedbackDoneButton.snp.top).inset(-11)
+            $0.bottom.equalTo(feedbackDoneButton.snp.top).offset(-11)
             $0.centerX.equalTo(feedbackDoneButtonView.snp.centerX)
         }
     }

--- a/Maddori.Apple/Maddori.Apple/Screen/AddFeedbackContent/AddFeedbackContentViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/AddFeedbackContent/AddFeedbackContentViewController.swift
@@ -85,6 +85,20 @@ final class AddFeedbackContentViewController: BaseViewController {
         label.font = .label2
         return label
     }()
+    private let feedbackStartTextViewLabel: UILabel = {
+        let label = UILabel()
+        label.text = "내용"
+        label.textColor = .black100
+        label.font = .label2
+        label.isHidden = true
+        return label
+    }()
+    private let feedbackStartTextView: FeedbackTextView = {
+        let textView = FeedbackTextView(frame: CGRect(x: 0, y: 0, width: 327, height: 150))
+        textView.placeholder = "제안하고 싶은 Start를 작성해주세요"
+        textView.isHidden = true
+        return textView
+    }()
     private lazy var feedbackDoneButton: MainButton = {
         let button = MainButton()
         button.title = TextLiteral.addFeedbackContentViewControllerDoneButtonTitle
@@ -186,6 +200,20 @@ final class AddFeedbackContentViewController: BaseViewController {
             $0.leading.equalTo(addFeedbackContentView.snp.leading).inset(SizeLiteral.leadingTrailingPadding)
         }
         
+        addFeedbackContentView.addSubview(feedbackStartTextViewLabel)
+        feedbackStartTextViewLabel.snp.makeConstraints {
+            $0.top.equalTo(feedbackStartSwitch.snp.bottom).offset(SizeLiteral.componentIntervalPadding)
+            $0.leading.equalTo(addFeedbackContentView.snp.leading).inset(SizeLiteral.leadingTrailingPadding)
+        }
+        
+        addFeedbackContentView.addSubview(feedbackStartTextView)
+        feedbackStartTextView.snp.makeConstraints {
+            $0.top.equalTo(feedbackStartTextViewLabel.snp.bottom).offset(SizeLiteral.labelComponentPadding)
+            $0.centerX.equalTo(addFeedbackContentView.snp.centerX)
+            $0.width.equalTo(addFeedbackContentView.snp.width).inset(SizeLiteral.leadingTrailingPadding)
+            $0.height.greaterThanOrEqualTo(150)
+        }
+        
         addFeedbackContentView.addSubview(feedbackDoneButton)
         feedbackDoneButton.snp.makeConstraints {
             $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(2)
@@ -249,7 +277,8 @@ final class AddFeedbackContentViewController: BaseViewController {
     }
     
     private func didTappedSwitch() {
-        
+        feedbackStartTextViewLabel.isHidden.toggle()
+        feedbackStartTextView.isHidden.toggle()
     }
     
     private func didTappedDoneButton() {

--- a/Maddori.Apple/Maddori.Apple/Screen/AddFeedbackContent/AddFeedbackContentViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/AddFeedbackContent/AddFeedbackContentViewController.swift
@@ -150,59 +150,56 @@ final class AddFeedbackContentViewController: BaseViewController {
         addFeedbackContentView.addSubview(addFeedbackTitleLabel)
         addFeedbackTitleLabel.snp.makeConstraints {
             $0.top.equalTo(addFeedbackContentView.snp.top).offset(SizeLiteral.topPadding)
-            $0.leading.equalTo(addFeedbackContentView.snp.leading).offset(SizeLiteral.leadingTrailingPadding)
+            $0.leading.equalToSuperview().offset(SizeLiteral.leadingTrailingPadding)
         }
         
         addFeedbackContentView.addSubview(feedbackTypeLabel)
         feedbackTypeLabel.snp.makeConstraints {
             $0.top.equalTo(addFeedbackTitleLabel.snp.bottom).offset(SizeLiteral.topComponentPadding)
-            $0.leading.equalTo(addFeedbackContentView.snp.leading).inset(SizeLiteral.leadingTrailingPadding)
+            $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
         }
         
         addFeedbackContentView.addSubview(feedbackTypeButtonView)
         feedbackTypeButtonView.snp.makeConstraints {
             $0.top.equalTo(feedbackTypeLabel.snp.bottom).offset(SizeLiteral.labelComponentPadding)
-            $0.centerX.equalTo(addFeedbackContentView.snp.centerX)
-            $0.width.equalTo(addFeedbackContentView.snp.width).inset(SizeLiteral.leadingTrailingPadding)
+            $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
         }
         
         addFeedbackContentView.addSubview(feedbackKeywordLabel)
         feedbackKeywordLabel.snp.makeConstraints {
             $0.top.equalTo(feedbackTypeButtonView.snp.bottom).offset(SizeLiteral.componentIntervalPadding)
-            $0.leading.equalTo(addFeedbackContentView.snp.leading).inset(SizeLiteral.leadingTrailingPadding)
+            $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
         }
         
         addFeedbackContentView.addSubview(feedbackKeywordTextField)
         feedbackKeywordTextField.snp.makeConstraints {
             $0.top.equalTo(feedbackKeywordLabel.snp.bottom).offset(SizeLiteral.labelComponentPadding)
-            $0.width.equalTo(addFeedbackContentView.snp.width).inset(SizeLiteral.leadingTrailingPadding)
-            $0.centerX.equalTo(addFeedbackContentView.snp.centerX)
+            $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
         }
         
         addFeedbackContentView.addSubview(textLimitLabel)
         textLimitLabel.snp.makeConstraints {
             $0.top.equalTo(feedbackKeywordTextField.snp.bottom).offset(4)
-            $0.trailing.equalTo(addFeedbackContentView.snp.trailing).inset(27)
+            $0.trailing.equalToSuperview().inset(27)
         }
         
         addFeedbackContentView.addSubview(feedbackContentLabel)
         feedbackContentLabel.snp.makeConstraints {
             $0.top.equalTo(feedbackKeywordTextField.snp.bottom).offset(SizeLiteral.componentIntervalPadding)
-            $0.leading.equalTo(addFeedbackContentView.snp.leading).inset(SizeLiteral.leadingTrailingPadding)
+            $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
         }
         
         addFeedbackContentView.addSubview(feedbackContentTextView)
         feedbackContentTextView.snp.makeConstraints {
             $0.top.equalTo(feedbackContentLabel.snp.bottom).offset(SizeLiteral.labelComponentPadding)
-            $0.leading.equalTo(addFeedbackContentView.snp.leading).inset(SizeLiteral.leadingTrailingPadding)
-            $0.trailing.equalTo(addFeedbackContentView.snp.trailing).inset(SizeLiteral.leadingTrailingPadding)
+            $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
             $0.height.equalTo(150)
         }
         
         addFeedbackContentView.addSubview(feedbackStartSwitch)
         feedbackStartSwitch.snp.makeConstraints {
             $0.top.equalTo(feedbackContentTextView.snp.bottom).offset(SizeLiteral.componentIntervalPadding)
-            $0.trailing.equalTo(addFeedbackContentView.snp.trailing).inset(SizeLiteral.leadingTrailingPadding)
+            $0.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
             $0.width.equalTo(51)
             $0.height.equalTo(31)
         }
@@ -210,20 +207,19 @@ final class AddFeedbackContentViewController: BaseViewController {
         addFeedbackContentView.addSubview(feedbackStartLabel)
         feedbackStartLabel.snp.makeConstraints {
             $0.centerY.equalTo(feedbackStartSwitch.snp.centerY)
-            $0.leading.equalTo(addFeedbackContentView.snp.leading).inset(SizeLiteral.leadingTrailingPadding)
+            $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
         }
         
         addFeedbackContentView.addSubview(feedbackStartTextViewLabel)
         feedbackStartTextViewLabel.snp.makeConstraints {
             $0.top.equalTo(feedbackStartSwitch.snp.bottom).offset(SizeLiteral.componentIntervalPadding)
-            $0.leading.equalTo(addFeedbackContentView.snp.leading).inset(SizeLiteral.leadingTrailingPadding)
+            $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
         }
         
         addFeedbackContentView.addSubview(feedbackStartTextView)
         feedbackStartTextView.snp.makeConstraints {
             $0.top.equalTo(feedbackStartTextViewLabel.snp.bottom).offset(SizeLiteral.labelComponentPadding)
-            $0.leading.equalTo(addFeedbackContentView.snp.leading).inset(SizeLiteral.leadingTrailingPadding)
-            $0.trailing.equalTo(addFeedbackContentView.snp.trailing).inset(SizeLiteral.leadingTrailingPadding)
+            $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
             $0.height.equalTo(150)
         }
         
@@ -237,8 +233,7 @@ final class AddFeedbackContentViewController: BaseViewController {
         feedbackDoneButtonView.addSubview(feedbackDoneButton)
         feedbackDoneButton.snp.makeConstraints {
             $0.bottom.equalTo(feedbackDoneButtonView.snp.bottom).inset(36)
-            $0.centerX.equalTo(feedbackDoneButtonView.snp.centerX)
-            $0.width.equalTo(feedbackDoneButtonView.snp.width).inset(SizeLiteral.leadingTrailingPadding)
+            $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
         }
         
         feedbackDoneButtonView.addSubview(feedbackSendTimeLabel)


### PR DESCRIPTION
## 🌁 Background
키워드 추가하기 페이지에서 Start 부분을 추가해서 구현했습니다


## 👩‍💻 Contents
- Start 라벨과 토글 추가
- Start 토글 터치시 Start 내용 TextView 등장
- TextView & TextField 눌렀을 때 ScrollView 위치 이동 -> 작성하기 편하도록
- DoneButtonView 추가 -> 뒤에 흰색 background 추가하기 위해
- ButtonTopLabel 추가 -> 회고 날짜 유무에 따라 분기 처리
- Date Extension 추가


## ✅ Testing
feature/19-add-feedback-start 로 오셔서 root를 AddFeedbackContentViewController 로 바꾼 후핸드폰에 빌드해보시면 감사하겠습니다!


## 📱 Screenshot
https://user-images.githubusercontent.com/81340603/197524849-2fbd57a6-8a76-4405-82bb-34b7ea62982e.MP4


## 📝 Review Note
- TextView나 TextField가 가려지지 않도록 해당 부분을 터치했을 때 ScrollView를 이동시키도록 했는데 그 값을 상수로 줬습니다.. 기기마다 다르게 보일 것 같은데 더 좋은 방법 아시는 분 말씀 부탁드려요..
- ScrollView에 올라갈 ContentView의 height 를 지정해줘야 하는데 Start의 유무에 따라 길이가 자동 조정되도록 하는 방법을 이 글을 적으면서 깨달았어요.. Toggle 누를 때 height 값을 바꾸면 되는 군요..! 수정해보겠습니다!


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #19 


## 📬 Reference
https://www.zehye.kr/ios/2020/03/09/11iOS_scroll_view/
