### PR TITLE
[ADD] 보관함 Feedback CollectionView 생성

### DIFF
--- a/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
+++ b/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
@@ -21,6 +21,9 @@
 		39257DF128F93C2A00201E0B /* ImageLiteral.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39257DF028F93C2A00201E0B /* ImageLiteral.swift */; };
 		39257DF328F93D8900201E0B /* TextLiteral.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39257DF228F93D8900201E0B /* TextLiteral.swift */; };
 		39257DF528F93E4700201E0B /* UIColor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39257DF428F93E4700201E0B /* UIColor+Extension.swift */; };
+		39436C1029127BBA0083D77A /* MyFeedbackCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39436C0F29127BBA0083D77A /* MyFeedbackCollectionView.swift */; };
+		39436C132912877D0083D77A /* MyFeedbackHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39436C122912877D0083D77A /* MyFeedbackHeaderView.swift */; };
+		39436C15291287A00083D77A /* MyFeedbackCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39436C14291287A00083D77A /* MyFeedbackCollectionViewCell.swift */; };
 		395C7E0328F945B500FC2FCA /* UIFont+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 395C7E0228F945B500FC2FCA /* UIFont+Extension.swift */; };
 		395C7E0528F953D200FC2FCA /* UIViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 395C7E0428F953D200FC2FCA /* UIViewController+Extension.swift */; };
 		395C7E0B28F9550A00FC2FCA /* NSObject+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 395C7E0A28F9550A00FC2FCA /* NSObject+Extension.swift */; };
@@ -82,6 +85,9 @@
 		39257DF028F93C2A00201E0B /* ImageLiteral.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLiteral.swift; sourceTree = "<group>"; };
 		39257DF228F93D8900201E0B /* TextLiteral.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextLiteral.swift; sourceTree = "<group>"; };
 		39257DF428F93E4700201E0B /* UIColor+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Extension.swift"; sourceTree = "<group>"; };
+		39436C0F29127BBA0083D77A /* MyFeedbackCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyFeedbackCollectionView.swift; sourceTree = "<group>"; };
+		39436C122912877D0083D77A /* MyFeedbackHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyFeedbackHeaderView.swift; sourceTree = "<group>"; };
+		39436C14291287A00083D77A /* MyFeedbackCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyFeedbackCollectionViewCell.swift; sourceTree = "<group>"; };
 		395C7E0228F945B500FC2FCA /* UIFont+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Extension.swift"; sourceTree = "<group>"; };
 		395C7E0428F953D200FC2FCA /* UIViewController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extension.swift"; sourceTree = "<group>"; };
 		395C7E0A28F9550A00FC2FCA /* NSObject+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSObject+Extension.swift"; sourceTree = "<group>"; };
@@ -401,6 +407,7 @@
 		39F1A136291262B4005E3456 /* UIComponent */ = {
 			isa = PBXGroup;
 			children = (
+				39436C0F29127BBA0083D77A /* MyFeedbackCollectionView.swift */,
 			);
 			path = UIComponent;
 			sourceTree = "<group>";
@@ -409,6 +416,8 @@
 			isa = PBXGroup;
 			children = (
 				39F1A13B2912637E005E3456 /* MyBoxMemberCollectionViewCell.swift */,
+				39436C122912877D0083D77A /* MyFeedbackHeaderView.swift */,
+				39436C14291287A00083D77A /* MyFeedbackCollectionViewCell.swift */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -558,8 +567,10 @@
 				3E557FFA2901CD4200714E46 /* KeywordCollectionViewCell.swift in Sources */,
 				395C7E0528F953D200FC2FCA /* UIViewController+Extension.swift in Sources */,
 				39257DEB28F9373900201E0B /* BaseViewController.swift in Sources */,
+				39436C1029127BBA0083D77A /* MyFeedbackCollectionView.swift in Sources */,
 				525E722128FFC9A800EF3FCB /* BackButton.swift in Sources */,
 				3E5580072906A7B200714E46 /* InProgressViewController.swift in Sources */,
+				39436C132912877D0083D77A /* MyFeedbackHeaderView.swift in Sources */,
 				395C7E1828F9912700FC2FCA /* UIButton+Extension.swift in Sources */,
 				3E557FC328FE7BBC00714E46 /* HomeViewController.swift in Sources */,
 				52FA42A02906608E00C35824 /* Date+Extension.swift in Sources */,
@@ -594,6 +605,7 @@
 				395C7E2228FEDB6500FC2FCA /* UITextField+Extension.swift in Sources */,
 				D72CF1B0290552960067A118 /* InvitedCodeViewController.swift in Sources */,
 				39257DF328F93D8900201E0B /* TextLiteral.swift in Sources */,
+				39436C15291287A00083D77A /* MyFeedbackCollectionViewCell.swift in Sources */,
 				395C7E0D28F959A500FC2FCA /* MainButton.swift in Sources */,
 				525E721528FEEE8500EF3FCB /* AddFeedbackMemberViewController.swift in Sources */,
 				39257DF528F93E4700201E0B /* UIColor+Extension.swift in Sources */,

--- a/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
+++ b/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		39436C1029127BBA0083D77A /* MyFeedbackCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39436C0F29127BBA0083D77A /* MyFeedbackCollectionView.swift */; };
 		39436C132912877D0083D77A /* MyFeedbackHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39436C122912877D0083D77A /* MyFeedbackHeaderView.swift */; };
 		39436C15291287A00083D77A /* MyFeedbackCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39436C14291287A00083D77A /* MyFeedbackCollectionViewCell.swift */; };
+		39436C182912A2E10083D77A /* Feedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39436C172912A2E10083D77A /* Feedback.swift */; };
 		395C7E0328F945B500FC2FCA /* UIFont+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 395C7E0228F945B500FC2FCA /* UIFont+Extension.swift */; };
 		395C7E0528F953D200FC2FCA /* UIViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 395C7E0428F953D200FC2FCA /* UIViewController+Extension.swift */; };
 		395C7E0B28F9550A00FC2FCA /* NSObject+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 395C7E0A28F9550A00FC2FCA /* NSObject+Extension.swift */; };
