### PR TITLE
[FEAT] Setup View들 API연결 완료

### DIFF
--- a/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
+++ b/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		39F52C72292476AE00B19A77 /* KeywordResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F52C71292476AE00B19A77 /* KeywordResponse.swift */; };
 		39F52C74292476EA00B19A77 /* FeedBackResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F52C73292476EA00B19A77 /* FeedBackResponse.swift */; };
 		39F52C772924BB9A00B19A77 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 39F52C762924BB9A00B19A77 /* Alamofire */; };
+		39F52C7A2924CC9600B19A77 /* SetupEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F52C792924CC9600B19A77 /* SetupEndPoint.swift */; };
 		39F5582B2908027500CD6F6E /* UIDevice+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F5582A2908027500CD6F6E /* UIDevice+Extension.swift */; };
 		39F5583D2908CFAD00CD6F6E /* Encodable+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F5583C2908CFAD00CD6F6E /* Encodable+Extension.swift */; };
 		3E557FC328FE7BBC00714E46 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E557FC228FE7BBC00714E46 /* HomeViewController.swift */; };
@@ -173,6 +174,7 @@
 		39F52C6F2924747600B19A77 /* AllCertainTypeFeedBackResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllCertainTypeFeedBackResponse.swift; sourceTree = "<group>"; };
 		39F52C71292476AE00B19A77 /* KeywordResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordResponse.swift; sourceTree = "<group>"; };
 		39F52C73292476EA00B19A77 /* FeedBackResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedBackResponse.swift; sourceTree = "<group>"; };
+		39F52C792924CC9600B19A77 /* SetupEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupEndPoint.swift; sourceTree = "<group>"; };
 		39F5582A2908027500CD6F6E /* UIDevice+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIDevice+Extension.swift"; sourceTree = "<group>"; };
 		39F5583C2908CFAD00CD6F6E /* Encodable+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encodable+Extension.swift"; sourceTree = "<group>"; };
 		3E557FC228FE7BBC00714E46 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
@@ -289,6 +291,7 @@
 		39257DD828F90EA900201E0B /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				39F52C782924CC8600B19A77 /* EndPoint */,
 				39F52C512923307000B19A77 /* Response */,
 				39F52C502923306700B19A77 /* Reqeust */,
 				39F52C422923298800B19A77 /* Model */,
@@ -593,6 +596,14 @@
 				39F52C73292476EA00B19A77 /* FeedBackResponse.swift */,
 			);
 			path = Response;
+			sourceTree = "<group>";
+		};
+		39F52C782924CC8600B19A77 /* EndPoint */ = {
+			isa = PBXGroup;
+			children = (
+				39F52C792924CC9600B19A77 /* SetupEndPoint.swift */,
+			);
+			path = EndPoint;
 			sourceTree = "<group>";
 		};
 		3E557FC128FE7B9200714E46 /* Home */ = {
@@ -921,6 +932,7 @@
 				39F52C702924747600B19A77 /* AllCertainTypeFeedBackResponse.swift in Sources */,
 				391D217C29050427003FC871 /* CustomVisualEffectView.swift in Sources */,
 				391CBA1C290582130044CA30 /* ReflectionInfoModel.swift in Sources */,
+				39F52C7A2924CC9600B19A77 /* SetupEndPoint.swift in Sources */,
 				39F52C5F2923338B00B19A77 /* CurrentMemberResponse.swift in Sources */,
 				3E557FFA2901CD4200714E46 /* KeywordCollectionViewCell.swift in Sources */,
 				52F0CB5229178C2700E39C50 /* AlertViewController.swift in Sources */,

--- a/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
+++ b/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		395C7E2028FED7B500FC2FCA /* ReflectionNameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 395C7E1F28FED7B500FC2FCA /* ReflectionNameView.swift */; };
 		395C7E2228FEDB6500FC2FCA /* UITextField+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 395C7E2128FEDB6500FC2FCA /* UITextField+Extension.swift */; };
 		395C7E252900E74700FC2FCA /* StartReflectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 395C7E242900E74700FC2FCA /* StartReflectionViewController.swift */; };
+		397E49572924D93F004220D6 /* UrlLiteral.swift in Sources */ = {isa = PBXBuildFile; fileRef = 397E49562924D93F004220D6 /* UrlLiteral.swift */; };
 		39A64ACE2905885F001DB020 /* StartSuggestionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39A64ACD2905885F001DB020 /* StartSuggestionView.swift */; };
 		39F1A13529125762005E3456 /* MyFeedbackViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F1A13429125762005E3456 /* MyFeedbackViewController.swift */; };
 		39F1A13C2912637E005E3456 /* MyFeedbackMemberCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F1A13B2912637E005E3456 /* MyFeedbackMemberCollectionViewCell.swift */; };
