### PR TITLE
[FEAT] 피드백 추가하기 API 연결

### DIFF
--- a/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
+++ b/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		397E495A2924F871004220D6 /* UserDefaultStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 397E49592924F871004220D6 /* UserDefaultStorage.swift */; };
 		397E495C2924F8A2004220D6 /* UserDefaultHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 397E495B2924F8A2004220D6 /* UserDefaultHandler.swift */; };
 		398474222925CF4800EDC139 /* TeamInfoResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 398474212925CF4800EDC139 /* TeamInfoResponse.swift */; };
+		39847424292603B000EDC139 /* AddFeedBackEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39847423292603B000EDC139 /* AddFeedBackEndPoint.swift */; };
 		39A64ACE2905885F001DB020 /* StartSuggestionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39A64ACD2905885F001DB020 /* StartSuggestionView.swift */; };
 		39F1A13529125762005E3456 /* MyFeedbackViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F1A13429125762005E3456 /* MyFeedbackViewController.swift */; };
 		39F1A13C2912637E005E3456 /* MyFeedbackMemberCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F1A13B2912637E005E3456 /* MyFeedbackMemberCollectionViewCell.swift */; };
@@ -156,6 +157,7 @@
 		397E49592924F871004220D6 /* UserDefaultStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultStorage.swift; sourceTree = "<group>"; };
 		397E495B2924F8A2004220D6 /* UserDefaultHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultHandler.swift; sourceTree = "<group>"; };
 		398474212925CF4800EDC139 /* TeamInfoResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamInfoResponse.swift; sourceTree = "<group>"; };
+		39847423292603B000EDC139 /* AddFeedBackEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddFeedBackEndPoint.swift; sourceTree = "<group>"; };
 		39A64ACD2905885F001DB020 /* StartSuggestionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartSuggestionView.swift; sourceTree = "<group>"; };
 		39F1A13429125762005E3456 /* MyFeedbackViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyFeedbackViewController.swift; sourceTree = "<group>"; };
 		39F1A13B2912637E005E3456 /* MyFeedbackMemberCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyFeedbackMemberCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -622,6 +624,7 @@
 			isa = PBXGroup;
 			children = (
 				39F52C792924CC9600B19A77 /* SetupEndPoint.swift */,
+				39847423292603B000EDC139 /* AddFeedBackEndPoint.swift */,
 			);
 			path = EndPoint;
 			sourceTree = "<group>";
@@ -1018,6 +1021,7 @@
 				39257DF128F93C2A00201E0B /* ImageLiteral.swift in Sources */,
 				395C7E252900E74700FC2FCA /* StartReflectionViewController.swift in Sources */,
 				3E557FF82901CD3400714E46 /* KeywordCollectionViewFlowLayout.swift in Sources */,