@@ -88,6 +89,7 @@
 		39436C0F29127BBA0083D77A /* MyFeedbackCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyFeedbackCollectionView.swift; sourceTree = "<group>"; };
 		39436C122912877D0083D77A /* MyFeedbackHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyFeedbackHeaderView.swift; sourceTree = "<group>"; };
 		39436C14291287A00083D77A /* MyFeedbackCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyFeedbackCollectionViewCell.swift; sourceTree = "<group>"; };
+		39436C172912A2E10083D77A /* Feedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feedback.swift; sourceTree = "<group>"; };
 		395C7E0228F945B500FC2FCA /* UIFont+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Extension.swift"; sourceTree = "<group>"; };
 		395C7E0428F953D200FC2FCA /* UIViewController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extension.swift"; sourceTree = "<group>"; };
 		395C7E0A28F9550A00FC2FCA /* NSObject+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSObject+Extension.swift"; sourceTree = "<group>"; };
@@ -197,6 +199,7 @@
 		39257DD828F90EA900201E0B /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				39436C162912A2D30083D77A /* Feedback */,
 				391CBA1A290582030044CA30 /* ReflectionInfo */,
 				3E557FFB2901CD6600714E46 /* Keyword */,
 			);
@@ -294,6 +297,14 @@
 				D724790B28FEC8C900D67B50 /* BaseTextFieldViewController.swift */,
 			);
 			path = Base;