@@ -148,6 +149,7 @@
 		395C7E1F28FED7B500FC2FCA /* ReflectionNameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReflectionNameView.swift; sourceTree = "<group>"; };
 		395C7E2128FEDB6500FC2FCA /* UITextField+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+Extension.swift"; sourceTree = "<group>"; };
 		395C7E242900E74700FC2FCA /* StartReflectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartReflectionViewController.swift; sourceTree = "<group>"; };
+		397E49562924D93F004220D6 /* UrlLiteral.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UrlLiteral.swift; sourceTree = "<group>"; };
 		39A64ACD2905885F001DB020 /* StartSuggestionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartSuggestionView.swift; sourceTree = "<group>"; };
 		39F1A13429125762005E3456 /* MyFeedbackViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyFeedbackViewController.swift; sourceTree = "<group>"; };
 		39F1A13B2912637E005E3456 /* MyFeedbackMemberCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyFeedbackMemberCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -329,6 +331,7 @@
 				39257DF028F93C2A00201E0B /* ImageLiteral.swift */,
 				39257DF228F93D8900201E0B /* TextLiteral.swift */,
 				395C7E1228F9841A00FC2FCA /* SizeLiteral.swift */,
+				397E49562924D93F004220D6 /* UrlLiteral.swift */,
 			);
 			path = Literal;
 			sourceTree = "<group>";
@@ -934,6 +937,7 @@
 				391CBA1C290582130044CA30 /* ReflectionInfoModel.swift in Sources */,
 				39F52C7A2924CC9600B19A77 /* SetupEndPoint.swift in Sources */,
 				39F52C5F2923338B00B19A77 /* CurrentMemberResponse.swift in Sources */,
+				397E49572924D93F004220D6 /* UrlLiteral.swift in Sources */,
 				3E557FFA2901CD4200714E46 /* KeywordCollectionViewCell.swift in Sources */,
 				52F0CB5229178C2700E39C50 /* AlertViewController.swift in Sources */,
 				395C7E0528F953D200FC2FCA /* UIViewController+Extension.swift in Sources */,

--- a/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
+++ b/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
@@ -39,6 +39,8 @@
 		395C7E2228FEDB6500FC2FCA /* UITextField+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 395C7E2128FEDB6500FC2FCA /* UITextField+Extension.swift */; };
 		395C7E252900E74700FC2FCA /* StartReflectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 395C7E242900E74700FC2FCA /* StartReflectionViewController.swift */; };
 		397E49572924D93F004220D6 /* UrlLiteral.swift in Sources */ = {isa = PBXBuildFile; fileRef = 397E49562924D93F004220D6 /* UrlLiteral.swift */; };
+		397E495A2924F871004220D6 /* UserDefaultStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 397E49592924F871004220D6 /* UserDefaultStorage.swift */; };
+		397E495C2924F8A2004220D6 /* UserDefaultHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 397E495B2924F8A2004220D6 /* UserDefaultHandler.swift */; };
 		39A64ACE2905885F001DB020 /* StartSuggestionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39A64ACD2905885F001DB020 /* StartSuggestionView.swift */; };
 		39F1A13529125762005E3456 /* MyFeedbackViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F1A13429125762005E3456 /* MyFeedbackViewController.swift */; };
 		39F1A13C2912637E005E3456 /* MyFeedbackMemberCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F1A13B2912637E005E3456 /* MyFeedbackMemberCollectionViewCell.swift */; };
@@ -150,6 +152,8 @@
 		395C7E2128FEDB6500FC2FCA /* UITextField+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+Extension.swift"; sourceTree = "<group>"; };
 		395C7E242900E74700FC2FCA /* StartReflectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartReflectionViewController.swift; sourceTree = "<group>"; };
 		397E49562924D93F004220D6 /* UrlLiteral.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UrlLiteral.swift; sourceTree = "<group>"; };
+		397E49592924F871004220D6 /* UserDefaultStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultStorage.swift; sourceTree = "<group>"; };
+		397E495B2924F8A2004220D6 /* UserDefaultHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultHandler.swift; sourceTree = "<group>"; };
 		39A64ACD2905885F001DB020 /* StartSuggestionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartSuggestionView.swift; sourceTree = "<group>"; };
 		39F1A13429125762005E3456 /* MyFeedbackViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyFeedbackViewController.swift; sourceTree = "<group>"; };
 		39F1A13B2912637E005E3456 /* MyFeedbackMemberCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyFeedbackMemberCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -293,6 +297,7 @@
 		39257DD828F90EA900201E0B /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				397E49582924F80E004220D6 /* Storage */,
 				39F52C782924CC8600B19A77 /* EndPoint */,
 				39F52C512923307000B19A77 /* Response */,
 				39F52C502923306700B19A77 /* Reqeust */,
@@ -514,6 +519,15 @@
 				3EA341C029221998005CBD1C /* ToastContentView.swift */,
 			);
 			path = View;
