### PR TITLE
[ADD] ToastContentView 추가 및 부분적 컴포넌트화

### DIFF
--- a/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
+++ b/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		3E557FFD2901CD7400714E46 /* Keyword.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E557FFC2901CD7400714E46 /* Keyword.swift */; };
 		3E5580072906A7B200714E46 /* InProgressViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E5580062906A7B200714E46 /* InProgressViewController.swift */; };
 		3E8052DF2906E09100A6449D /* SectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E8052DE2906E09100A6449D /* SectionHeaderView.swift */; };
+		3EA341C129221998005CBD1C /* ToastContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA341C029221998005CBD1C /* ToastContentView.swift */; };
 		3EB5085C2912427600FB77CB /* MyReflectionMainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EB5085B2912427600FB77CB /* MyReflectionMainViewController.swift */; };
 		3EB508622912B12700FB77CB /* ReflectionCollectionViewHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EB508612912B12700FB77CB /* ReflectionCollectionViewHeader.swift */; };
 		3EB50866291350BB00FB77CB /* TotalReflectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EB50865291350BB00FB77CB /* TotalReflectionCell.swift */; };
@@ -132,6 +133,7 @@
 		3E557FFC2901CD7400714E46 /* Keyword.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keyword.swift; sourceTree = "<group>"; };
 		3E5580062906A7B200714E46 /* InProgressViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InProgressViewController.swift; sourceTree = "<group>"; };
 		3E8052DE2906E09100A6449D /* SectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionHeaderView.swift; sourceTree = "<group>"; };
+		3EA341C029221998005CBD1C /* ToastContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastContentView.swift; sourceTree = "<group>"; };
 		3EB5085B2912427600FB77CB /* MyReflectionMainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyReflectionMainViewController.swift; sourceTree = "<group>"; };
 		3EB508612912B12700FB77CB /* ReflectionCollectionViewHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReflectionCollectionViewHeader.swift; sourceTree = "<group>"; };
 		3EB50865291350BB00FB77CB /* TotalReflectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalReflectionCell.swift; sourceTree = "<group>"; };
@@ -459,6 +461,7 @@
 				3EB5088D2916D05F00FB77CB /* EmptyFeedbackView.swift */,
 				3EB5088F2917525600FB77CB /* EmptyReflectionView.swift */,
 				52F0CB5129178C2700E39C50 /* AlertViewController.swift */,
+				3EA341C029221998005CBD1C /* ToastContentView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -705,6 +708,7 @@
 				525E721C28FF0F5B00EF3FCB /* MemberCollectionView.swift in Sources */,
 				395C7E2028FED7B500FC2FCA /* ReflectionNameView.swift in Sources */,
 				522D99BF29041B51009CBD95 /* FeedbackTextView.swift in Sources */,
+				3EA341C129221998005CBD1C /* ToastContentView.swift in Sources */,
 				39F1A13529125762005E3456 /* MyBoxViewController.swift in Sources */,
 				391D217C29050427003FC871 /* CustomVisualEffectView.swift in Sources */,
 				391CBA1C290582130044CA30 /* ReflectionInfoModel.swift in Sources */,
@@ -724,7 +728,7 @@
 				D7AFB7C72916FF9400E998B7 /* CustomSegmentedControl.swift in Sources */,
 				3EB508692913560A00FB77CB /* Reflection.swift in Sources */,
 				52DC9091291A98CC00904739 /* EditFeedbackFromMeViewController.swift in Sources */,
-				D7AFB7C72916FF9400E998B7 /* SegmentedControl.swift in Sources */,
+				D7AFB7C72916FF9400E998B7 /* CustomSegmentedControl.swift in Sources */,
 				52FA42A02906608E00C35824 /* Date+Extension.swift in Sources */,
 				39F5582B2908027500CD6F6E /* UIDevice+Extension.swift in Sources */,
 				395C7E1328F9841A00FC2FCA /* SizeLiteral.swift in Sources */,

