### PR TITLE
[ADD] 내가 작성한 피드백 수정하기 뷰 구현

### DIFF
--- a/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
+++ b/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		3E557FFD2901CD7400714E46 /* Keyword.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E557FFC2901CD7400714E46 /* Keyword.swift */; };
 		3E5580072906A7B200714E46 /* InProgressViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E5580062906A7B200714E46 /* InProgressViewController.swift */; };
 		3E8052DF2906E09100A6449D /* SectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E8052DE2906E09100A6449D /* SectionHeaderView.swift */; };
+		52294C432917FD5100E81969 /* EditFeedbackFromMeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52294C422917FD5100E81969 /* EditFeedbackFromMeViewController.swift */; };
 		522D99BF29041B51009CBD95 /* FeedbackTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522D99BE29041B51009CBD95 /* FeedbackTextView.swift */; };
 		525E721528FEEE8500EF3FCB /* AddFeedbackMemberViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525E721428FEEE8500EF3FCB /* AddFeedbackMemberViewController.swift */; };
 		525E721A28FF0F1900EF3FCB /* MemberCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525E721928FF0F1900EF3FCB /* MemberCollectionViewCell.swift */; };
@@ -116,6 +117,7 @@
 		3E557FFC2901CD7400714E46 /* Keyword.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keyword.swift; sourceTree = "<group>"; };
 		3E5580062906A7B200714E46 /* InProgressViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InProgressViewController.swift; sourceTree = "<group>"; };
 		3E8052DE2906E09100A6449D /* SectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionHeaderView.swift; sourceTree = "<group>"; };
+		52294C422917FD5100E81969 /* EditFeedbackFromMeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditFeedbackFromMeViewController.swift; sourceTree = "<group>"; };
 		522D99BE29041B51009CBD95 /* FeedbackTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackTextView.swift; sourceTree = "<group>"; };
 		525E721428FEEE8500EF3FCB /* AddFeedbackMemberViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddFeedbackMemberViewController.swift; sourceTree = "<group>"; };
 		525E721928FF0F1900EF3FCB /* MemberCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -356,6 +358,7 @@
 		3977E1202910CF7E000E9761 /* MyBox */ = {
 			isa = PBXGroup;
 			children = (
+				52294C412917FD2C00E81969 /* EditFeedbackFromMe */,
 				39F1A138291262EA005E3456 /* Cell */,
 				39F1A136291262B4005E3456 /* UIComponent */,
 				39F1A13429125762005E3456 /* MyBoxViewController.swift */,
@@ -461,6 +464,14 @@
 				3E5580062906A7B200714E46 /* InProgressViewController.swift */,
 			);
 			path = InProgress;
+			sourceTree = "<group>";
+		};
+		52294C412917FD2C00E81969 /* EditFeedbackFromMe */ = {
+			isa = PBXGroup;
+			children = (
+				52294C422917FD5100E81969 /* EditFeedbackFromMeViewController.swift */,
+			);
+			path = EditFeedbackFromMe;
 			sourceTree = "<group>";
 		};
 		525E721328FE9C5600EF3FCB /* AddFeedbackMember */ = {
@@ -635,6 +646,7 @@
 				7EB4D58229011EF7001FC396 /* JoinTeamViewController.swift in Sources */,
 				39257DED28F9378D00201E0B /* BaseCollectionViewCell.swift in Sources */,
 				391CBA19290580460044CA30 /* ReflectionInfoViewController.swift in Sources */,
+				52294C432917FD5100E81969 /* EditFeedbackFromMeViewController.swift in Sources */,
 				39F1A13C2912637E005E3456 /* MyBoxMemberCollectionViewCell.swift in Sources */,
 				525E721A28FF0F1900EF3FCB /* MemberCollectionViewCell.swift in Sources */,
 				395C7E2228FEDB6500FC2FCA /* UITextField+Extension.swift in Sources */,

--- a/Maddori.Apple/Maddori.Apple/Global/Supports/SceneDelegate.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Supports/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        let rootViewController = UINavigationController(rootViewController: EditFeedbackFromMeViewController(from: "진저", to: "메리"))
+        let rootViewController = UINavigationController(rootViewController: HomeViewController())
         window?.rootViewController = rootViewController
         window?.makeKeyAndVisible()
     }