+			sourceTree = "<group>";
+		};
+		397E49582924F80E004220D6 /* Storage */ = {
+			isa = PBXGroup;
+			children = (
+				397E49592924F871004220D6 /* UserDefaultStorage.swift */,
+				397E495B2924F8A2004220D6 /* UserDefaultHandler.swift */,
+			);
+			path = Storage;
 			sourceTree = "<group>";
 		};
 		39A64ACC2905882C001DB020 /* UIComponent */ = {
@@ -981,6 +995,7 @@
 				52AED2DD29128532004D70B9 /* FeedbackFromMeModel.swift in Sources */,
 				D724790C28FEC8C900D67B50 /* BaseTextFieldViewController.swift in Sources */,
 				7E6B662F28FE887300C3BEEF /* UILabel+Extension.swift in Sources */,
+				397E495C2924F8A2004220D6 /* UserDefaultHandler.swift in Sources */,
 				395C7E0B28F9550A00FC2FCA /* NSObject+Extension.swift in Sources */,
 				D79D908E29041F42004DDC4A /* CreateTeamViewController.swift in Sources */,
 				3E557FFD2901CD7400714E46 /* Keyword.swift in Sources */,
@@ -1001,6 +1016,7 @@
 				3E557FF82901CD3400714E46 /* KeywordCollectionViewFlowLayout.swift in Sources */,
 				39F52C4729232DD600B19A77 /* LoginDTO.swift in Sources */,
 				39F52C592923321700B19A77 /* CertainTeamDetailResponse.swift in Sources */,
+				397E495A2924F871004220D6 /* UserDefaultStorage.swift in Sources */,
 				395C7E1B28FEC42900FC2FCA /* CreateReflectionViewController.swift in Sources */,
 				39F52C612923344C00B19A77 /* FeedBackContentResponse.swift in Sources */,
 				D724790E28FEEEC300D67B50 /* CustomTextField.swift in Sources */,

--- a/Maddori.Apple/Maddori.Apple/Global/Base/BaseTextFieldViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Base/BaseTextFieldViewController.swift
@@ -26,7 +26,7 @@ class BaseTextFieldViewController: BaseViewController {
         label.setTitleFont(text: titleText)
         return label
     }()
-    private lazy var kigoTextField: CustomTextField = {
+    lazy var kigoTextField: CustomTextField = {
         let textField = CustomTextField()
         textField.placeHolderText = placeholderText
         return textField

--- a/Maddori.Apple/Maddori.Apple/Global/Literal/UrlLiteral.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Literal/UrlLiteral.swift
@@ -1,0 +1,12 @@
+//
+//  UrlLiteral.swift
+//  Maddori.Apple
+//
+//  Created by Mingwan Choi on 2022/11/16.
+//
+
+import Foundation
+
+enum UrlLiteral {
+    static let baseUrl = "http://3.34.57.155:3000/api/v1"
+}

--- a/Maddori.Apple/Maddori.Apple/Global/Supports/SceneDelegate.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Supports/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        let isLogined = UserData<Bool>.getValue(forKey: .isLogin) ?? false
+        let isLogined = UserDefaultStorage.isLogin
         var rootViewController: UIViewController
         if isLogined {
             rootViewController = CustomTabBarController()

--- a/Maddori.Apple/Maddori.Apple/Global/Supports/SceneDelegate.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Supports/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        var isLogined = true
+        let isLogined = UserData<Bool>.getValue(forKey: .isLogin) ?? false
         var rootViewController: UIViewController
         if isLogined {
             rootViewController = CustomTabBarController()

--- a/Maddori.Apple/Maddori.Apple/Network/EndPoint/SetupEndPoint.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/EndPoint/SetupEndPoint.swift
@@ -8,51 +8,51 @@
 import Alamofire
 
 enum SetupEndPoint<T: Encodable> {
-    case login(T)
-    case createTeam(T, userId: String)
-    case joinTeam(T, userId: String)
+    case dispatchlogin(T)
+    case dispatchCreateTeam(T, userId: String)
+    case dispatchJoinTeam(T, userId: String)
     
     var address: String {
         switch self {
-        case .login:
+        case .dispatchlogin:
             return "\(UrlLiteral.baseUrl)/users/login"
-        case .createTeam:
+        case .dispatchCreateTeam:
             return "\(UrlLiteral.baseUrl)/teams"
-        case .joinTeam:
+        case .dispatchJoinTeam:
             return "\(UrlLiteral.baseUrl)/users/join-team"
         }
     }
 
     var method: HTTPMethod {
         switch self {
-        case .login:
+        case .dispatchlogin:
             return .post
-        case .createTeam:
+        case .dispatchCreateTeam:
             return .post
-        case .joinTeam:
+        case .dispatchJoinTeam:
             return .post
         }
     }
     
     var body: T? {
         switch self {
-        case .login(let body):
+        case .dispatchlogin(let body):
             return body
-        case .createTeam(let body, _):
+        case .dispatchCreateTeam(let body, _):
             return body
-        case .joinTeam(let body, _):
+        case .dispatchJoinTeam(let body, _):
             return body
         }
     }
     
     var headers: HTTPHeaders? {
         switch self {
-        case .login:
+        case .dispatchlogin:
             return nil
-        case .createTeam(_, let userId):
+        case .dispatchCreateTeam(_, let userId):
             let headers = ["user_id": userId]
             return HTTPHeaders(headers)
-        case .joinTeam(_, let userId):
+        case .dispatchJoinTeam(_, let userId):
             let headers = ["user_id": userId]
             return HTTPHeaders(headers)
         }

--- a/Maddori.Apple/Maddori.Apple/Network/EndPoint/SetupEndPoint.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/EndPoint/SetupEndPoint.swift
@@ -15,11 +15,11 @@ enum SetupEndPoint<T: Encodable> {
     var address: String {
         switch self {
         case .login:
-            return "http://3.34.57.155:3000/api/v1/users/login"
+            return "\(UrlLiteral.baseUrl)/users/login"
         case .createTeam:
-            return "http://3.34.57.155:3000/api/v1/teams"
+            return "\(UrlLiteral.baseUrl)/teams"
         case .joinTeam:
-            return "http://3.34.57.155:3000/api/v1/users/join-team"
+            return "\(UrlLiteral.baseUrl)/users/join-team"
         }
     }
 

--- a/Maddori.Apple/Maddori.Apple/Network/EndPoint/SetupEndPoint.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/EndPoint/SetupEndPoint.swift
@@ -9,17 +9,22 @@ import Alamofire
 
 enum SetupEndPoint<T: Encodable> {
     case login(T)
+    case createTeam(T, header: String)
     
     var address: String {
         switch self {
         case .login:
             return "http://3.34.57.155:3000/api/v1/users/login"
+        case .createTeam:
+            return "http://3.34.57.155:3000/api/v1/teams"
         }
     }
 
     var method: HTTPMethod {
         switch self {
         case .login:
+            return .post
+        case .createTeam:
             return .post
         }
     }
@@ -28,6 +33,8 @@ enum SetupEndPoint<T: Encodable> {
         switch self {
         case .login(let body):
             return body
+        case .createTeam(let body, _):
+            return body
         }
     }
     
@@ -35,6 +42,9 @@ enum SetupEndPoint<T: Encodable> {
         switch self {
         case .login:
             return nil
+        case .createTeam(_, let header):
+            let headers = ["user_id": header]
+            return HTTPHeaders(headers)
         }
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Network/EndPoint/SetupEndPoint.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/EndPoint/SetupEndPoint.swift
@@ -8,13 +8,13 @@
 import Alamofire
 
 enum SetupEndPoint<T: Encodable> {
-    case dispatchlogin(T)
+    case dispatchLogin(T)
     case dispatchCreateTeam(T, userId: String)
     case dispatchJoinTeam(T, userId: String)
     
     var address: String {
         switch self {
-        case .dispatchlogin:
+        case .dispatchLogin:
             return "\(UrlLiteral.baseUrl)/users/login"
         case .dispatchCreateTeam:
             return "\(UrlLiteral.baseUrl)/teams"
@@ -25,7 +25,7 @@ enum SetupEndPoint<T: Encodable> {
 
     var method: HTTPMethod {
         switch self {
-        case .dispatchlogin:
+        case .dispatchLogin:
             return .post
         case .dispatchCreateTeam:
             return .post
@@ -36,7 +36,7 @@ enum SetupEndPoint<T: Encodable> {
     
     var body: T? {
         switch self {
-        case .dispatchlogin(let body):
+        case .dispatchLogin(let body):
             return body
         case .dispatchCreateTeam(let body, _):
             return body
@@ -47,7 +47,7 @@ enum SetupEndPoint<T: Encodable> {
     
     var headers: HTTPHeaders? {
         switch self {
-        case .dispatchlogin:
+        case .dispatchLogin:
             return nil
         case .dispatchCreateTeam(_, let userId):
             let headers = ["user_id": userId]

--- a/Maddori.Apple/Maddori.Apple/Network/EndPoint/SetupEndPoint.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/EndPoint/SetupEndPoint.swift
@@ -9,7 +9,8 @@ import Alamofire
 
 enum SetupEndPoint<T: Encodable> {
     case login(T)
-    case createTeam(T, header: String)
+    case createTeam(T, userId: String)
+    case joinTeam(T, userId: String)
     
     var address: String {
         switch self {
@@ -17,6 +18,8 @@ enum SetupEndPoint<T: Encodable> {
             return "http://3.34.57.155:3000/api/v1/users/login"
         case .createTeam:
             return "http://3.34.57.155:3000/api/v1/teams"
+        case .joinTeam:
+            return "http://3.34.57.155:3000/api/v1/users/join-team"
         }
     }
 
@@ -25,6 +28,8 @@ enum SetupEndPoint<T: Encodable> {
         case .login:
             return .post
         case .createTeam:
+            return .post
+        case .joinTeam:
             return .post
         }
     }
@@ -35,6 +40,8 @@ enum SetupEndPoint<T: Encodable> {
             return body
         case .createTeam(let body, _):
             return body
+        case .joinTeam(let body, _):
+            return body
         }
     }
     
@@ -42,8 +49,11 @@ enum SetupEndPoint<T: Encodable> {
         switch self {
         case .login:
             return nil
-        case .createTeam(_, let header):
-            let headers = ["user_id": header]
+        case .createTeam(_, let userId):
+            let headers = ["user_id": userId]
+            return HTTPHeaders(headers)
+        case .joinTeam(_, let userId):
+            let headers = ["user_id": userId]
             return HTTPHeaders(headers)
         }
     }

--- a/Maddori.Apple/Maddori.Apple/Network/EndPoint/SetupEndPoint.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/EndPoint/SetupEndPoint.swift
@@ -1,0 +1,40 @@
+//
+//  SetupEndPoint.swift
+//  Maddori.Apple
+//
+//  Created by Mingwan Choi on 2022/11/16.
+//
+
+import Alamofire
+
+enum SetupEndPoint<T: Encodable> {
+    case login(T)
+    
+    var address: String {
+        switch self {
+        case .login:
+            return "http://3.34.57.155:3000/api/v1/users/login"
+        }
+    }
+
+    var method: HTTPMethod {
+        switch self {
+        case .login:
+            return .post
+        }
+    }
+    
+    var body: T? {
+        switch self {
+        case .login(let body):
+            return body
+        }
+    }
+    
+    var headers: HTTPHeaders? {
+        switch self {
+        case .login:
+            return nil
+        }
+    }
+}

--- a/Maddori.Apple/Maddori.Apple/Network/Model/BaseModel.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/Model/BaseModel.swift
@@ -11,4 +11,11 @@ struct BaseModel<T: Decodable>: Decodable {
     let success: Bool
     let message: String
     let detail: T?
+    
+    // FIXME: - 서버에서 오타 수정되면 enum이 삭제되어야함
+    enum CodingKeys: String, CodingKey {
+        case success
+        case message
+        case detail = "datail"
+    }
 }

--- a/Maddori.Apple/Maddori.Apple/Network/Model/BaseModel.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/Model/BaseModel.swift
@@ -11,11 +11,4 @@ struct BaseModel<T: Decodable>: Decodable {
     let success: Bool
     let message: String
     let detail: T?
-    
-    // FIXME: - 서버에서 오타 수정되면 enum이 삭제되어야함
-    enum CodingKeys: String, CodingKey {
-        case success
-        case message
-        case detail = "datail"
-    }
 }

--- a/Maddori.Apple/Maddori.Apple/Network/Storage/UserDefaultHandler.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/Storage/UserDefaultHandler.swift
@@ -1,0 +1,26 @@
+//
+//  UserDefaultHandler.swift
+//  Maddori.Apple
+//
+//  Created by Mingwan Choi on 2022/11/16.
+//
+
+import Foundation
+
+struct UserDefaultHandler {
+    static func clearAllData() {
+        UserData<Any>.clearAll()
+    }
+    
+    static func setIsLogin(isLogin: Bool) {
+        UserData.setValue(isLogin, forKey: .isLogin)
+    }
+    
+    static func setUserID(userID: String) {
+        UserData.setValue(userID, forKey: .userID)
+    }
+    
+    static func setNickname(nickname: String) {
+        UserData.setValue(nickname, forKey: .nickname)
+    }
+}

--- a/Maddori.Apple/Maddori.Apple/Network/Storage/UserDefaultHandler.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/Storage/UserDefaultHandler.swift
@@ -16,7 +16,7 @@ struct UserDefaultHandler {
         UserData.setValue(isLogin, forKey: .isLogin)
     }
     
-    static func setUserID(userID: String) {
+    static func setUserID(userID: Int) {
         UserData.setValue(userID, forKey: .userID)
     }
     

--- a/Maddori.Apple/Maddori.Apple/Network/Storage/UserDefaultStorage.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/Storage/UserDefaultStorage.swift
@@ -1,0 +1,53 @@
+//
+//  UserDefaultStorage.swift
+//  Maddori.Apple
+//
+//  Created by Mingwan Choi on 2022/11/16.
+//
+
+import Foundation
+
+enum DataKeys: String, CaseIterable {
+    case isLogin = "isLogin"
+    case userID = "userID"
+    case nickname = "nickname"
+}
+
+struct UserDefaultStorage {
+    static var isLogin: Bool {
+        return UserData<Bool>.getValue(forKey: .isLogin) ?? false
+    }
+    
+    static var userID: String {
+        return UserData<String>.getValue(forKey: .userID) ?? ""
+    }
+        
+    static var nickname: String? {
+        return UserData<String?>.getValue(forKey: .nickname) ?? nil
+    }
+}
+
+struct UserData<T> {
+    static func getValue(forKey key: DataKeys) -> T? {
+        if let data = UserDefaults.standard.value(forKey: key.rawValue) as? T {
+            return data
+        } else {
+            return nil
+        }
+    }
+    
+    static func setValue(_ value: T, forKey key: DataKeys) {
+        UserDefaults.standard.set(value, forKey: key.rawValue)
+    }
+    
+    static func clearAll() {
+        DataKeys.allCases.forEach { key in
+            print(key.rawValue)
+            UserDefaults.standard.removeObject(forKey: key.rawValue)
+        }
+    }
+    
+    static func clear(forKey key: DataKeys) {
+        UserDefaults.standard.removeObject(forKey: key.rawValue)
+    }
+}

--- a/Maddori.Apple/Maddori.Apple/Network/Storage/UserDefaultStorage.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/Storage/UserDefaultStorage.swift
@@ -18,12 +18,12 @@ struct UserDefaultStorage {
         return UserData<Bool>.getValue(forKey: .isLogin) ?? false
     }
     
-    static var userID: String {
-        return UserData<String>.getValue(forKey: .userID) ?? ""
+    static var userID: Int {
+        return UserData<Int>.getValue(forKey: .userID) ?? 1
     }
         
-    static var nickname: String? {
-        return UserData<String?>.getValue(forKey: .nickname) ?? nil
+    static var nickname: String {
+        return UserData<String>.getValue(forKey: .nickname) ?? ""
     }
 }
 

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/CreateTeam/CreateTeamViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/CreateTeam/CreateTeamViewController.swift
@@ -86,7 +86,7 @@ final class CreateTeamViewController: BaseTextFieldViewController {
         let action = UIAction { [weak self] _ in
             guard let teamName = self?.kigoTextField.text else { return }
             // FIXME: - header에는 user defaults에 있는 내 유저 id 값 넣기 -> 나중에는 로그인 토큰으로 변환 예정
-            self?.dispatchCreateTeam(type: .createTeam(CreateTeamDTO(team_name: teamName), userId: 1.description))
+            self?.dispatchCreateTeam(type: .dispatchCreateTeam(CreateTeamDTO(team_name: teamName), userId: 1.description))
         }
         super.doneButton.addAction(action, for: .touchUpInside)
     }

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/CreateTeam/CreateTeamViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/CreateTeam/CreateTeamViewController.swift
@@ -86,7 +86,7 @@ final class CreateTeamViewController: BaseTextFieldViewController {
         let action = UIAction { [weak self] _ in
             guard let teamName = self?.kigoTextField.text else { return }
             // FIXME: - header에는 user defaults에 있는 내 유저 id 값 넣기 -> 나중에는 로그인 토큰으로 변환 예정
-            self?.dispatchCreateTeam(type: .createTeam(CreateTeamDTO(team_name: teamName), header: 1.description))
+            self?.dispatchCreateTeam(type: .createTeam(CreateTeamDTO(team_name: teamName), userId: 1.description))
         }
         super.doneButton.addAction(action, for: .touchUpInside)
     }

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/CreateTeam/CreateTeamViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/CreateTeam/CreateTeamViewController.swift
@@ -86,7 +86,7 @@ final class CreateTeamViewController: BaseTextFieldViewController {
         let action = UIAction { [weak self] _ in
             guard let teamName = self?.kigoTextField.text else { return }
             // FIXME: - header에는 user defaults에 있는 내 유저 id 값 넣기 -> 나중에는 로그인 토큰으로 변환 예정
-            self?.dispatchCreateTeam(type: .dispatchCreateTeam(CreateTeamDTO(team_name: teamName), userId: 1.description))
+            self?.dispatchCreateTeam(type: .dispatchCreateTeam(CreateTeamDTO(team_name: teamName), userId: UserDefaultStorage.userID.description))
         }
         super.doneButton.addAction(action, for: .touchUpInside)
     }

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/CreateTeam/CreateTeamViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/CreateTeam/CreateTeamViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import Alamofire
 import SnapKit
 
 final class CreateTeamViewController: BaseTextFieldViewController {
@@ -66,7 +67,7 @@ final class CreateTeamViewController: BaseTextFieldViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        setupCreateButtonAction()
+        setupDoneButton()
     }
     
     override func setupNavigationBar() {
@@ -81,9 +82,11 @@ final class CreateTeamViewController: BaseTextFieldViewController {
     
     // MARK: - setup
     
-    private func setupCreateButtonAction() {
+    private func setupDoneButton() {
         let action = UIAction { [weak self] _ in
-            self?.pushHomeViewController()
+            guard let teamName = self?.kigoTextField.text else { return }
+            // FIXME: - header에는 user defaults에 있는 내 유저 id 값 넣기 -> 나중에는 로그인 토큰으로 변환 예정
+            self?.dispatchCreateTeam(type: .createTeam(CreateTeamDTO(team_name: teamName), header: 1.description))
         }
         super.doneButton.addAction(action, for: .touchUpInside)
     }
@@ -93,5 +96,28 @@ final class CreateTeamViewController: BaseTextFieldViewController {
     private func pushHomeViewController() {
         let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate
         sceneDelegate?.changeRootViewCustomTabBarView()
+    }
+    
+    // MARK: - api
+    
+    private func dispatchCreateTeam(type: SetupEndPoint<CreateTeamDTO>) {
+        AF.request(type.address,
+                   method: type.method,
+                   parameters: type.body,
+                   encoder: JSONParameterEncoder.default,
+                   headers: type.headers
+        ).responseDecodable(of: BaseModel<CreateTeamResponse>.self) { json in
+            if let json = json.value {
+                dump(json)
+                DispatchQueue.main.async {
+                    self.pushHomeViewController()
+                }
+            } else {
+                DispatchQueue.main.async {
+                    // FIXME: - UXWriting 필요
+                    self.makeAlert(title: "에러", message: "중복된 팀 이름입니다람쥐")
+                }
+            }
+        }
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/JoinTeam/JoinTeamViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/JoinTeam/JoinTeamViewController.swift
@@ -11,8 +11,8 @@ import Alamofire
 import SnapKit
 
 final class JoinTeamViewController: BaseTextFieldViewController {
-    
-    var name = "진저"
+    // FIXME: - nil 일때 어떤 값을 표시해줄지??
+    var name = UserData.getValue(forKey: .nickname) ?? ""
     
     override var titleText: String {
         get {

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/JoinTeam/JoinTeamViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/JoinTeam/JoinTeamViewController.swift
@@ -108,7 +108,7 @@ final class JoinTeamViewController: BaseTextFieldViewController {
         let action = UIAction { [weak self] _ in
             guard let invitationCode = self?.kigoTextField.text else { return }
             // FIXME: - userId는 우선 UserDefaults로 변경. -> 이후엔 토큰으로 처리
-            self?.dispatchJoinTeam(type: .joinTeam(JoinTeamDTO(invitation_code: invitationCode), userId: 18.description))
+            self?.dispatchJoinTeam(type: .dispatchJoinTeam(JoinTeamDTO(invitation_code: invitationCode), userId: 18.description))
         }
         super.doneButton.addAction(action, for: .touchUpInside)
     }

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/JoinTeam/JoinTeamViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/JoinTeam/JoinTeamViewController.swift
@@ -11,12 +11,10 @@ import Alamofire
 import SnapKit
 
 final class JoinTeamViewController: BaseTextFieldViewController {
-    // FIXME: - nil 일때 어떤 값을 표시해줄지??
-    var name = UserData.getValue(forKey: .nickname) ?? ""
     
     override var titleText: String {
         get {
-            return name + TextLiteral.joinTeamViewControllerTitleLabel
+            return UserDefaultStorage.nickname + TextLiteral.joinTeamViewControllerTitleLabel
         }
         
         set {

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/JoinTeam/JoinTeamViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/JoinTeam/JoinTeamViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import Alamofire
 import SnapKit
 
 final class JoinTeamViewController: BaseTextFieldViewController {
@@ -105,7 +106,9 @@ final class JoinTeamViewController: BaseTextFieldViewController {
     
     private func setupDoneButton() {
         let action = UIAction { [weak self] _ in
-            self?.pushHomeViewController()
+            guard let invitationCode = self?.kigoTextField.text else { return }
+            // FIXME: - userId는 우선 UserDefaults로 변경. -> 이후엔 토큰으로 처리
+            self?.dispatchJoinTeam(type: .joinTeam(JoinTeamDTO(invitation_code: invitationCode), userId: 18.description))
         }
         super.doneButton.addAction(action, for: .touchUpInside)
     }
@@ -122,5 +125,28 @@ final class JoinTeamViewController: BaseTextFieldViewController {
     private func pushHomeViewController() {
         let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate
         sceneDelegate?.changeRootViewCustomTabBarView()
+    }
+    
+    // MARK: - api
+    
+    private func dispatchJoinTeam(type: SetupEndPoint<JoinTeamDTO>) {
+        AF.request(type.address,
+                   method: type.method,
+                   parameters: type.body,
+                   encoder: JSONParameterEncoder.default,
+                   headers: type.headers
+        ).responseDecodable(of: BaseModel<JoinTeamResponse>.self) { json in
+            if let json = json.value {
+                dump(json)
+                DispatchQueue.main.async {
+                    self.pushHomeViewController()
+                }
+            } else {
+                DispatchQueue.main.async {
+                    // FIXME: - UXWriting 필요
+                    self.makeAlert(title: "에러", message: "존재하지 않는 팀입니다.")
+                }
+            }
+        }
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/Login/LoginViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/Login/LoginViewController.swift
@@ -36,6 +36,8 @@ final class LoginViewController: BaseViewController {
         let action = UIAction { [weak self] _ in
             // FIXME: - 로그인 API연결
             self?.presentSetupNickNameViewController()
+            // FIXME: - AppleLogin 연결 후, 성공했을 때로 옮겨야 함.
+            self?.setLoginUserDefaults()
 //            self?.appleSignIn()
         }
         button.cornerRadius = 15
@@ -101,6 +103,10 @@ final class LoginViewController: BaseViewController {
         let viewController = SetNicknameViewController()
         viewController.navigationItem.setHidesBackButton(true, animated: false)
         navigationController?.pushViewController(viewController, animated: true)
+    }
+    
+    private func setLoginUserDefaults() {
+        UserData.setValue(true, forKey: .isLogin)
     }
 }
 

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/Login/LoginViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/Login/LoginViewController.swift
@@ -106,7 +106,7 @@ final class LoginViewController: BaseViewController {
     }
     
     private func setLoginUserDefaults() {
-        UserData.setValue(true, forKey: .isLogin)
+        UserDefaultHandler.setIsLogin(isLogin: true)
     }
 }
 

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/SetNickname/SetNicknameViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/SetNickname/SetNicknameViewController.swift
@@ -86,6 +86,8 @@ final class SetNicknameViewController: BaseTextFieldViewController {
         ).responseDecodable(of: BaseModel<MemberResponse>.self) { json in
             if let json = json.value {
                 dump(json)
+                guard let nickname = json.detail?.username else { return }
+                UserData.setValue(nickname, forKey: .nickname)
                 DispatchQueue.main.async {
                     self.navigationController?.pushViewController(JoinTeamViewController(), animated: true)
                 }

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/SetNickname/SetNicknameViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/SetNickname/SetNicknameViewController.swift
@@ -71,17 +71,17 @@ final class SetNicknameViewController: BaseTextFieldViewController {
     private func setupDoneButton() {
         let action = UIAction { [weak self] _ in
             guard let nickname = self?.kigoTextField.text else { return }
-            self?.dispatchUserLogin(api: .dispatchlogin(LoginDTO(username: nickname)))
+            self?.dispatchUserLogin(type: .dispatchLogin(LoginDTO(username: nickname)))
         }
         super.doneButton.addAction(action, for: .touchUpInside)
     }
     
     // MARK: - api
     
-    private func dispatchUserLogin(api: SetupEndPoint<LoginDTO>) {
-        AF.request(api.address,
-                   method: api.method,
-                   parameters: api.body,
+    private func dispatchUserLogin(type: SetupEndPoint<LoginDTO>) {
+        AF.request(type.address,
+                   method: type.method,
+                   parameters: type.body,
                    encoder: JSONParameterEncoder.default
         ).responseDecodable(of: BaseModel<MemberResponse>.self) { json in
             if let json = json.value {

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/SetNickname/SetNicknameViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/SetNickname/SetNicknameViewController.swift
@@ -50,7 +50,6 @@ final class SetNicknameViewController: BaseTextFieldViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        pushJoinTeamViewController()
         setupDoneButton()
     }
     
@@ -63,13 +62,6 @@ final class SetNicknameViewController: BaseTextFieldViewController {
     }
     
     // MARK: - func
-    
-    private func pushJoinTeamViewController() {
-        let action = UIAction { [weak self] _ in
-            self?.navigationController?.pushViewController(JoinTeamViewController(), animated: true)
-        }
-//        super.doneButton.addAction(action, for: .touchUpInside)
-    }
     
     override func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()
@@ -92,7 +84,6 @@ final class SetNicknameViewController: BaseTextFieldViewController {
                    parameters: api.body,
                    encoder: JSONParameterEncoder.default
         ).responseDecodable(of: BaseModel<MemberResponse>.self) { json in
-            print("code: ", json.response?.statusCode)
             if let json = json.value {
                 dump(json)
                 DispatchQueue.main.async {

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/SetNickname/SetNicknameViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/SetNickname/SetNicknameViewController.swift
@@ -86,8 +86,11 @@ final class SetNicknameViewController: BaseTextFieldViewController {
         ).responseDecodable(of: BaseModel<MemberResponse>.self) { json in
             if let json = json.value {
                 dump(json)
-                guard let nickname = json.detail?.username else { return }
-                UserData.setValue(nickname, forKey: .nickname)
+                guard let nickname = json.detail?.username,
+                      let userId = json.detail?.id
+                else { return }
+                UserDefaultHandler.setUserID(userID: userId)
+                UserDefaultHandler.setNickname(nickname: nickname)
                 DispatchQueue.main.async {
                     self.navigationController?.pushViewController(JoinTeamViewController(), animated: true)
                 }

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/SetNickname/SetNicknameViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/SetNickname/SetNicknameViewController.swift
@@ -71,7 +71,7 @@ final class SetNicknameViewController: BaseTextFieldViewController {
     private func setupDoneButton() {
         let action = UIAction { [weak self] _ in
             guard let nickname = self?.kigoTextField.text else { return }
-            self?.dispatchUserLogin(api: .login(LoginDTO(username: nickname)))
+            self?.dispatchUserLogin(api: .dispatchlogin(LoginDTO(username: nickname)))
         }
         super.doneButton.addAction(action, for: .touchUpInside)
     }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
setup 부분의 view들의 API 연결을 했습니다. 우리 모두 Alamofire를 처음 써보는거라 api 몇개만 뚫으면 금방 할 수 있다는 생각에 3개정도 뚫었습니다. 아자아자 화이팅 !


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 닉네임 설정뷰 (SetNicknameViewController)
- 팀 생성뷰 (CreateTeamViewController)
- 팀 합류뷰 (JoinTeamViewController)
에 연결되는 API들을 추가했습니다 .
<img width="1724" alt="image" src="https://user-images.githubusercontent.com/78677571/202141366-4a529511-faa9-4700-ab59-59fba3bf29c8.png">


## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
feature/105-setup-view-api 브랜치로 오셔서 sceneDelegate에 있는 `isLogined = false`로 변경하고 
닉네임 설정, 팀 생성, 팀 합류하기를 테스트 해보시면 됩니다 !
팀 합류 코드는 **EJHLFR** 로 사용하시면 됩니다.

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->


https://user-images.githubusercontent.com/78677571/202142639-2cc7b6b8-aabf-4594-a000-2d9c17c223d0.mp4


https://user-images.githubusercontent.com/78677571/202142670-11a156de-26c3-442f-9df1-9f81263d3b03.mp4


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
ViewController에서 각 API마다 함수를 만들어서 사용하려고 했습니다. 그렇게 했을때 사소한 실수가 생길 수 있을 것 같아서 해당 view들이 정리된 EndPoint를 만들었습니다.
다른분들도 EndPoint형식으로 만들고 사용하면 좋을 것 같습니다 !
추가적으로 EndPointable 이라는 프로토콜을 만들어서 확실히 하고 싶은데 추후에 추가 해보겠습니다 !


++)
에러에 대한 alert의 UXWriting은 추후에 하면 좋을 것 같습니다 !

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #105 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
https://nsios.tistory.com/49