### PR TITLE
[CHORE] Stop만 있을 때 안뜨는 문제 해결

### DIFF
--- a/Maddori.Apple/Maddori.Apple/Screen/MyBox/UIComponent/MyFeedbackCollectionView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyBox/UIComponent/MyFeedbackCollectionView.swift
@@ -70,7 +70,12 @@ extension MyFeedbackCollectionView: UICollectionViewDelegate {
         } else {
             header.setDividerHidden(false)
         }
-        header.setCssLabelText(with: indexPath.section)
+        let hasContinue = mockData.contains(where: { $0.type == .continueType} )
+        if hasContinue {
+            header.setCssLabelText(with: indexPath.section)
+        } else {
+            header.setCssLabelText(with: 1)
+        }
         switch kind {
         case UICollectionView.elementKindSectionHeader:
             return header
@@ -81,15 +86,25 @@ extension MyFeedbackCollectionView: UICollectionViewDelegate {
 }
 extension MyFeedbackCollectionView: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        mockData.filter { $0.type == FeedBackType.allCases[section] }.count
+        let hasContinue = mockData.contains(where: { $0.type == .continueType} )
+        if hasContinue {
+            return mockData.filter { $0.type == FeedBackType.allCases[section] }.count
+        } else {
+            return mockData.filter { $0.type == .stopType }.count
+        }
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MyFeedbackCollectionViewCell.className, for: indexPath) as? MyFeedbackCollectionViewCell else { return UICollectionViewCell() }
         var data: [FeedBack] = []
+        let hasContinue = mockData.contains(where: { $0.type == .continueType} )
         switch indexPath.section {
         case 0:
-            data = mockData.filter { $0.type == .continueType }
+            if hasContinue {
+                data = mockData.filter { $0.type == .continueType }
+            } else {
+                data = mockData.filter { $0.type == .stopType }
+            }
             if indexPath.item == data.count - 1 {
                 cell.setDividerHidden(true)
             }
@@ -122,8 +137,13 @@ extension MyFeedbackCollectionView: UICollectionViewDelegateFlowLayout {
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         var data: [FeedBack] = []
-        if indexPath.section == 0 {
-            data = mockData.filter { $0.type == .continueType }
+        let hasContinue = mockData.contains(where: { $0.type == .continueType} )
+        if hasContinue {
+            if indexPath.section == 0 {
+                data = mockData.filter { $0.type == .continueType }
+            } else {
+                data = mockData.filter { $0.type == .stopType }
+            }
         } else {
             data = mockData.filter { $0.type == .stopType }
         }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
<img width="328" alt="image" src="https://user-images.githubusercontent.com/78677571/200168818-05500237-fdc8-453c-8d99-8e98c6b847ca.png">

보관함뷰를 만들때 mockData로 구현을 해뒀는데, Continue와 Stop이 둘 다 있다는 생각으로 만들었습니다. 근데 Stop만 있을 때는 해당 View가 뜨지 않는 문제가 있었습니다. 해당 문제를 해결했습니다.
<img width="458" alt="image" src="https://user-images.githubusercontent.com/78677571/200168881-f6cd1bde-479b-4047-97d7-cf56e43bd6c4.png">

버그를 제보해주셔서 감사합니다 @seongmin221 

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
피드백이 Stop만 있더라도 Stop만 표시되게끔 (정상적으로) 구현했습니다.

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
feature/79-mybox-stop-issue 브랜치로 오셔서 SceneDelegate를 MyBoxViewController 로 수정해주세요
Network/Feedback/Feedback.swift 의 mockData들 중에서 continue부분을 다 주석처리하고 실행시켜보면 됩니다 !

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->

https://user-images.githubusercontent.com/78677571/200169015-f9695cbc-6163-4eb3-a38e-6d6a5b255303.mp4



## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
delegate collectionView 모든 함수에서 continue가 있는지 체크하고 조건문을 걸었는데, 더 나은 방식이 있을 것 같다는 생각이 들었습니다. 현재는 급해서 전부다 if를 넣어서 처리해뒀습니다.

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #79 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
