### PR TITLE
[ADD] FeedBack CollectionView Divider 추가

### DIFF
--- a/Maddori.Apple/Maddori.Apple/Network/Feedback/Feedback.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/Feedback/Feedback.swift
@@ -24,14 +24,14 @@ struct FeedBack {
     
     #if DEBUG
     static let mockData: [FeedBack] = [
-        FeedBack(type: .continueType, title: "필기능력", content: "Continue~~", from: "케미", to: "호야"),
+        FeedBack(type: .continueType, title: "필기능력", content: "Continue~~Continue~~Continue~~Continue~~C", from: "케미", to: "호야"),
         FeedBack(type: .continueType, title: "두둥탁", content: "Continue 두둥탁 두둥탁 두둥탁 두둥탁 두둥탁 두둥탁 두둥탁 두둥탁 두둥탁 두둥탁 너무 좋아요~ 너무 좋아요~너무 좋아요~너무 좋아요~", from: "케미", to: "호야"),
         FeedBack(type: .continueType, title: "정리정돈", content: "Continue 스프린트 때 유독 행사가 많았는데 그때마다 행사 전후로 정리정돈 잘 해주셔서 감사해요 ! 특히 행사 끝나고 분리수거 깔끔해주신 게 인상 깊어요 ㅋㅋ 앞으로 우리 팀의 청결 지킴이 해주실거죠? 잘 부탁드립니다 ~", from: "케미", to: "호야"),
         FeedBack(type: .stopType, title: "멈출줄모르는", content: "Stop 좋아요~ 너무 좋아요~ 너무 좋아요 ~ 너무 좋아요~ 너무 좋아요~ 너무 좋아요~너무 좋아요~너무 좋아요~", from: "케미", to: "호야"),
         FeedBack(type: .stopType, title: "토끼", content: "Stop 좋아요~ 너무 좋아요~ 너무 좋아요 ~ 너무 좋아요~ 너무 좋아요~ 너무 좋아요~너무 좋아요~너무 좋아요~", from: "케미", to: "호야"),
         FeedBack(type: .stopType, title: "진저비어", content: "Stop 좋아요~ 너무 좋아요~ 너무 좋아요~", from: "케미", to: "호야"),
         FeedBack(type: .stopType, title: "불도저", content: "Stop 좋아요~ 너무 좋아요~ 너무 좋아요 ~ 너무 좋아요~ 너무 좋아요~ 너무 좋아요~너무 좋아요~너무 좋아요~", from: "케미", to: "호야"),
-        FeedBack(type: .continueType, title: "진저비어", content: "좋아요~좋아요~좋아요~좋아요~좋아요~좋아요~좋아요", from: "케미", to: "호야"),
+        FeedBack(type: .continueType, title: "진저비어", content: "좋아요~좋아요~좋아요~좋아요~좋아요~좋아요~좋!~", from: "케미", to: "호야"),
         FeedBack(type: .stopType, title: "불도저", content: "Start 좋아요~ 너무 좋아요~ 너무 좋아요 ~ 너무 좋아요~ 너무 좋아요~ 너무 좋아요~너무 좋아요~너무 좋아요~", from: "케미", to: "호야")
     ]
     #endif

--- a/Maddori.Apple/Maddori.Apple/Screen/MyBox/Cell/MyFeedbackCollectionViewCell.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyBox/Cell/MyFeedbackCollectionViewCell.swift
@@ -32,6 +32,11 @@ final class MyFeedbackCollectionViewCell: BaseCollectionViewCell {
         imageView.tintColor = .gray400
         return imageView
     }()
+    private let dividerView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .gray300
+        return view
+    }()
     
     // MARK: - life cycle
     
@@ -48,16 +53,23 @@ final class MyFeedbackCollectionViewCell: BaseCollectionViewCell {
         self.addSubview(contentLabel)
         contentLabel.snp.makeConstraints {
             $0.leading.equalToSuperview()
-            $0.trailing.equalToSuperview().inset(66 - SizeLiteral.leadingTrailingPadding)
+            $0.trailing.equalToSuperview().inset(66)
             $0.top.equalTo(titleLabel.snp.bottom).offset(8)
         }
         
         self.addSubview(rightImage)
         rightImage.snp.makeConstraints {
-            $0.trailing.equalToSuperview()
+            $0.trailing.equalToSuperview().inset(24)
             $0.top.equalTo(contentLabel.snp.top)
             $0.width.equalTo(12)
             $0.height.equalTo(20)
+        }
+        
+        self.addSubview(dividerView)
+        dividerView.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalToSuperview()
+            $0.height.equalTo(0.5)
         }
     }
     