+				39847424292603B000EDC139 /* AddFeedBackEndPoint.swift in Sources */,
 				39F52C4729232DD600B19A77 /* LoginDTO.swift in Sources */,
 				39F52C592923321700B19A77 /* CertainTeamDetailResponse.swift in Sources */,
 				397E495A2924F871004220D6 /* UserDefaultStorage.swift in Sources */,

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/CollectionView/MemberCollectionView/MemberCollectionView.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/CollectionView/MemberCollectionView/MemberCollectionView.swift
@@ -13,7 +13,7 @@ final class MemberCollectionView: UIView {
     
     // FIXME: - 목업 데이터 추후 데이터 연결한 후 삭제할 내용
     
-    var memberList: [String] = [] {
+    var memberList: [MemberResponse] = [] {
         didSet {
             collectionView.reloadData()
         }
@@ -73,8 +73,8 @@ final class MemberCollectionView: UIView {
 
 extension MemberCollectionView: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        if !selectedMemberList.contains(memberList[indexPath.item]) {
-            selectedMemberList.append(memberList[indexPath.item])
+        if !selectedMemberList.contains(memberList[indexPath.item].username ?? "") {
+            selectedMemberList.append(memberList[indexPath.item].username ?? "")
         }
         didTappedMember?(selectedMemberList)
     }
@@ -90,7 +90,7 @@ extension MemberCollectionView: UICollectionViewDataSource {
             assert(false, "Wrong Cell")
             return UICollectionViewCell()
         }
-        cell.memberLabel.text = memberList[indexPath.item]
+        cell.memberLabel.text = memberList[indexPath.item].username
         return cell
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/CollectionView/MemberCollectionView/MemberCollectionView.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/CollectionView/MemberCollectionView/MemberCollectionView.swift
@@ -13,7 +13,7 @@ final class MemberCollectionView: UIView {
     
     enum CollectionType {
         case addFeedback
-        case selectMember
+        case progressReflection
     }
     // FIXME: - 목업 데이터 추후 데이터 연결한 후 삭제할 내용
     
@@ -84,7 +84,7 @@ extension MemberCollectionView: UICollectionViewDelegate {
         switch type {
         case .addFeedback:
             didTappedFeedBackMember?(memberList[indexPath.item])
-        case .selectMember:
+        case .progressReflection:
             if !selectedMemberList.contains(where: { $0.username == memberList[indexPath.item].username} ) {
                 selectedMemberList.append(memberList[indexPath.item])
             }

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/CollectionView/MemberCollectionView/MemberCollectionView.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/CollectionView/MemberCollectionView/MemberCollectionView.swift
@@ -13,7 +13,11 @@ final class MemberCollectionView: UIView {
     
     // FIXME: - 목업 데이터 추후 데이터 연결한 후 삭제할 내용
     
-    var memberList: [String] = []
+    var memberList: [String] = [] {
+        didSet {
+            collectionView.reloadData()
+        }
+    }
     var didTappedMember: (([String]) -> ())?
     private var selectedMemberList: [String] = []
     private enum Size {

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/CollectionView/MemberCollectionView/MemberCollectionView.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/CollectionView/MemberCollectionView/MemberCollectionView.swift
@@ -11,15 +11,22 @@ import SnapKit
 
 final class MemberCollectionView: UIView {
     
+    enum CollectionType {
+        case addFeedback
+        case selectMember
+    }
     // FIXME: - 목업 데이터 추후 데이터 연결한 후 삭제할 내용
     
+    var type: CollectionType
+    var currentToUserId = 0
     var memberList: [MemberResponse] = [] {
         didSet {
             collectionView.reloadData()
         }
     }
-    var didTappedMember: (([String]) -> ())?
-    private var selectedMemberList: [String] = []
+    var didTappedMember: (([MemberResponse]) -> ())?
+    var didTappedFeedBackMember: ((MemberResponse) -> ())?
+    private var selectedMemberList: [MemberResponse] = []
     private enum Size {
         static let collectionHorizontalSpacing: CGFloat = 14
         static let collectionTopSpacing: CGFloat = 40
@@ -54,8 +61,9 @@ final class MemberCollectionView: UIView {
     
     // MARK: - life cycle
     
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    init(type: CollectionType) {
+        self.type = type
+        super.init(frame: .zero)
         render()
     }
     
@@ -73,10 +81,17 @@ final class MemberCollectionView: UIView {
 
 extension MemberCollectionView: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        if !selectedMemberList.contains(memberList[indexPath.item].username ?? "") {
-            selectedMemberList.append(memberList[indexPath.item].username ?? "")
+        switch type {
+        case .addFeedback:
+            didTappedFeedBackMember?(memberList[indexPath.item])
+        case .selectMember:
+            if !selectedMemberList.contains(where: { $0.username == memberList[indexPath.item].username} ) {
+                selectedMemberList.append(memberList[indexPath.item])
+            }
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MemberCollectionViewCell.className, for: indexPath) as? MemberCollectionViewCell else { return }
+            cell.setupAttribute()
+            didTappedMember?(selectedMemberList)
         }
-        didTappedMember?(selectedMemberList)
     }
 }
 

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/CollectionView/MemberCollectionView/MemberCollectionViewCell.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/CollectionView/MemberCollectionView/MemberCollectionViewCell.swift
@@ -17,10 +17,6 @@ final class MemberCollectionViewCell: BaseCollectionViewCell {
         static let frame = CGRect(x: 0, y: 0, width: Size.width, height: Size.height)
     }
     
-//    override var isSelected: Bool {
-//        didSet { setupAttribute() }
-//    }
-    
     // MARK: - property
     
     let memberLabel: UILabel = {

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/CollectionView/MemberCollectionView/MemberCollectionViewCell.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/CollectionView/MemberCollectionView/MemberCollectionViewCell.swift
@@ -17,9 +17,9 @@ final class MemberCollectionViewCell: BaseCollectionViewCell {
         static let frame = CGRect(x: 0, y: 0, width: Size.width, height: Size.height)
     }
     
-    override var isSelected: Bool {
-        didSet { setupAttribute() }
-    }
+//    override var isSelected: Bool {
+//        didSet { setupAttribute() }
+//    }
     
     // MARK: - property
     
@@ -61,7 +61,7 @@ final class MemberCollectionViewCell: BaseCollectionViewCell {
     
     // MARK: - func
     
-    private func setupAttribute() {
+    func setupAttribute() {
         if isSelected {
             memberLabel.textColor = .gray300
             memberLabel.backgroundColor = .white100

--- a/Maddori.Apple/Maddori.Apple/Network/EndPoint/AddFeedBackEndPoint.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/EndPoint/AddFeedBackEndPoint.swift
@@ -1,0 +1,43 @@
+//
+//  AddFeedBackEndPoint.swift
+//  Maddori.Apple
+//
+//  Created by Mingwan Choi on 2022/11/17.
+//
+
+import Foundation
+
+import Alamofire
+
+enum AddFeedBackEndPoint<T: Encodable> {
+    case fetchCurrentTeamMember(teamId: String, userId: String)
+    
+    var address: String {
+        switch self {
+        case .fetchCurrentTeamMember(let teamId, _):
+            return "\(UrlLiteral.baseUrl)/teams/\(teamId)/members"
+        }
+    }
+
+    var method: HTTPMethod {
+        switch self {
+        case .fetchCurrentTeamMember:
+            return .get
+        }
+    }
+    
+    var body: T? {
+        switch self {
+        case .fetchCurrentTeamMember:
+            return nil
+        }
+    }
+    
+    var headers: HTTPHeaders? {
+        switch self {
+        case .fetchCurrentTeamMember(_, let userId):
+            let header = ["user_id": userId]
+            return HTTPHeaders(header)
+        }
+    }
+}

--- a/Maddori.Apple/Maddori.Apple/Network/EndPoint/AddFeedBackEndPoint.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/EndPoint/AddFeedBackEndPoint.swift
@@ -10,8 +10,8 @@ import Foundation
 import Alamofire
 
 enum AddFeedBackEndPoint<T: Encodable> {
-    case fetchCurrentTeamMember(teamId: String, userId: String)
-    case dispatchAddFeedBack(teamId: String, reflectionId: String, userId: String, T)
+    case fetchCurrentTeamMember(teamId: Int, userId: Int)
+    case dispatchAddFeedBack(teamId: Int, reflectionId: Int, userId: Int, T)
     
     var address: String {
         switch self {
@@ -43,10 +43,10 @@ enum AddFeedBackEndPoint<T: Encodable> {
     var headers: HTTPHeaders? {
         switch self {
         case .fetchCurrentTeamMember(_, let userId):
-            let headers = ["user_id": userId]
+            let headers = ["user_id": "\(userId)"]
             return HTTPHeaders(headers)
         case .dispatchAddFeedBack(_, _, let userId, _):
-            let headers = ["user_id": userId]
+            let headers = ["user_id": "\(userId)"]
             return HTTPHeaders(headers)
         }
     }

--- a/Maddori.Apple/Maddori.Apple/Network/EndPoint/AddFeedBackEndPoint.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/EndPoint/AddFeedBackEndPoint.swift
@@ -11,11 +11,14 @@ import Alamofire
 
 enum AddFeedBackEndPoint<T: Encodable> {
     case fetchCurrentTeamMember(teamId: String, userId: String)
+    case dispatchAddFeedBack(teamId: String, reflectionId: String, userId: String, T)
     
     var address: String {
         switch self {
         case .fetchCurrentTeamMember(let teamId, _):
             return "\(UrlLiteral.baseUrl)/teams/\(teamId)/members"
+        case .dispatchAddFeedBack(let teamId, let reflectionId, _, _):
+            return "\(UrlLiteral.baseUrl)/teams/\(teamId)/reflections/\(reflectionId)/feedbacks"
         }
     }
 
@@ -23,6 +26,8 @@ enum AddFeedBackEndPoint<T: Encodable> {
         switch self {
         case .fetchCurrentTeamMember:
             return .get
+        case .dispatchAddFeedBack:
+            return .post
         }
     }
     
@@ -30,14 +35,19 @@ enum AddFeedBackEndPoint<T: Encodable> {
         switch self {
         case .fetchCurrentTeamMember:
             return nil
+        case .dispatchAddFeedBack(_, _, _, let body):
+            return body
         }
     }
     
     var headers: HTTPHeaders? {
         switch self {
         case .fetchCurrentTeamMember(_, let userId):
-            let header = ["user_id": userId]
-            return HTTPHeaders(header)
+            let headers = ["user_id": userId]
+            return HTTPHeaders(headers)
+        case .dispatchAddFeedBack(_, _, let userId, _):
+            let headers = ["user_id": userId]
+            return HTTPHeaders(headers)
         }
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Network/Reqeust/DTO/FeedBackContentDTO.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/Reqeust/DTO/FeedBackContentDTO.swift
@@ -11,7 +11,7 @@ struct FeedBackContentDTO: Encodable {
     let type: FeedBackDTO
     let keyword: String
     let content: String
-    let start_content: String
+    let start_content: String?
     let to_id: Int
     
     enum FeedBackDTO: String, Encodable {

--- a/Maddori.Apple/Maddori.Apple/Network/Reqeust/DTO/FeedBackContentDTO.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/Reqeust/DTO/FeedBackContentDTO.swift
@@ -14,8 +14,9 @@ struct FeedBackContentDTO: Encodable {
     let start_content: String?
     let to_id: Int
     
-    enum FeedBackDTO: String, Encodable {
-        case continueType = "Continue"
-        case stopType = "Stop"
-    }
+}
+
+enum FeedBackDTO: String, Encodable {
+    case continueType = "Continue"
+    case stopType = "Stop"
 }

--- a/Maddori.Apple/Maddori.Apple/Network/Response/MemberResponse.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/Response/MemberResponse.swift
@@ -9,6 +9,11 @@ import Foundation
 
 struct MemberResponse: Decodable {
     // MARK: - userLogin
-    let id: Int?
+    let userId: Int?
     let username: String?
+    
+    enum CodingKeys: String, CodingKey {
+        case userId = "user_id"
+        case username
+    }
 }

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/AddFeedback/AddFeedbackViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/AddFeedback/AddFeedbackViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import Alamofire
 import SnapKit
 
 class AddFeedbackViewController: BaseViewController {
@@ -17,14 +18,14 @@ class AddFeedbackViewController: BaseViewController {
         static let textViewMaxLength: Int = 200
     }
     var type: FeedbackButtonType = .continueType
-    var fromNickname: String
     var toNickname: String
+    var toUserId: Int
     var keywordHasText: Bool = false
     var contentHasText: Bool = false
     
-    init(from: String, to: String) {
-        self.fromNickname = from
+    init(to: String, toUserId: Int) {
         self.toNickname = to
+        self.toUserId = toUserId
         super.init()
     }
     
@@ -359,7 +360,27 @@ class AddFeedbackViewController: BaseViewController {
     }
     
     private func didTappedDoneButton() {
-        dismiss(animated: true)
+        guard let keyword = feedbackKeywordTextField.text,
+              let content = feedbackContentTextView.text
+        else { return }
+        let dto = FeedBackContentDTO(type: .continueType, keyword: keyword, content: content, start_content: feedbackStartTextView.text, to_id: toUserId)
+        dispatchAddFeedBack(type: .dispatchAddFeedBack(teamId: 1.description, reflectionId: 2.description, userId: 1.description, dto))
+    }
+    
+    // MARK: - api
+    
+    private func dispatchAddFeedBack(type: AddFeedBackEndPoint<FeedBackContentDTO>) {
+        AF.request(type.address,
+                   method: type.method,
+                   parameters: type.body,
+                   encoder: JSONParameterEncoder.default,
+                   headers: type.headers
+        ).responseDecodable(of: BaseModel<FeedBackContentResponse>.self) { json in
+            dump(json.value)
+            DispatchQueue.main.async {
+                self.dismiss(animated: true)
+            }
+        }
     }
     
     // MARK: - selector

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/AddFeedback/AddFeedbackViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/AddFeedback/AddFeedbackViewController.swift
@@ -364,6 +364,7 @@ class AddFeedbackViewController: BaseViewController {
               let content = feedbackContentTextView.text
         else { return }
         let dto = FeedBackContentDTO(type: .continueType, keyword: keyword, content: content, start_content: feedbackStartTextView.text, to_id: toUserId)
+        // FIXME: - 각 id들 UserDefault에 저장되어 있는 값을 불러와야 함.
         dispatchAddFeedBack(type: .dispatchAddFeedBack(teamId: 1.description, reflectionId: 2.description, userId: 1.description, dto))
     }
     

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/AddFeedback/AddFeedbackViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/AddFeedback/AddFeedbackViewController.swift
@@ -366,7 +366,7 @@ class AddFeedbackViewController: BaseViewController {
         else { return }
         let dto = FeedBackContentDTO(type: type, keyword: keyword, content: content, start_content: startContent, to_id: toUserId)
         // FIXME: - 각 id들 UserDefault에 저장되어 있는 값을 불러와야 함.
-        dispatchAddFeedBack(type: .dispatchAddFeedBack(teamId: 1.description, reflectionId: 2.description, userId: 1.description, dto))
+        dispatchAddFeedBack(type: .dispatchAddFeedBack(teamId: 1, reflectionId: 2, userId: 1, dto))
     }
     
     // MARK: - api

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/AddFeedback/AddFeedbackViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/AddFeedback/AddFeedbackViewController.swift
@@ -17,7 +17,7 @@ class AddFeedbackViewController: BaseViewController {
         static let keywordMaxLength: Int = 15
         static let textViewMaxLength: Int = 200
     }
-    var type: FeedbackButtonType = .continueType
+    var type: FeedBackDTO = .continueType
     var toNickname: String
     var toUserId: Int
     var keywordHasText: Bool = false
@@ -71,7 +71,7 @@ class AddFeedbackViewController: BaseViewController {
     lazy var feedbackTypeButtonView: FeedbackTypeButtonView = {
         let view = FeedbackTypeButtonView()
         view.changeFeedbackType = { [weak self] type in
-            if let typeValue = FeedbackButtonType.init(rawValue: type.rawValue) {
+            if let typeValue = FeedBackDTO.init(rawValue: type.rawValue) {
                 self?.type = typeValue
             }
         }
@@ -360,10 +360,11 @@ class AddFeedbackViewController: BaseViewController {
     }
     
     private func didTappedDoneButton() {
+        let startContent = feedbackStartSwitch.isOn ? feedbackStartTextView.text : nil
         guard let keyword = feedbackKeywordTextField.text,
               let content = feedbackContentTextView.text
         else { return }
-        let dto = FeedBackContentDTO(type: .continueType, keyword: keyword, content: content, start_content: feedbackStartTextView.text, to_id: toUserId)
+        let dto = FeedBackContentDTO(type: type, keyword: keyword, content: content, start_content: startContent, to_id: toUserId)
         // FIXME: - 각 id들 UserDefault에 저장되어 있는 값을 불러와야 함.
         dispatchAddFeedBack(type: .dispatchAddFeedBack(teamId: 1.description, reflectionId: 2.description, userId: 1.description, dto))
     }

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/SelectFeedbackMember/SelectFeedbackMemberViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/SelectFeedbackMember/SelectFeedbackMemberViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import Alamofire
 import SnapKit
 
 final class SelectFeedbackMemberViewController: BaseViewController {
@@ -36,6 +37,11 @@ final class SelectFeedbackMemberViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupCloseButtonAction()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        fetchCurrentTeamMember(type: .fetchCurrentTeamMember(teamId: 1.description, userId: 1.description))
     }
     
     override func render() {
@@ -71,5 +77,17 @@ final class SelectFeedbackMemberViewController: BaseViewController {
         navigationController?.navigationBar.prefersLargeTitles = false
         navigationItem.largeTitleDisplayMode = .never
         navigationItem.rightBarButtonItem = rightButton
+    }
+    
+    // MARK: - api
+    
+    private func fetchCurrentTeamMember(type: AddFeedBackEndPoint<AddReflectionDTO>) {
+        AF.request(
+            type.address,
+            method: type.method,
+            headers: type.headers
+        ).responseDecodable(of: BaseModel<TeamMembersResponse>.self) { json in
+            dump(json.value)
+        }
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/SelectFeedbackMember/SelectFeedbackMemberViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/SelectFeedbackMember/SelectFeedbackMemberViewController.swift
@@ -87,7 +87,7 @@ final class SelectFeedbackMemberViewController: BaseViewController {
                 guard let allMemberList = data.detail?.members else { return }
                 let memberList = allMemberList.filter { $0.username != UserDefaultStorage.nickname }
                 DispatchQueue.main.async {
-                    self.memberCollectionView.memberList = memberList.map { $0.username ?? "" }
+                    self.memberCollectionView.memberList = memberList
                 }
             }
         }

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/SelectFeedbackMember/SelectFeedbackMemberViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/SelectFeedbackMember/SelectFeedbackMemberViewController.swift
@@ -24,9 +24,9 @@ final class SelectFeedbackMemberViewController: BaseViewController {
         return label
     }()
     private lazy var memberCollectionView: MemberCollectionView = {
-        let collectionView = MemberCollectionView()
-        collectionView.didTappedMember = { [weak self] arr in
-            self?.navigationController?.pushViewController(AddFeedbackViewController(from: "나", to: arr.last ?? "팀원"), animated: true)
+        let collectionView = MemberCollectionView(type: .addFeedback)
+        collectionView.didTappedFeedBackMember = { [weak self] user in
+            self?.navigationController?.pushViewController(AddFeedbackViewController(to: user.username ?? "", toUserId: user.userId ?? 0), animated: true)
         }
         return collectionView
     }()

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/SelectFeedbackMember/SelectFeedbackMemberViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/SelectFeedbackMember/SelectFeedbackMemberViewController.swift
@@ -25,7 +25,6 @@ final class SelectFeedbackMemberViewController: BaseViewController {
     }()
     private lazy var memberCollectionView: MemberCollectionView = {
         let collectionView = MemberCollectionView()
-        collectionView.memberList = Member.getMemberListExceptUser()
         collectionView.didTappedMember = { [weak self] arr in
             self?.navigationController?.pushViewController(AddFeedbackViewController(from: "나", to: arr.last ?? "팀원"), animated: true)
         }
@@ -37,10 +36,6 @@ final class SelectFeedbackMemberViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupCloseButtonAction()
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
         fetchCurrentTeamMember(type: .fetchCurrentTeamMember(teamId: 1.description, userId: 1.description))
     }
     
@@ -88,6 +83,13 @@ final class SelectFeedbackMemberViewController: BaseViewController {
             headers: type.headers
         ).responseDecodable(of: BaseModel<TeamMembersResponse>.self) { json in
             dump(json.value)
+            if let data = json.value {
+                guard let allMemberList = data.detail?.members else { return }
+                let memberList = allMemberList.filter { $0.username != UserDefaultStorage.nickname }
+                DispatchQueue.main.async {
+                    self.memberCollectionView.memberList = memberList.map { $0.username ?? "" }
+                }
+            }
         }
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/SelectFeedbackMember/SelectFeedbackMemberViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/SelectFeedbackMember/SelectFeedbackMemberViewController.swift
@@ -36,7 +36,7 @@ final class SelectFeedbackMemberViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupCloseButtonAction()
-        fetchCurrentTeamMember(type: .fetchCurrentTeamMember(teamId: 1.description, userId: 1.description))
+        fetchCurrentTeamMember(type: .fetchCurrentTeamMember(teamId: 1, userId: 1))
     }
     
     override func render() {

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/SelectReflectionMember/SelectReflectionMemberViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/SelectReflectionMember/SelectReflectionMemberViewController.swift
@@ -22,7 +22,7 @@ final class SelectReflectionMemberViewController: BaseViewController {
     }()
     private let memberCollectionView: MemberCollectionView = {
         let collectionView = MemberCollectionView()
-        collectionView.memberList = Member.getTotalMemberList()
+//        collectionView.memberList = Member.getTotalMemberList()
         return collectionView
     }()
     private lazy var feedbackDoneButton: MainButton = {

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/SelectReflectionMember/SelectReflectionMemberViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/SelectReflectionMember/SelectReflectionMemberViewController.swift
@@ -20,7 +20,7 @@ final class SelectReflectionMemberViewController: BaseViewController {
         label.setTitleFont(text: TextLiteral.selectReflectionMemberViewControllerTitleLabel)
         return label
     }()
-    private let memberCollectionView = MemberCollectionView(type: .selectMember)
+    private let memberCollectionView = MemberCollectionView(type: .progressReflection)
     private lazy var feedbackDoneButton: MainButton = {
         let button = MainButton()
         button.title = TextLiteral.selectReflectionMemberViewControllerDoneButtonText + "(0/\(memberCollectionView.memberList.count))"

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/SelectReflectionMember/SelectReflectionMemberViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/SelectReflectionMember/SelectReflectionMemberViewController.swift
@@ -20,11 +20,7 @@ final class SelectReflectionMemberViewController: BaseViewController {
         label.setTitleFont(text: TextLiteral.selectReflectionMemberViewControllerTitleLabel)
         return label
     }()
-    private let memberCollectionView: MemberCollectionView = {
-        let collectionView = MemberCollectionView()
-//        collectionView.memberList = Member.getTotalMemberList()
-        return collectionView
-    }()
+    private let memberCollectionView = MemberCollectionView(type: .selectMember)
     private lazy var feedbackDoneButton: MainButton = {
         let button = MainButton()
         button.title = TextLiteral.selectReflectionMemberViewControllerDoneButtonText + "(0/\(memberCollectionView.memberList.count))"

--- a/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackDetail/MyFeedbackDetailViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackDetail/MyFeedbackDetailViewController.swift
@@ -268,7 +268,7 @@ final class MyFeedbackDetailViewController: BaseViewController {
     private func setupMainButton() {
         let action = UIAction { [weak self ] _ in
             // FIXME: - 내 데이터는 유저디폴트로 변경
-            self?.navigationController?.pushViewController(MyFeedbackEditViewController(from: "나", to: "케미"), animated: true)
+            self?.navigationController?.pushViewController(MyFeedbackEditViewController(to: "케미", toUserId: 0), animated: true)
         }
         feedbackEditButton.addAction(action, for: .touchUpInside)
     }

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/SetNickname/SetNicknameViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/SetNickname/SetNicknameViewController.swift
@@ -87,7 +87,7 @@ final class SetNicknameViewController: BaseTextFieldViewController {
             if let json = json.value {
                 dump(json)
                 guard let nickname = json.detail?.username,
-                      let userId = json.detail?.id
+                      let userId = json.detail?.userId
                 else { return }
                 UserDefaultHandler.setUserID(userID: userId)
                 UserDefaultHandler.setNickname(nickname: nickname)


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
특정 팀원에게 피드백을 추가하는 API를 연결했습니다. 

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
피드백 추가하기 API 연결
현재 멤버를 선택하는 컬렉션 뷰가 공통으로 사용되고 있었는데, 피드백을 추가할 땐 해당 cell이 선택되었다고 표시될 필요가 없습니다. 그 부분까지 같이 수정했습니다.
현재 팀의 멤버들을 불러오는 과정에서 id값도 같이 오는데, 그 값을 다음 뷰컨으로 넘겨주는 방식으로 사용했습니다 !



## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
feature/113-add-feedback-api 브랜치로 오셔서, 실제 피드백을 추가해보시면 됩니다 !

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->

https://user-images.githubusercontent.com/78677571/202396531-c0f2b172-9a89-44d7-89e0-807dff99cfca.mp4




## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
현재 teamId, reflectionId, userId들은 하드코딩방식으로 넣어뒀습니다.
추후에 수정하려고 fixme를 적어두었습니다 !

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #113 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