+			sourceTree = "<group>";
+		};
+		39436C162912A2D30083D77A /* Feedback */ = {
+			isa = PBXGroup;
+			children = (
+				39436C172912A2E10083D77A /* Feedback.swift */,
+			);
+			path = Feedback;
 			sourceTree = "<group>";
 		};
 		395C7E1928FEC3FB00FC2FCA /* AddReflection */ = {
@@ -612,6 +623,7 @@
 				52F2D1C12906F172009CBF89 /* SelectFeedbackMemberViewController.swift in Sources */,
 				395C7E0328F945B500FC2FCA /* UIFont+Extension.swift in Sources */,
 				3E8052DF2906E09100A6449D /* SectionHeaderView.swift in Sources */,
+				39436C182912A2E10083D77A /* Feedback.swift in Sources */,
 				7E2ECA102901136700A4D65C /* SetupNicknameViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Maddori.Apple/Maddori.Apple/Global/Extension/UILabel+Extension.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Extension/UILabel+Extension.swift
@@ -53,4 +53,13 @@ extension UILabel {
         self.setLineSpacing()
         self.numberOfLines = 0
     }
+    
+    class func textSize(font: UIFont, text: String, width: CGFloat, height: CGFloat) -> CGSize {
+        let label = UILabel(frame: CGRect(x: 0, y: 0, width: width, height: height))
+        label.numberOfLines = 0
+        label.font = font
+        label.text = text
+        label.sizeToFit()
+        return label.frame.size
+    }
 }

--- a/Maddori.Apple/Maddori.Apple/Global/Literal/ImageLiteral.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Literal/ImageLiteral.swift
@@ -14,6 +14,7 @@ enum ImageLiterals {
     static var icClose: UIImage { .load(systemName: "xmark") }
     static var icBack: UIImage { .load(systemName: "chevron.left") }
     static var icWarning: UIImage { .load(systemName: "exclamationmark.circle.fill") }
+    static var icRight: UIImage { .load(systemName: "chevron.right") }
     
     // MARK: - image
     

--- a/Maddori.Apple/Maddori.Apple/Network/Feedback/Feedback.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/Feedback/Feedback.swift
@@ -29,9 +29,9 @@ struct FeedBack {
         FeedBack(type: .continueType, title: "정리정돈", content: "Continue 스프린트 때 유독 행사가 많았는데 그때마다 행사 전후로 정리정돈 잘 해주셔서 감사해요 ! 특히 행사 끝나고 분리수거 깔끔해주신 게 인상 깊어요 ㅋㅋ 앞으로 우리 팀의 청결 지킴이 해주실거죠? 잘 부탁드립니다 ~", from: "케미", to: "호야"),
         FeedBack(type: .stopType, title: "멈출줄모르는", content: "Stop 좋아요~ 너무 좋아요~ 너무 좋아요 ~ 너무 좋아요~ 너무 좋아요~ 너무 좋아요~너무 좋아요~너무 좋아요~", from: "케미", to: "호야"),
         FeedBack(type: .stopType, title: "토끼", content: "Stop 좋아요~ 너무 좋아요~ 너무 좋아요 ~ 너무 좋아요~ 너무 좋아요~ 너무 좋아요~너무 좋아요~너무 좋아요~", from: "케미", to: "호야"),
-        FeedBack(type: .stopType, title: "진저비어", content: "Stop 좋아요~ 너무 좋아요~ 너무 좋아요 ~ 너무 좋아요~ 너무 좋아요~ 너무 좋아요~너무 좋아요~너무 좋아요~", from: "케미", to: "호야"),
+        FeedBack(type: .stopType, title: "진저비어", content: "Stop 좋아요~ 너무 좋아요~ 너무 좋아요~", from: "케미", to: "호야"),
         FeedBack(type: .stopType, title: "불도저", content: "Stop 좋아요~ 너무 좋아요~ 너무 좋아요 ~ 너무 좋아요~ 너무 좋아요~ 너무 좋아요~너무 좋아요~너무 좋아요~", from: "케미", to: "호야"),
-        FeedBack(type: .continueType, title: "진저비어", content: "Start 좋아요~ 너무 좋아요~ 너무 좋아요 ~ 너무 좋아요~ 너무 좋아요~ 너무 좋아요~너무 좋아요~너무 좋아요~", from: "케미", to: "호야"),
+        FeedBack(type: .continueType, title: "진저비어", content: "좋아요~좋아요~좋아요~좋아요~좋아요~좋아요~좋아요", from: "케미", to: "호야"),
         FeedBack(type: .stopType, title: "불도저", content: "Start 좋아요~ 너무 좋아요~ 너무 좋아요 ~ 너무 좋아요~ 너무 좋아요~ 너무 좋아요~너무 좋아요~너무 좋아요~", from: "케미", to: "호야")
     ]
     #endif

--- a/Maddori.Apple/Maddori.Apple/Network/Feedback/Feedback.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/Feedback/Feedback.swift
@@ -24,7 +24,7 @@ struct FeedBack {
     
     #if DEBUG
     static let mockData: [FeedBack] = [
-        FeedBack(type: .continueType, title: "필기능력", content: "Continue~ 너무 좋아요~ 너무 좋아요 ~ 너무 좋아요~ 너무 좋아요~ 너무 좋아요~너무 좋아요~너무 좋아요~", from: "케미", to: "호야"),
+        FeedBack(type: .continueType, title: "필기능력", content: "Continue~~", from: "케미", to: "호야"),
         FeedBack(type: .continueType, title: "두둥탁", content: "Continue 두둥탁 두둥탁 두둥탁 두둥탁 두둥탁 두둥탁 두둥탁 두둥탁 두둥탁 두둥탁 너무 좋아요~ 너무 좋아요~너무 좋아요~너무 좋아요~", from: "케미", to: "호야"),
         FeedBack(type: .continueType, title: "정리정돈", content: "Continue 스프린트 때 유독 행사가 많았는데 그때마다 행사 전후로 정리정돈 잘 해주셔서 감사해요 ! 특히 행사 끝나고 분리수거 깔끔해주신 게 인상 깊어요 ㅋㅋ 앞으로 우리 팀의 청결 지킴이 해주실거죠? 잘 부탁드립니다 ~", from: "케미", to: "호야"),
         FeedBack(type: .stopType, title: "멈출줄모르는", content: "Stop 좋아요~ 너무 좋아요~ 너무 좋아요 ~ 너무 좋아요~ 너무 좋아요~ 너무 좋아요~너무 좋아요~너무 좋아요~", from: "케미", to: "호야"),

--- a/Maddori.Apple/Maddori.Apple/Network/Feedback/Feedback.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/Feedback/Feedback.swift
@@ -1,0 +1,38 @@
+//
+//  Feedback.swift
+//  Maddori.Apple
+//
+//  Created by Mingwan Choi on 2022/11/02.
+//
+
+import Foundation
+
+struct FeedBack {
+    let type: FeedBackType
+    let title: String
+    let content: String
+    let from: String
+    let to: String
+    
+    init(type: FeedBackType, title: String, content: String, from: String, to: String) {
+        self.type = type
+        self.title = title
+        self.content = content
+        self.from = from
+        self.to = to
+    }
+    
+    #if DEBUG
+    static let mockData: [FeedBack] = [
+        FeedBack(type: .continueType, title: "필기능력", content: "Continue~ 너무 좋아요~ 너무 좋아요 ~ 너무 좋아요~ 너무 좋아요~ 너무 좋아요~너무 좋아요~너무 좋아요~", from: "케미", to: "호야"),
+        FeedBack(type: .continueType, title: "두둥탁", content: "Continue 두둥탁 두둥탁 두둥탁 두둥탁 두둥탁 두둥탁 두둥탁 두둥탁 두둥탁 두둥탁 너무 좋아요~ 너무 좋아요~너무 좋아요~너무 좋아요~", from: "케미", to: "호야"),
+        FeedBack(type: .continueType, title: "정리정돈", content: "Continue 스프린트 때 유독 행사가 많았는데 그때마다 행사 전후로 정리정돈 잘 해주셔서 감사해요 ! 특히 행사 끝나고 분리수거 깔끔해주신 게 인상 깊어요 ㅋㅋ 앞으로 우리 팀의 청결 지킴이 해주실거죠? 잘 부탁드립니다 ~", from: "케미", to: "호야"),
+        FeedBack(type: .stopType, title: "멈출줄모르는", content: "Stop 좋아요~ 너무 좋아요~ 너무 좋아요 ~ 너무 좋아요~ 너무 좋아요~ 너무 좋아요~너무 좋아요~너무 좋아요~", from: "케미", to: "호야"),
+        FeedBack(type: .stopType, title: "토끼", content: "Stop 좋아요~ 너무 좋아요~ 너무 좋아요 ~ 너무 좋아요~ 너무 좋아요~ 너무 좋아요~너무 좋아요~너무 좋아요~", from: "케미", to: "호야"),
+        FeedBack(type: .stopType, title: "진저비어", content: "Stop 좋아요~ 너무 좋아요~ 너무 좋아요 ~ 너무 좋아요~ 너무 좋아요~ 너무 좋아요~너무 좋아요~너무 좋아요~", from: "케미", to: "호야"),
+        FeedBack(type: .stopType, title: "불도저", content: "Stop 좋아요~ 너무 좋아요~ 너무 좋아요 ~ 너무 좋아요~ 너무 좋아요~ 너무 좋아요~너무 좋아요~너무 좋아요~", from: "케미", to: "호야"),
+        FeedBack(type: .startType, title: "진저비어", content: "Start 좋아요~ 너무 좋아요~ 너무 좋아요 ~ 너무 좋아요~ 너무 좋아요~ 너무 좋아요~너무 좋아요~너무 좋아요~", from: "케미", to: "호야"),
+        FeedBack(type: .startType, title: "불도저", content: "Start 좋아요~ 너무 좋아요~ 너무 좋아요 ~ 너무 좋아요~ 너무 좋아요~ 너무 좋아요~너무 좋아요~너무 좋아요~", from: "케미", to: "호야")
+    ]
+    #endif
+}

--- a/Maddori.Apple/Maddori.Apple/Network/Feedback/Feedback.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/Feedback/Feedback.swift
@@ -31,8 +31,8 @@ struct FeedBack {
         FeedBack(type: .stopType, title: "토끼", content: "Stop 좋아요~ 너무 좋아요~ 너무 좋아요 ~ 너무 좋아요~ 너무 좋아요~ 너무 좋아요~너무 좋아요~너무 좋아요~", from: "케미", to: "호야"),
         FeedBack(type: .stopType, title: "진저비어", content: "Stop 좋아요~ 너무 좋아요~ 너무 좋아요 ~ 너무 좋아요~ 너무 좋아요~ 너무 좋아요~너무 좋아요~너무 좋아요~", from: "케미", to: "호야"),
         FeedBack(type: .stopType, title: "불도저", content: "Stop 좋아요~ 너무 좋아요~ 너무 좋아요 ~ 너무 좋아요~ 너무 좋아요~ 너무 좋아요~너무 좋아요~너무 좋아요~", from: "케미", to: "호야"),
-        FeedBack(type: .startType, title: "진저비어", content: "Start 좋아요~ 너무 좋아요~ 너무 좋아요 ~ 너무 좋아요~ 너무 좋아요~ 너무 좋아요~너무 좋아요~너무 좋아요~", from: "케미", to: "호야"),
-        FeedBack(type: .startType, title: "불도저", content: "Start 좋아요~ 너무 좋아요~ 너무 좋아요 ~ 너무 좋아요~ 너무 좋아요~ 너무 좋아요~너무 좋아요~너무 좋아요~", from: "케미", to: "호야")
+        FeedBack(type: .continueType, title: "진저비어", content: "Start 좋아요~ 너무 좋아요~ 너무 좋아요 ~ 너무 좋아요~ 너무 좋아요~ 너무 좋아요~너무 좋아요~너무 좋아요~", from: "케미", to: "호야"),
+        FeedBack(type: .stopType, title: "불도저", content: "Start 좋아요~ 너무 좋아요~ 너무 좋아요 ~ 너무 좋아요~ 너무 좋아요~ 너무 좋아요~너무 좋아요~너무 좋아요~", from: "케미", to: "호야")
     ]
     #endif
 }

--- a/Maddori.Apple/Maddori.Apple/Network/ReflectionInfo/ReflectionInfoModel.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/ReflectionInfo/ReflectionInfoModel.swift
@@ -7,10 +7,10 @@
 
 import Foundation
 
-enum FeedBackType: String {
-    case continueType = "continue"
-    case stopType = "stop"
-    case startType = "start"
+enum FeedBackType: String, CaseIterable {
+    case continueType = "Continue"
+    case stopType = "Stop"
+    case startType = "Start"
 }
 
 struct ReflectionInfoModel {

--- a/Maddori.Apple/Maddori.Apple/Screen/MyBox/Cell/MyFeedbackCollectionViewCell.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyBox/Cell/MyFeedbackCollectionViewCell.swift
@@ -28,6 +28,12 @@ final class MyFeedbackCollectionViewCell: BaseCollectionViewCell {
         label.numberOfLines = 2
         return label
     }()
+    private let rightImage: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = ImageLiterals.icRight
+        imageView.tintColor = .gray400
+        return imageView
+    }()
     
     // MARK: - life cycle
     
@@ -46,6 +52,11 @@ final class MyFeedbackCollectionViewCell: BaseCollectionViewCell {
             $0.leading.equalToSuperview()
             $0.trailing.equalToSuperview().inset(66)
             $0.top.equalTo(titleLabel.snp.bottom).offset(8)
+        }
+        
+        self.addSubview(rightImage)
+        rightImage.snp.makeConstraints {
+            $0.trailing.centerY.equalToSuperview()
         }
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Screen/MyBox/Cell/MyFeedbackCollectionViewCell.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyBox/Cell/MyFeedbackCollectionViewCell.swift
@@ -26,7 +26,6 @@ final class MyFeedbackCollectionViewCell: BaseCollectionViewCell {
         label.font = .body2
         label.textColor = .gray400
         label.numberOfLines = 2
-        
         return label
     }()
     

--- a/Maddori.Apple/Maddori.Apple/Screen/MyBox/Cell/MyFeedbackCollectionViewCell.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyBox/Cell/MyFeedbackCollectionViewCell.swift
@@ -1,0 +1,30 @@
+//
+//  MyFeedbackCollectionViewCell.swift
+//  Maddori.Apple
+//
+//  Created by Mingwan Choi on 2022/11/02.
+//
+
+import UIKit
+
+import SnapKit
+
+final class MyFeedbackCollectionViewCell: BaseCollectionViewCell {
+    
+    // MARK: - property
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "test"
+        return label
+    }()
+    
+    // MARK: - life cycle
+    
+    override func render() {
+        self.addSubview(titleLabel)
+        titleLabel.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+}

--- a/Maddori.Apple/Maddori.Apple/Screen/MyBox/Cell/MyFeedbackCollectionViewCell.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyBox/Cell/MyFeedbackCollectionViewCell.swift
@@ -15,14 +15,12 @@ final class MyFeedbackCollectionViewCell: BaseCollectionViewCell {
     
     private let titleLabel: UILabel = {
         let label = UILabel()
-        label.text = "test"
         label.font = .label1
         label.textColor = .black100
         return label
     }()
     private let contentLabel: UILabel = {
         let label = UILabel()
-        label.text = "너무 좋아요 ~ 너무 좋아요 ~ 너무 좋아요 ~ 너무 좋아요 ~ 너무 좋아요 ~ 너무 좋아요 ~ 너무 좋아요 ~ 너무 좋아요 ~ "
         label.font = .body2
         label.textColor = .gray400
         label.numberOfLines = 2
@@ -58,5 +56,12 @@ final class MyFeedbackCollectionViewCell: BaseCollectionViewCell {
         rightImage.snp.makeConstraints {
             $0.trailing.centerY.equalToSuperview()
         }
+    }
+    
+    // MARK: - func
+    
+    func setCellLabel(title: String, content: String) {
+        titleLabel.text = title
+        contentLabel.text = content
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Screen/MyBox/Cell/MyFeedbackCollectionViewCell.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyBox/Cell/MyFeedbackCollectionViewCell.swift
@@ -48,13 +48,16 @@ final class MyFeedbackCollectionViewCell: BaseCollectionViewCell {
         self.addSubview(contentLabel)
         contentLabel.snp.makeConstraints {
             $0.leading.equalToSuperview()
-            $0.trailing.equalToSuperview().inset(66)
+            $0.trailing.equalToSuperview().inset(66 - SizeLiteral.leadingTrailingPadding)
             $0.top.equalTo(titleLabel.snp.bottom).offset(8)
         }
         
         self.addSubview(rightImage)
         rightImage.snp.makeConstraints {
-            $0.trailing.centerY.equalToSuperview()
+            $0.trailing.equalToSuperview()
+            $0.top.equalTo(contentLabel.snp.top)
+            $0.width.equalTo(12)
+            $0.height.equalTo(20)
         }
     }
     
@@ -62,6 +65,6 @@ final class MyFeedbackCollectionViewCell: BaseCollectionViewCell {
     
     func setCellLabel(title: String, content: String) {
         titleLabel.text = title
-        contentLabel.text = content
+        contentLabel.setTextWithLineHeight(text: content, lineHeight: 22)
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Screen/MyBox/Cell/MyFeedbackCollectionViewCell.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyBox/Cell/MyFeedbackCollectionViewCell.swift
@@ -54,8 +54,7 @@ final class MyFeedbackCollectionViewCell: BaseCollectionViewCell {
         
         self.addSubview(rightImage)
         rightImage.snp.makeConstraints {
-            $0.trailing.equalToSuperview()
-            $0.top.equalTo(contentLabel.snp.top)
+            $0.centerY.trailing.equalToSuperview()
             $0.width.equalTo(12)
             $0.height.equalTo(20)
         }

--- a/Maddori.Apple/Maddori.Apple/Screen/MyBox/Cell/MyFeedbackCollectionViewCell.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyBox/Cell/MyFeedbackCollectionViewCell.swift
@@ -16,15 +16,37 @@ final class MyFeedbackCollectionViewCell: BaseCollectionViewCell {
     private let titleLabel: UILabel = {
         let label = UILabel()
         label.text = "test"
+        label.font = .label1
+        label.textColor = .black100
+        return label
+    }()
+    private let contentLabel: UILabel = {
+        let label = UILabel()
+        label.text = "너무 좋아요 ~ 너무 좋아요 ~ 너무 좋아요 ~ 너무 좋아요 ~ 너무 좋아요 ~ 너무 좋아요 ~ 너무 좋아요 ~ 너무 좋아요 ~ "
+        label.font = .body2
+        label.textColor = .gray400
+        label.numberOfLines = 2
+        
         return label
     }()
     
     // MARK: - life cycle
     
+    override func configUI() {
+        backgroundColor = .backgroundWhite
+    }
+    
     override func render() {
         self.addSubview(titleLabel)
         titleLabel.snp.makeConstraints {
-            $0.edges.equalToSuperview()
+            $0.top.leading.equalToSuperview()
+        }
+        
+        self.addSubview(contentLabel)
+        contentLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview()
+            $0.trailing.equalToSuperview().inset(66)
+            $0.top.equalTo(titleLabel.snp.bottom).offset(8)
         }
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Screen/MyBox/Cell/MyFeedbackHeaderView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyBox/Cell/MyFeedbackHeaderView.swift
@@ -20,6 +20,8 @@ final class MyFeedbackHeaderView: UICollectionReusableView {
         return label
     }()
     
+    // MARK: - life cycle
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         render()
@@ -34,6 +36,8 @@ final class MyFeedbackHeaderView: UICollectionReusableView {
             $0.centerY.equalToSuperview()
         }
     }
+    
+    // MARK: - func
     
     func setCssLabelText(with index: Int) {
         cssLabel.text = FeedBackType.allCases[index].rawValue

--- a/Maddori.Apple/Maddori.Apple/Screen/MyBox/Cell/MyFeedbackHeaderView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyBox/Cell/MyFeedbackHeaderView.swift
@@ -15,7 +15,6 @@ final class MyFeedbackHeaderView: UICollectionReusableView {
     
     private let cssLabel: UILabel = {
         let label = UILabel()
-        label.text = "Continue"
         label.font = .main
         label.textColor = .blue200
         return label

--- a/Maddori.Apple/Maddori.Apple/Screen/MyBox/Cell/MyFeedbackHeaderView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyBox/Cell/MyFeedbackHeaderView.swift
@@ -36,4 +36,7 @@ final class MyFeedbackHeaderView: UICollectionReusableView {
         }
     }
     
+    func setCssLabelText(with index: Int) {
+        cssLabel.text = FeedBackType.allCases[index].rawValue
+    }
 }

--- a/Maddori.Apple/Maddori.Apple/Screen/MyBox/Cell/MyFeedbackHeaderView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyBox/Cell/MyFeedbackHeaderView.swift
@@ -1,0 +1,39 @@
+//
+//  MyFeedbackHeaderView.swift
+//  Maddori.Apple
+//
+//  Created by Mingwan Choi on 2022/11/02.
+//
+
+import UIKit
+
+import SnapKit
+
+final class MyFeedbackHeaderView: UICollectionReusableView {
+    
+    // MARK: - property
+    
+    private let cssLabel: UILabel = {
+        let label = UILabel()
+        label.text = "Continue"
+        label.font = .main
+        label.textColor = .blue200
+        return label
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        render()
+    }
+    
+    required init?(coder: NSCoder) { nil }
+    
+    private func render() {
+        self.addSubview(cssLabel)
+        cssLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+            $0.centerY.equalToSuperview()
+        }
+    }
+    
+}

--- a/Maddori.Apple/Maddori.Apple/Screen/MyBox/MyBoxViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyBox/MyBoxViewController.swift
@@ -51,6 +51,7 @@ final class MyBoxViewController: BaseViewController {
         view.backgroundColor = .gray300
         return view
     }()
+    private let feedbackCollectionView = MyFeedbackCollectionView()
     
     // MARK: - life cycle
     
@@ -73,6 +74,12 @@ final class MyBoxViewController: BaseViewController {
             $0.leading.trailing.equalToSuperview()
             $0.top.equalTo(memberCollectionView.snp.bottom)
             $0.height.equalTo(0.5)
+        }
+        
+        view.addSubview(feedbackCollectionView)
+        feedbackCollectionView.snp.makeConstraints {
+            $0.leading.trailing.bottom.equalToSuperview()
+            $0.top.equalTo(dividerView.snp.bottom).offset(24)
         }
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Screen/MyBox/UIComponent/MyFeedbackCollectionView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyBox/UIComponent/MyFeedbackCollectionView.swift
@@ -78,18 +78,17 @@ extension MyFeedbackCollectionView: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MyFeedbackCollectionViewCell.className, for: indexPath) as? MyFeedbackCollectionViewCell else { return UICollectionViewCell()}
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MyFeedbackCollectionViewCell.className, for: indexPath) as? MyFeedbackCollectionViewCell else { return UICollectionViewCell() }
+        var data: [FeedBack] = []
         switch indexPath.section {
         case 0:
-            let data = mockData.filter { $0.type == .continueType }
-            cell.setCellLabel(title: data[indexPath.item].title, content: data[indexPath.item].content)
+            data = mockData.filter { $0.type == .continueType }
         case 1:
-            let data = mockData.filter { $0.type == .stopType }
-            cell.setCellLabel(title: data[indexPath.item].title, content: data[indexPath.item].content)
+            data = mockData.filter { $0.type == .stopType }
         default:
-            let data = mockData.filter { $0.type == .startType }
-            cell.setCellLabel(title: data[indexPath.item].title, content: data[indexPath.item].content)
+            data = mockData.filter { $0.type == .startType }
         }
+        cell.setCellLabel(title: data[indexPath.item].title, content: data[indexPath.item].content)
         return cell
     }
     

--- a/Maddori.Apple/Maddori.Apple/Screen/MyBox/UIComponent/MyFeedbackCollectionView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyBox/UIComponent/MyFeedbackCollectionView.swift
@@ -63,6 +63,7 @@ final class MyFeedbackCollectionView: UIView {
 extension MyFeedbackCollectionView: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
         guard let header = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: MyFeedbackHeaderView.className, for: indexPath) as? MyFeedbackHeaderView else { return UICollectionReusableView() }
+        header.setCssLabelText(with: indexPath.section)
         switch kind {
         case UICollectionView.elementKindSectionHeader:
             return header
@@ -73,12 +74,16 @@ extension MyFeedbackCollectionView: UICollectionViewDelegate {
 }
 extension MyFeedbackCollectionView: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        25
+        10
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MyFeedbackCollectionViewCell.className, for: indexPath) as? MyFeedbackCollectionViewCell else { return UICollectionViewCell()}
         return cell
+    }
+    
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+        2
     }
 }
 

--- a/Maddori.Apple/Maddori.Apple/Screen/MyBox/UIComponent/MyFeedbackCollectionView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyBox/UIComponent/MyFeedbackCollectionView.swift
@@ -13,12 +13,12 @@ final class MyFeedbackCollectionView: UIView {
     private let mockData = FeedBack.mockData
     private enum Size {
         static let horizontalPadding: CGFloat = 24
-        static let topSpacing: CGFloat = 20
+        static let topSpacing: CGFloat = 24
         static let cellWidth: CGFloat = UIScreen.main.bounds.size.width - (SizeLiteral.leadingTrailingPadding * 2)
-        static let cellHeight: CGFloat = 85
+        static let cellHeight: CGFloat = 75
         static let collectionViewInset = UIEdgeInsets.init(top: Size.topSpacing,
                                                            left: Size.horizontalPadding,
-                                                           bottom: 0,
+                                                           bottom: 15,
                                                            right: Size.horizontalPadding)
     }
     

--- a/Maddori.Apple/Maddori.Apple/Screen/MyBox/UIComponent/MyFeedbackCollectionView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyBox/UIComponent/MyFeedbackCollectionView.swift
@@ -1,0 +1,85 @@
+//
+//  MyFeedbackCollectionView.swift
+//  Maddori.Apple
+//
+//  Created by Mingwan Choi on 2022/11/02.
+//
+
+import UIKit
+
+import SnapKit
+
+final class MyFeedbackCollectionView: UIView {
+    
+    private enum Size {
+        static let horizontalPadding: CGFloat = 24
+        static let topSpacing: CGFloat = 20
+    }
+    
+    // MARK: - property
+    
+    private let collectionViewFlowLayout: UICollectionViewFlowLayout = {
+        let flowLayout = UICollectionViewFlowLayout()
+        flowLayout.sectionInset = UIEdgeInsets.init(top: Size.topSpacing,
+                                                    left: Size.horizontalPadding,
+                                                    bottom: 0,
+                                                    right: Size.horizontalPadding)
+        return flowLayout
+    }()
+    private lazy var feedbackCollectionView: UICollectionView = {
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionViewFlowLayout)
+        collectionView.delegate = self
+        collectionView.dataSource = self
+        collectionView.register(MyFeedbackCollectionViewCell.self, forCellWithReuseIdentifier: MyFeedbackCollectionViewCell.className)
+        collectionView.register(MyFeedbackHeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: MyFeedbackHeaderView.className)
+        return collectionView
+    }()
+    
+    // MARK: - life cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        render()
+    }
+    
+    required init?(coder: NSCoder) { nil }
+    
+    private func render() {
+        self.addSubview(feedbackCollectionView)
+        feedbackCollectionView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+}
+
+    // MARK: - extension
+
+extension MyFeedbackCollectionView: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+        guard let header = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: MyFeedbackHeaderView.className, for: indexPath) as? MyFeedbackHeaderView else { return UICollectionReusableView() }
+        switch kind {
+        case UICollectionView.elementKindSectionHeader:
+            return header
+        default:
+            return UICollectionReusableView()
+        }
+    }
+}
+extension MyFeedbackCollectionView: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        5
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MyFeedbackCollectionViewCell.className, for: indexPath) as? MyFeedbackCollectionViewCell else { return UICollectionViewCell()}
+        return cell
+    }
+}
+
+extension MyFeedbackCollectionView: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
+        return CGSize(width: 300, height: 40)
+    }
+}
+
+

--- a/Maddori.Apple/Maddori.Apple/Screen/MyBox/UIComponent/MyFeedbackCollectionView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyBox/UIComponent/MyFeedbackCollectionView.swift
@@ -14,8 +14,10 @@ final class MyFeedbackCollectionView: UIView {
     private enum Size {
         static let horizontalPadding: CGFloat = 24
         static let topSpacing: CGFloat = 24
+        static let cellContentWidth: CGFloat = UIScreen.main.bounds.size.width - SizeLiteral.leadingTrailingPadding - 66
+        static let resizingTextLineOneHeight: CGFloat = 53
+        static let resizingTextLineTwoHeight: CGFloat = 75
         static let cellWidth: CGFloat = UIScreen.main.bounds.size.width - (SizeLiteral.leadingTrailingPadding * 2)
-        static let cellHeight: CGFloat = 75
         static let collectionViewInset = UIEdgeInsets.init(top: Size.topSpacing,
                                                            left: Size.horizontalPadding,
                                                            bottom: 15,
@@ -28,7 +30,6 @@ final class MyFeedbackCollectionView: UIView {
         let flowLayout = UICollectionViewFlowLayout()
         flowLayout.scrollDirection = .vertical
         flowLayout.sectionInset = Size.collectionViewInset
-        flowLayout.itemSize = CGSize(width: Size.cellWidth, height: Size.cellHeight)
         return flowLayout
     }()
     private lazy var feedbackCollectionView: UICollectionView = {
@@ -106,6 +107,20 @@ extension MyFeedbackCollectionView: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
         return CGSize(width: 80, height: 25)
     }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        var data: [FeedBack] = []
+        if indexPath.section == 0 {
+            data = mockData.filter { $0.type == .continueType }
+        } else {
+            data = mockData.filter { $0.type == .stopType }
+        }
+        let cellHeight = UILabel.textSize(font: .body2, text: data[indexPath.item].content, width: Size.cellContentWidth, height: 30).height
+        let isOneTextLine = cellHeight < 18
+        if isOneTextLine {
+            return CGSize(width: Size.cellWidth, height: Size.resizingTextLineOneHeight)
+        } else {
+            return CGSize(width: Size.cellWidth, height: Size.resizingTextLineTwoHeight)
+        }
+    }
 }
-
-

--- a/Maddori.Apple/Maddori.Apple/Screen/MyBox/UIComponent/MyFeedbackCollectionView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyBox/UIComponent/MyFeedbackCollectionView.swift
@@ -14,24 +14,30 @@ final class MyFeedbackCollectionView: UIView {
     private enum Size {
         static let horizontalPadding: CGFloat = 24
         static let topSpacing: CGFloat = 20
+        static let cellWidth: CGFloat = UIScreen.main.bounds.size.width - (SizeLiteral.leadingTrailingPadding * 2)
+        static let cellHeight: CGFloat = 85
+        static let collectionViewInset = UIEdgeInsets.init(top: Size.topSpacing,
+                                                           left: Size.horizontalPadding,
+                                                           bottom: 0,
+                                                           right: Size.horizontalPadding)
     }
     
     // MARK: - property
     
     private let collectionViewFlowLayout: UICollectionViewFlowLayout = {
         let flowLayout = UICollectionViewFlowLayout()
-        flowLayout.sectionInset = UIEdgeInsets.init(top: Size.topSpacing,
-                                                    left: Size.horizontalPadding,
-                                                    bottom: 0,
-                                                    right: Size.horizontalPadding)
+        flowLayout.scrollDirection = .vertical
+        flowLayout.sectionInset = Size.collectionViewInset
+        flowLayout.itemSize = CGSize(width: Size.cellWidth, height: Size.cellHeight)
         return flowLayout
     }()
     private lazy var feedbackCollectionView: UICollectionView = {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionViewFlowLayout)
+        collectionView.backgroundColor = .backgroundWhite
         collectionView.delegate = self
         collectionView.dataSource = self
-        collectionView.register(MyFeedbackCollectionViewCell.self, forCellWithReuseIdentifier: MyFeedbackCollectionViewCell.className)
         collectionView.register(MyFeedbackHeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: MyFeedbackHeaderView.className)
+        collectionView.register(MyFeedbackCollectionViewCell.self, forCellWithReuseIdentifier: MyFeedbackCollectionViewCell.className)
         return collectionView
     }()
     
@@ -67,7 +73,7 @@ extension MyFeedbackCollectionView: UICollectionViewDelegate {
 }
 extension MyFeedbackCollectionView: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        5
+        25
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
@@ -78,7 +84,7 @@ extension MyFeedbackCollectionView: UICollectionViewDataSource {
 
 extension MyFeedbackCollectionView: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
-        return CGSize(width: 300, height: 40)
+        return CGSize(width: 80, height: 25)
     }
 }
 

--- a/Maddori.Apple/Maddori.Apple/Screen/MyBox/UIComponent/MyFeedbackCollectionView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyBox/UIComponent/MyFeedbackCollectionView.swift
@@ -86,7 +86,7 @@ extension MyFeedbackCollectionView: UICollectionViewDataSource {
         case 1:
             data = mockData.filter { $0.type == .stopType }
         default:
-            data = mockData.filter { $0.type == .startType }
+            break
         }
         cell.setCellLabel(title: data[indexPath.item].title, content: data[indexPath.item].content)
         return cell
@@ -94,9 +94,7 @@ extension MyFeedbackCollectionView: UICollectionViewDataSource {
     
     // FIXME: - 예외 처리해야함 (continue와 start만 있다던지?)
     func numberOfSections(in collectionView: UICollectionView) -> Int {
-        if mockData.contains(where: { $0.type == .continueType }) && mockData.contains(where: { $0.type == .stopType }) && mockData.contains(where: { $0.type == .startType }) {
-            return 3
-        } else if mockData.contains(where: { $0.type == .continueType }) && mockData.contains(where: { $0.type == .stopType }) {
+        if mockData.contains(where: { $0.type == .continueType }) && mockData.contains(where: { $0.type == .stopType }) {
             return 2
         } else {
             return 1

--- a/Maddori.Apple/Maddori.Apple/Screen/MyBox/UIComponent/MyFeedbackCollectionView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyBox/UIComponent/MyFeedbackCollectionView.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 
 final class MyFeedbackCollectionView: UIView {
-    
+    private let mockData = FeedBack.mockData
     private enum Size {
         static let horizontalPadding: CGFloat = 24
         static let topSpacing: CGFloat = 20
@@ -74,16 +74,34 @@ extension MyFeedbackCollectionView: UICollectionViewDelegate {
 }
 extension MyFeedbackCollectionView: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        10
+        mockData.filter { $0.type == FeedBackType.allCases[section] }.count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MyFeedbackCollectionViewCell.className, for: indexPath) as? MyFeedbackCollectionViewCell else { return UICollectionViewCell()}
+        switch indexPath.section {
+        case 0:
+            let data = mockData.filter { $0.type == .continueType }
+            cell.setCellLabel(title: data[indexPath.item].title, content: data[indexPath.item].content)
+        case 1:
+            let data = mockData.filter { $0.type == .stopType }
+            cell.setCellLabel(title: data[indexPath.item].title, content: data[indexPath.item].content)
+        default:
+            let data = mockData.filter { $0.type == .startType }
+            cell.setCellLabel(title: data[indexPath.item].title, content: data[indexPath.item].content)
+        }
         return cell
     }
     
+    // FIXME: - 예외 처리해야함 (continue와 start만 있다던지?)
     func numberOfSections(in collectionView: UICollectionView) -> Int {
-        2
+        if mockData.contains(where: { $0.type == .continueType }) && mockData.contains(where: { $0.type == .stopType }) && mockData.contains(where: { $0.type == .startType }) {
+            return 3
+        } else if mockData.contains(where: { $0.type == .continueType }) && mockData.contains(where: { $0.type == .stopType }) {
+            return 2
+        } else {
+            return 1
+        }
     }
 }
 

--- a/Maddori.Apple/Maddori.Apple/Screen/MyBox/UIComponent/MyFeedbackCollectionView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyBox/UIComponent/MyFeedbackCollectionView.swift
@@ -115,7 +115,7 @@ extension MyFeedbackCollectionView: UICollectionViewDelegateFlowLayout {
         } else {
             data = mockData.filter { $0.type == .stopType }
         }
-        let cellHeight = UILabel.textSize(font: .body2, text: data[indexPath.item].content, width: Size.cellContentWidth, height: 30).height
+        let cellHeight = UILabel.textSize(font: .body2, text: data[indexPath.item].content, width: Size.cellContentWidth, height: 0).height
         let isOneTextLine = cellHeight < 18
         if isOneTextLine {
             return CGSize(width: Size.cellWidth, height: Size.resizingTextLineOneHeight)


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
https://github.com/DeveloperAcademy-POSTECH/MacC-Team-Maddori.Apple/pull/66 이 PR에 이어서 아랫부분 작업 했습니다 !

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
| 전체 View | 작업 한 부분 |
|---|---|
|<img width="404" alt="image" src="https://user-images.githubusercontent.com/78677571/199454861-43c6a19f-f5e9-4a84-a4c2-6800ee12fc44.png">|<img width="404" alt="image" src="https://user-images.githubusercontent.com/78677571/199510966-e22b8d9c-5958-4852-a7fc-f01d7e100e49.png">|

앞선 PR에선 멤버들의 CollectionView를 만들었는데, 이어서 네모 체크해놓은 피드백 받은 부분의 CollectionView를 만들었습니다 !

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
feature/65-feedback-collectionview 브랜치로 오셔서 SceneDelegate를 MyBoxViewController로 변경해주세요 !
Network/Feedback 폴더에 Feedback이라는 `struct`를 만들어 뒀는데, 거기에 목데이터를 추가하시면서 데이터가 잘 추가되는지 확인해주시면 됩니다 !

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->

https://user-images.githubusercontent.com/78677571/199657363-7a72bb4d-c678-4d04-8142-6ea8677ec58c.mp4


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
앞선 PR과 이번 PR에선 cell에 접근할때 `cell.titleLabel` 이런식으로 바로 property에 접근하지 않고, 객체지향적으로 클래스 내부에 함수를 만들어 두고, 함수를 통해 접근했는데 이것도 결국 의존성 문제는 같은 맥락인지 궁금하네요.. 

추가적으로 만약 받은 피드백이 continue, stop, start 이 세개가 다 있다면 제일 좋겠지만, continue와 start만 있고 stop은 없다던지 했을때의 분기처리가 아직 덜 되어있습니다 (fixme를 적어뒀습니다) 이 부분의 분기처리는 조금 더 고민해보겠습니다

현재 divider는 아직 구현을 하지 않았습니다. 새로 브랜치 파서 추가적으로 작업하겠습니다. 뭔가 쉬워보이진 않아서 PR을 분리하고자 함입니다 ^________^

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- #65 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