@@ -66,5 +78,9 @@ final class MyFeedbackCollectionViewCell: BaseCollectionViewCell {
     func setCellLabel(title: String, content: String) {
         titleLabel.text = title
         contentLabel.setTextWithLineHeight(text: content, lineHeight: 22)
+    }
+    
+    func setHiddenDivider(value: Bool) {
+        dividerView.isHidden = value
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Screen/MyBox/Cell/MyFeedbackCollectionViewCell.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyBox/Cell/MyFeedbackCollectionViewCell.swift
@@ -80,7 +80,7 @@ final class MyFeedbackCollectionViewCell: BaseCollectionViewCell {
         contentLabel.setTextWithLineHeight(text: content, lineHeight: 22)
     }
     
-    func setHiddenDivider(value: Bool) {
+    func setDividerHidden(_ value: Bool) {
         dividerView.isHidden = value
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Screen/MyBox/Cell/MyFeedbackHeaderView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyBox/Cell/MyFeedbackHeaderView.swift
@@ -13,6 +13,11 @@ final class MyFeedbackHeaderView: UICollectionReusableView {
     
     // MARK: - property
     
+    private let dividerView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .gray300
+        return view
+    }()
     private let cssLabel: UILabel = {
         let label = UILabel()
         label.font = .main
@@ -30,10 +35,16 @@ final class MyFeedbackHeaderView: UICollectionReusableView {
     required init?(coder: NSCoder) { nil }
     
     private func render() {
+        self.addSubview(dividerView)
+        dividerView.snp.makeConstraints {
+            $0.leading.trailing.top.equalToSuperview()
+            $0.height.equalTo(0.5)
+        }
+        
         self.addSubview(cssLabel)
         cssLabel.snp.makeConstraints {
             $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
-            $0.centerY.equalToSuperview()
+            $0.bottom.equalToSuperview()
         }
     }
     
@@ -41,5 +52,9 @@ final class MyFeedbackHeaderView: UICollectionReusableView {
     
     func setCssLabelText(with index: Int) {
         cssLabel.text = FeedBackType.allCases[index].rawValue
+    }
+    
+    func setHiddenDivider(value: Bool) {
+        dividerView.isHidden = value
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Screen/MyBox/Cell/MyFeedbackHeaderView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyBox/Cell/MyFeedbackHeaderView.swift
@@ -54,7 +54,7 @@ final class MyFeedbackHeaderView: UICollectionReusableView {
         cssLabel.text = FeedBackType.allCases[index].rawValue
     }
     
-    func setHiddenDivider(value: Bool) {
+    func setDividerHidden(_ value: Bool) {
         dividerView.isHidden = value
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Screen/MyBox/MyBoxViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyBox/MyBoxViewController.swift
@@ -79,7 +79,7 @@ final class MyBoxViewController: BaseViewController {
         view.addSubview(feedbackCollectionView)
         feedbackCollectionView.snp.makeConstraints {
             $0.leading.trailing.bottom.equalToSuperview()
-            $0.top.equalTo(dividerView.snp.bottom).offset(24)
+            $0.top.equalTo(dividerView.snp.bottom)
         }
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Screen/MyBox/UIComponent/MyFeedbackCollectionView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyBox/UIComponent/MyFeedbackCollectionView.swift
@@ -14,12 +14,12 @@ final class MyFeedbackCollectionView: UIView {
     private enum Size {
         static let horizontalPadding: CGFloat = 24
         static let topSpacing: CGFloat = 20
-        static let cellWidth: CGFloat = UIScreen.main.bounds.size.width - (SizeLiteral.leadingTrailingPadding * 2)
+        static let cellWidth: CGFloat = UIScreen.main.bounds.size.width - SizeLiteral.leadingTrailingPadding
         static let cellHeight: CGFloat = 85
         static let collectionViewInset = UIEdgeInsets.init(top: Size.topSpacing,
                                                            left: Size.horizontalPadding,
                                                            bottom: 0,
-                                                           right: Size.horizontalPadding)
+                                                           right: 0)
     }
     
     // MARK: - property
@@ -88,12 +88,21 @@ extension MyFeedbackCollectionView: UICollectionViewDataSource {
         case 0:
             let data = mockData.filter { $0.type == .continueType }
             cell.setCellLabel(title: data[indexPath.item].title, content: data[indexPath.item].content)
+            if indexPath.item == data.count - 1 {
+                cell.setHiddenDivider(value: true)
+            }
         case 1:
             let data = mockData.filter { $0.type == .stopType }
             cell.setCellLabel(title: data[indexPath.item].title, content: data[indexPath.item].content)
+            if indexPath.item == data.count - 1 {
+                cell.setHiddenDivider(value: true)
+            }
         default:
             let data = mockData.filter { $0.type == .startType }
             cell.setCellLabel(title: data[indexPath.item].title, content: data[indexPath.item].content)
+            if indexPath.item == data.count - 1 {
+                cell.setHiddenDivider(value: true)
+            }
         }
         return cell
     }

--- a/Maddori.Apple/Maddori.Apple/Screen/MyBox/UIComponent/MyFeedbackCollectionView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyBox/UIComponent/MyFeedbackCollectionView.swift
@@ -15,12 +15,12 @@ final class MyFeedbackCollectionView: UIView {
         static let horizontalPadding: CGFloat = 24
         static let topSpacing: CGFloat = 24
         static let cellContentWidth: CGFloat = UIScreen.main.bounds.size.width - SizeLiteral.leadingTrailingPadding - 66
-        static let resizingTextLineOneHeight: CGFloat = 53
-        static let resizingTextLineTwoHeight: CGFloat = 75
+        static let resizingTextLineOneHeight: CGFloat = 65
+        static let resizingTextLineTwoHeight: CGFloat = 87
         static let cellWidth: CGFloat = UIScreen.main.bounds.size.width - (SizeLiteral.leadingTrailingPadding * 2)
         static let collectionViewInset = UIEdgeInsets.init(top: Size.topSpacing,
                                                            left: Size.horizontalPadding,
-                                                           bottom: 15,
+                                                           bottom: 20,
                                                            right: Size.horizontalPadding)
     }
     
@@ -30,6 +30,7 @@ final class MyFeedbackCollectionView: UIView {
         let flowLayout = UICollectionViewFlowLayout()
         flowLayout.scrollDirection = .vertical
         flowLayout.sectionInset = Size.collectionViewInset
+        flowLayout.minimumLineSpacing = 20
         return flowLayout
     }()
     private lazy var feedbackCollectionView: UICollectionView = {
@@ -126,7 +127,7 @@ extension MyFeedbackCollectionView: UICollectionViewDelegateFlowLayout {
         } else {
             data = mockData.filter { $0.type == .stopType }
         }
-        let cellHeight = UILabel.textSize(font: .body2, text: data[indexPath.item].content, width: Size.cellContentWidth, height: 0).height
+        let cellHeight = UILabel.textSize(font: .body2, text: data[indexPath.item].content, width: Size.cellContentWidth - 24, height: 0).height
         let isOneTextLine = cellHeight < 18
         if isOneTextLine {
             return CGSize(width: Size.cellWidth, height: Size.resizingTextLineOneHeight)

--- a/Maddori.Apple/Maddori.Apple/Screen/MyBox/UIComponent/MyFeedbackCollectionView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyBox/UIComponent/MyFeedbackCollectionView.swift
@@ -63,6 +63,11 @@ final class MyFeedbackCollectionView: UIView {
 extension MyFeedbackCollectionView: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
         guard let header = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: MyFeedbackHeaderView.className, for: indexPath) as? MyFeedbackHeaderView else { return UICollectionReusableView() }
+        if indexPath.section == 0 {
+            header.setHiddenDivider(value: true)
+        } else {
+            header.setHiddenDivider(value: false)
+        }
         header.setCssLabelText(with: indexPath.section)
         switch kind {
         case UICollectionView.elementKindSectionHeader:
@@ -107,8 +112,6 @@ extension MyFeedbackCollectionView: UICollectionViewDataSource {
 
 extension MyFeedbackCollectionView: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
-        return CGSize(width: 80, height: 25)
+        return CGSize(width: 80, height: 45)
     }
 }
-
-

--- a/Maddori.Apple/Maddori.Apple/Screen/MyBox/UIComponent/MyFeedbackCollectionView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyBox/UIComponent/MyFeedbackCollectionView.swift
@@ -64,9 +64,9 @@ extension MyFeedbackCollectionView: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
         guard let header = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: MyFeedbackHeaderView.className, for: indexPath) as? MyFeedbackHeaderView else { return UICollectionReusableView() }
         if indexPath.section == 0 {
-            header.setHiddenDivider(value: true)
+            header.setDividerHidden(true)
         } else {
-            header.setHiddenDivider(value: false)
+            header.setDividerHidden(false)
         }
         header.setCssLabelText(with: indexPath.section)
         switch kind {
@@ -89,19 +89,19 @@ extension MyFeedbackCollectionView: UICollectionViewDataSource {
             let data = mockData.filter { $0.type == .continueType }
             cell.setCellLabel(title: data[indexPath.item].title, content: data[indexPath.item].content)
             if indexPath.item == data.count - 1 {
-                cell.setHiddenDivider(value: true)
+                cell.setDividerHidden(true)
             }
         case 1:
             let data = mockData.filter { $0.type == .stopType }
             cell.setCellLabel(title: data[indexPath.item].title, content: data[indexPath.item].content)
             if indexPath.item == data.count - 1 {
-                cell.setHiddenDivider(value: true)
+                cell.setDividerHidden(true)
             }
         default:
             let data = mockData.filter { $0.type == .startType }
             cell.setCellLabel(title: data[indexPath.item].title, content: data[indexPath.item].content)
             if indexPath.item == data.count - 1 {
-                cell.setHiddenDivider(value: true)
+                cell.setDividerHidden(true)
             }
         }
         return cell


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
보관함 탭 부분의 앞선 두 PR에 이어서 마지막 divider(구분선)을 추가하는 PR입니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
| 전체 View | 작업 한 부분 |
|---|---|
|<img width="404" alt="image" src="https://user-images.githubusercontent.com/78677571/199454861-43c6a19f-f5e9-4a84-a4c2-6800ee12fc44.png">|<img width="404" alt="image" src="https://user-images.githubusercontent.com/78677571/199670475-58b5c568-894e-454c-8535-1a2bdc91ebdd.png">|


## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
feature/65-feedback-collectionview 브랜치로 오셔서 SceneDelegate를 MyBoxViewController로 변경해주세요 !
CollectionView의 스크롤을 막했을때 재사용되서 divider의 문제가 없는지 확인부탁드립니다 (제가 했을 땐 없었습니다)

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->

https://user-images.githubusercontent.com/78677571/199670959-41f99208-1b48-4574-8568-bce14cef638e.mp4



## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
Divider를 직접 만들어서 넣고 있었는데, @seongmin221 가 collectionview를 list로 만들어주는게 있다 그래서 적용해보려 했는데, 내부 셀들을 구분해주지만 섹션까지 깔끔하게 구분해주는지는 잘 모르겠더라구요. 우선은 이렇게도 만들 수 있어서 직접 구분선을 만들어두었습니다. 
추후에 더 공부해서 적용해보도록 하겠습니다 ! 감사합니다 이드 ^_______^

첫번째 Section엔 (첫 번째 Header -> Continue)
![image](https://user-images.githubusercontent.com/78677571/199671419-46aa18f0-f4e6-4646-a439-e8bfa85a9e5f.png)
구분선을 HeaderView에서 만들지 않고 따로 만들어 두었습니다.
![image](https://user-images.githubusercontent.com/78677571/199672018-ad2921bd-09da-4d13-8b46-7090f4cd380f.png)
**HeaderView와 같은 계층이 아닌 뒤에 있는 모습입니다 !**

 Stop 과 Start 헤더에서는 그 위에 구분선을 추가해두었습니다 !
![image](https://user-images.githubusercontent.com/78677571/199671800-364fd3d8-ab14-4d91-9510-1b7fe5ced2da.png)
**위의 Continue 부분과 달리 같은 계층에 포함되어 있습니다 !**


Continue부분 위엔 divider가 표시되지 않게 분기처리 해두었습니다.
각 Cell의 맨 마지막에도 divider가 표시되지 않게 분기처리 해두었습니다.

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #65 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