--- a/Maddori.Apple/Maddori.Apple/Global/Supports/SceneDelegate.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Supports/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        let rootViewController = UINavigationController(rootViewController: HomeViewController())
+        let rootViewController = UINavigationController(rootViewController: EditFeedbackFromMeViewController(from: "진저", to: "메리"))
         window?.rootViewController = rootViewController
         window?.makeKeyAndVisible()
     }

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/Button/FeedbackTypeButtonView.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/Button/FeedbackTypeButtonView.swift
@@ -10,11 +10,8 @@ import UIKit
 import SnapKit
 
 final class FeedbackTypeButtonView: UIButton {
-    var changeFeedbackType: ((FeedbackType) -> ())?
-    enum FeedbackType: String {
-        case continueType = "Continue"
-        case stopType = "Stop"
-    }
+    var changeFeedbackType: ((FeedbackButtonType) -> ())?
+    
     private enum Size {
         static let width: CGFloat = 158
         static let height: CGFloat = 46
@@ -50,8 +47,8 @@ final class FeedbackTypeButtonView: UIButton {
         button.clipsToBounds = true
         button.layer.cornerRadius = SizeLiteral.componentCornerRadius
         let action = UIAction { [weak self] _ in
-            self?.touchUpToSelectType(.continueType)
-            self?.changeFeedbackType?(.continueType)
+            self?.touchUpToSelectType(FeedbackButtonType.continueType)
+            self?.changeFeedbackType?(FeedbackButtonType.continueType)
         }
         button.addAction(action, for: .touchUpInside)
         return button
@@ -65,8 +62,8 @@ final class FeedbackTypeButtonView: UIButton {
         button.clipsToBounds = true
         button.layer.cornerRadius = SizeLiteral.componentCornerRadius
         let action = UIAction { [weak self] _ in
-            self?.touchUpToSelectType(.stopType)
-            self?.changeFeedbackType?(.stopType)
+            self?.touchUpToSelectType(FeedbackButtonType.stopType)
+            self?.changeFeedbackType?(FeedbackButtonType.stopType)
         }
         button.addAction(action, for: .touchUpInside)
         return button
@@ -116,7 +113,7 @@ final class FeedbackTypeButtonView: UIButton {
     
     // MARK: - func
     
-    private func touchUpToSelectType(_ type: FeedbackType) {
+    func touchUpToSelectType(_ type: FeedbackButtonType) {
         switch type {
         case .continueType:
             continueButton.setTitleColor(.white100, for: .normal)

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/AddFeedbackContent/AddFeedbackContentViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/AddFeedbackContent/AddFeedbackContentViewController.swift
@@ -103,12 +103,12 @@ class AddFeedbackContentViewController: BaseViewController {
         label.font = .label2
         return label
     }()
-    private let feedbackContentTextView: FeedbackTextView = {
+    let feedbackContentTextView: FeedbackTextView = {
         let textView = FeedbackTextView()
         textView.placeholder = TextLiteral.addFeedbackContentViewControllerFeedbackContentTextViewPlaceholder
         return textView
     }()
-    private lazy var feedbackStartSwitch: UISwitch = {
+    lazy var feedbackStartSwitch: UISwitch = {
         let toggle = UISwitch()
         toggle.onTintColor = .blue200
         toggle.isOn = false
@@ -125,7 +125,7 @@ class AddFeedbackContentViewController: BaseViewController {
         label.font = .label2
         return label
     }()
-    private let feedbackStartTextViewLabel: UILabel = {
+    let feedbackStartTextViewLabel: UILabel = {
         let label = UILabel()
         label.text = TextLiteral.feedbackContentLabel
         label.textColor = .black100
@@ -133,7 +133,7 @@ class AddFeedbackContentViewController: BaseViewController {
         label.isHidden = true
         return label
     }()
-    private let feedbackStartTextView: FeedbackTextView = {
+    let feedbackStartTextView: FeedbackTextView = {
         let textView = FeedbackTextView()
         textView.placeholder = TextLiteral.addFeedbackContentViewControllerStartTextViewPlaceholder
         textView.isHidden = true

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/AddFeedbackContent/AddFeedbackContentViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/AddFeedbackContent/AddFeedbackContentViewController.swift
@@ -139,12 +139,12 @@ class AddFeedbackContentViewController: BaseViewController {
         textView.isHidden = true
         return textView
     }()
-    private let feedbackDoneButtonView: UIView = {
+    let feedbackDoneButtonView: UIView = {
         let view = UIView()
         view.backgroundColor = .white200
         return view
     }()
-    private let editFeedbackUntilLabel: UILabel = {
+    let editFeedbackUntilLabel: UILabel = {
         let label = UILabel()
         label.setTextWithLineHeight(text: TextLiteral.addFeedbackContentViewControllerFeedbackSendTimeLabel, lineHeight: 22)
         label.textColor = .gray400

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/AddFeedbackContent/AddFeedbackContentViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/AddFeedbackContent/AddFeedbackContentViewController.swift
@@ -68,7 +68,7 @@ class AddFeedbackContentViewController: BaseViewController {
         label.font = .label2
         return label
     }()
-    private lazy var feedbackTypeButtonView: FeedbackTypeButtonView = {
+    lazy var feedbackTypeButtonView: FeedbackTypeButtonView = {
         let view = FeedbackTypeButtonView()
         view.changeFeedbackType = { [weak self] type in
             if let typeValue = FeedBackType.init(rawValue: type.rawValue) {

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/AddFeedbackContent/AddFeedbackContentViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/AddFeedbackContent/AddFeedbackContentViewController.swift
@@ -84,7 +84,7 @@ class AddFeedbackContentViewController: BaseViewController {
         label.font = .label2
         return label
     }()
-    private let feedbackKeywordTextField: KigoTextField = {
+    let feedbackKeywordTextField: KigoTextField = {
         let textField = KigoTextField()
         textField.placeHolderText = TextLiteral.addFeedbackContentViewControllerFeedbackKeywordTextFieldPlaceholder
         return textField
@@ -311,7 +311,7 @@ class AddFeedbackContentViewController: BaseViewController {
         }
     }
     
-    private func setCounter(count: Int) {
+    func setCounter(count: Int) {
         if count <= Length.keywordMaxLength {
             textLimitLabel.text = "\(count)/\(Length.keywordMaxLength)"
         }

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/AddFeedbackContent/AddFeedbackContentViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/AddFeedbackContent/AddFeedbackContentViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 
 import SnapKit
 
-final class AddFeedbackContentViewController: BaseViewController {
+class AddFeedbackContentViewController: BaseViewController {
     
     private enum Length {
         static let keywordMinLength: Int = 0

--- a/Maddori.Apple/Maddori.Apple/Screen/MyBox/EditFeedbackFromMe/EditFeedbackFromMeViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyBox/EditFeedbackFromMe/EditFeedbackFromMeViewController.swift
@@ -1,0 +1,19 @@
+//
+//  EditFeedbackFromMeViewController.swift
+//  Maddori.Apple
+//
+//  Created by 김유나 on 2022/11/06.
+//
+
+import UIKit
+
+import SnapKit
+
+final class EditFeedbackFromMeViewController: AddFeedbackContentViewController {
+    
+    // MARK: - property
+    
+    // MARK: - life cycle
+    
+    // MARK: - func
+}

--- a/Maddori.Apple/Maddori.Apple/Screen/MyBox/EditFeedbackFromMe/EditFeedbackFromMeViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyBox/EditFeedbackFromMe/EditFeedbackFromMeViewController.swift
@@ -13,14 +13,14 @@ final class EditFeedbackFromMeViewController: AddFeedbackContentViewController {
     
     private let model = FeedbackFromMeModel.mockData
     
-    // MARK: - property
-    
     // MARK: - life cycle
     
     override func configUI() {
         super.configUI()
         setupFeedbackType()
         setupFeedbackKeyword()
+        setupFeedbackContent()
+        setupFeedbackStart()
     }
     
     // MARK: - func
@@ -37,5 +37,20 @@ final class EditFeedbackFromMeViewController: AddFeedbackContentViewController {
     private func setupFeedbackKeyword() {
         feedbackKeywordTextField.text = model.keyword
         setCounter(count: model.keyword.count)
+    }
+    
+    private func setupFeedbackContent() {
+        feedbackContentTextView.text = model.info
+        feedbackContentTextView.textColor = .black100
+    }
+    
+    private func setupFeedbackStart() {
+        if let start = model.start {
+            feedbackStartSwitch.isOn = true
+            feedbackStartTextViewLabel.isHidden = false
+            feedbackStartTextView.isHidden = false
+            feedbackStartTextView.text = start
+            feedbackStartTextView.textColor = .black100
+        }
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Screen/MyBox/EditFeedbackFromMe/EditFeedbackFromMeViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyBox/EditFeedbackFromMe/EditFeedbackFromMeViewController.swift
@@ -21,6 +21,7 @@ final class EditFeedbackFromMeViewController: AddFeedbackContentViewController {
         setupFeedbackKeyword()
         setupFeedbackContent()
         setupFeedbackStart()
+        hideEditFeedbackUntilLabel()
     }
     
     // MARK: - func
@@ -51,6 +52,15 @@ final class EditFeedbackFromMeViewController: AddFeedbackContentViewController {
             feedbackStartTextView.isHidden = false
             feedbackStartTextView.text = start
             feedbackStartTextView.textColor = .black100
+        }
+    }
+    
+    private func hideEditFeedbackUntilLabel() {
+        editFeedbackUntilLabel.isHidden = true
+        feedbackDoneButtonView.snp.remakeConstraints {
+            $0.bottom.equalToSuperview()
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(95)
         }
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Screen/MyBox/EditFeedbackFromMe/EditFeedbackFromMeViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyBox/EditFeedbackFromMe/EditFeedbackFromMeViewController.swift
@@ -35,6 +35,7 @@ final class EditFeedbackFromMeViewController: AddFeedbackContentViewController {
     }
     
     private func setupFeedbackKeyword() {
-        
+        feedbackKeywordTextField.text = model.keyword
+        setCounter(count: model.keyword.count)
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Screen/MyBox/EditFeedbackFromMe/EditFeedbackFromMeViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyBox/EditFeedbackFromMe/EditFeedbackFromMeViewController.swift
@@ -11,9 +11,30 @@ import SnapKit
 
 final class EditFeedbackFromMeViewController: AddFeedbackContentViewController {
     
+    private let model = FeedbackFromMeModel.mockData
+    
     // MARK: - property
     
     // MARK: - life cycle
     
+    override func configUI() {
+        super.configUI()
+        setupFeedbackType()
+        setupFeedbackKeyword()
+    }
+    
     // MARK: - func
+    
+    private func setupFeedbackType() {
+        switch model.feedbackType {
+        case .continueType:
+            self.feedbackTypeButtonView.touchUpToSelectType(.continueType)
+        case .stopType:
+            self.feedbackTypeButtonView.touchUpToSelectType(.stopType)
+        }
+    }
+    
+    private func setupFeedbackKeyword() {
+        
+    }
 }


### PR DESCRIPTION
## 🌁 Background
MyBoxView>FeedbackFromMeDetailView 에서 '수정하러 가기' 버튼을 눌렀을 때 나오는 edit view 입니다.


## 👩‍💻 Contents
- AddFeedbackContentViewController 상속 받기
- 피드백 종류에 따라 버튼 활성화 상태 조정
- textfield & textview에 text 넣기
- Start 유무에 따라 switch on/off & Start 내용 textview isHidden 상태 조정


## ✅ Testing
feature/72-edit-feedback-from-me 로 이동하셔서 scene delegate root view를 EditFeedbackFromMeViewController(from: "진저", to: "메리") 로 변경하시면 됩니당구장!


## 📱 Screenshot
|https://user-images.githubusercontent.com/81340603/200180746-ada81e12-a831-4446-8013-0ce2890a1a7e.mp4|https://user-images.githubusercontent.com/81340603/200180752-5fb331cb-33fe-4a2f-87d9-616f412dde48.mp4|
|-|-|

## 📝 Review Note
1. 내가 작성한 수정하기 뷰에서는 언제까지 피드백을 수정할 수 있는지 안내해주는 라벨이 없어서 isHidden 처리를 했는데요! 때문에 editFeedbackUntilLabel과 feedbackDoneButton을 올려두었던 feedbackDoneButtonView의 height를 줄였습니다.
2. 기존에 만들어 두었던 FeedbackTypeButtonView는 내부에 FeedbackType이라는 private enum이 있었는데 그 쓰임이 Model/FeedbackFromMe/FeedbackFromMeModel의 FeedbackButtonType 과 중복되는 것 같아서 private enum을 삭제하고 FeedbackButtonType을 사용하도록 코드 수정했습니다.
3. AddFeedbackContentVC에서 final을 없애고, 일부 컴포넌트(함수)들의 private을 삭제했습니다!


## 📣 Related Issue
- close #72 