--- a/Maddori.Apple/Maddori.Apple.xcodeproj/xcshareddata/xcschemes/Maddori.Apple.xcscheme
+++ b/Maddori.Apple/Maddori.Apple.xcodeproj/xcshareddata/xcschemes/Maddori.Apple.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1410"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "39257DC028F8FEBD00201E0B"
+               BuildableName = "Maddori.Apple.app"
+               BlueprintName = "Maddori.Apple"
+               ReferencedContainer = "container:Maddori.Apple.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "39257DC028F8FEBD00201E0B"
+            BuildableName = "Maddori.Apple.app"
+            BlueprintName = "Maddori.Apple"
+            ReferencedContainer = "container:Maddori.Apple.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "39257DC028F8FEBD00201E0B"
+            BuildableName = "Maddori.Apple.app"
+            BlueprintName = "Maddori.Apple"
+            ReferencedContainer = "container:Maddori.Apple.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Maddori.Apple/Maddori.Apple/Global/Literal/ImageLiteral.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Literal/ImageLiteral.swift
@@ -14,6 +14,7 @@ enum ImageLiterals {
     static var icClose: UIImage { .load(systemName: "xmark") }
     static var icBack: UIImage { .load(systemName: "chevron.left") }
     static var icWarning: UIImage { .load(systemName: "exclamationmark.circle.fill") }
+    static var icComplete: UIImage { .load(systemName: "checkmark.circle.fill") }
     static var icPin: UIImage { .load(systemName: "pin.circle.fill") }
     static var icBox: UIImage { .load(systemName: "archivebox.circle.fill") }
     static var icRight: UIImage { .load(systemName: "chevron.right") }

--- a/Maddori.Apple/Maddori.Apple/Global/Literal/TextLiteral.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Literal/TextLiteral.swift
@@ -140,4 +140,9 @@ enum TextLiteral {
     static let homeTabTitle: String = "홈"
     static let myboxTabTitle: String = "보관함"
     static let myReflectionTabTitle: String = "나의회고"
+    
+    // MARK: - ToastPopUpView
+    
+    static let warningText: String = "아직 회고 시간이 아닙니다"
+    static let completeText: String = "초대코드가 복사되었습니다"
 }

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/View/ToastContentView.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/View/ToastContentView.swift
@@ -1,0 +1,86 @@
+//
+//  ToastContentView.swift
+//  Maddori.Apple
+//
+//  Created by 이성민 on 2022/11/14.
+//
+
+import UIKit
+
+import SnapKit
+
+enum toastType {
+    case warning
+    case complete
+    
+    var icon: UIImage {
+        switch self {
+        case .warning:
+            return ImageLiterals.icWarning
+        case .complete:
+            return ImageLiterals.icComplete
+        }
+    }
+    
+    var iconColor: UIColor {
+        switch self {
+        case .warning:
+            return .yellow300
+        case .complete:
+            return .green
+        }
+    }
+    
+    var text: String {
+        switch self {
+        case .warning:
+            return TextLiteral.warningText
+        case .complete:
+            return TextLiteral.completeText
+        }
+    }
+}
+
+final class ToastContentView: UIView {
+    
+    var toastType: toastType? {
+        didSet {
+            setupAttribute()
+        }
+    }
+    
+    // MARK: - property
+    
+    private let toastIcon = UIImageView()
+    private let toastLabel: UILabel = {
+        let label = UILabel()
+        label.font = .toast
+        label.textColor = .white100
+        return label
+    }()
+    
+    // MARK: - life cycle
+    
+    func render() {
+        superview?.addSubview(toastIcon)
+        toastIcon.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(16)
+            $0.centerY.equalToSuperview()
+        }
+        
+        superview?.addSubview(toastLabel)
+        toastLabel.snp.makeConstraints {
+            $0.leading.equalTo(toastIcon.snp.trailing).offset(10)
+            $0.centerY.equalToSuperview().offset(1)
+            $0.trailing.equalToSuperview().inset(22)
+        }
+    }
+    
+    // MARK: - func
+    
+    private func setupAttribute() {
+        self.toastIcon.image = toastType?.icon
+        self.toastIcon.tintColor = toastType?.iconColor
+        self.toastLabel.text = toastType?.text
+    }
+}

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/HomeView/HomeViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/HomeView/HomeViewController.swift
@@ -26,23 +26,15 @@ final class HomeViewController: BaseViewController {
     
     // MARK: - property
     
-    private let warningImageView: UIImageView = {
-        let imageView = UIImageView()
-        imageView.image = ImageLiterals.icWarning
-        imageView.tintColor = .yellow300
-        return imageView
-    }()
-    private let toastLabel: UILabel = {
-        let label = UILabel()
-        label.text = "아직 회고 시간이 아닙니다"
-        label.font = UIFont.font(.medium, ofSize: 14)
-        label.textColor = .white100
-        return label
-    }()
     private let toastView: UIView = {
         let view = UIView()
         view.layer.cornerRadius = 10
         view.clipsToBounds = true
+        return view
+    }()
+    private let toastContentView: ToastContentView = {
+        let view = ToastContentView()
+        view.toastType = .warning
         return view
     }()
     lazy var keywordCollectionView: UICollectionView = {
@@ -122,22 +114,14 @@ final class HomeViewController: BaseViewController {
         toastView.snp.makeConstraints {
             $0.top.equalToSuperview().inset(-60)
             $0.centerX.equalToSuperview()
-            $0.width.equalTo(250)
             $0.height.equalTo(46)
         }
         
-        // FIXME: - 크기 수정 필요
-        toastView.addSubview(toastLabel)
-        toastLabel.snp.makeConstraints {
-            $0.centerY.equalToSuperview()
-            $0.trailing.equalToSuperview().inset(16)
+        toastView.addSubview(toastContentView)
+        toastContentView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
         }
-        
-        toastView.addSubview(warningImageView)
-        warningImageView.snp.makeConstraints {
-            $0.centerY.equalToSuperview()
-            $0.leading.equalToSuperview().inset(16)
-        }
+        toastContentView.render()
         
         view.addSubview(teamNameLabel)
         teamNameLabel.snp.makeConstraints {


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
이전에 있던 ToastView가 깨진 문제를 해결했습니다
단, Toast 전체를 컴포넌트화 하기엔 시간이 조금 걸릴 것 같아서 약간의 편법을 사용해봤어요..!


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- ToastContentView 추가
- ToastPopup 부분적으로 컴포넌트로 사용할 수 있게 만듬


## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
SceneDelegate에서 HomeViewController로 바꿔주신 다음 아무 cell을 터치해보세요!
복사 완료된 토스트를 보고 싶으시면 toastContentView의 toastType을 .complete로 바꿔주세요!


## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->

https://user-images.githubusercontent.com/72431640/201875111-828d97f9-61d8-44fb-9c73-608c368739b5.mp4




## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
빠르게 하느라 토스트를 완전히 컴포넌트화 하진 못했습니다..ㅠ
그래도 어느정도만 property로 선언해두면 쉽게 사용할 수 있도록 만들어 뒀어요!!
약간 편법같긴 한데 한 번 어떤지 봐주십쇼


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #96 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
