### PR TITLE
[FEAT] 현재 팀, 현재 회고의 피드백 추가하기 기능 추가

### DIFF
--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/CollectionView/MemberCollectionView/MemberCollectionView.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/CollectionView/MemberCollectionView/MemberCollectionView.swift
@@ -85,7 +85,7 @@ extension MemberCollectionView: UICollectionViewDelegate {
         case .addFeedback:
             didTappedFeedBackMember?(memberList[indexPath.item])
         case .progressReflection:
-            if !selectedMemberList.contains(where: { $0.username == memberList[indexPath.item].username} ) {
+            if !selectedMemberList.contains(where: { $0.userName == memberList[indexPath.item].userName} ) {
                 selectedMemberList.append(memberList[indexPath.item])
             }
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MemberCollectionViewCell.className, for: indexPath) as? MemberCollectionViewCell else { return }
@@ -105,7 +105,7 @@ extension MemberCollectionView: UICollectionViewDataSource {
             assert(false, "Wrong Cell")
             return UICollectionViewCell()
         }
-        cell.memberLabel.text = memberList[indexPath.item].username
+        cell.memberLabel.text = memberList[indexPath.item].userName
         return cell
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/View/AlertViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/View/AlertViewController.swift
@@ -267,11 +267,11 @@ final class AlertViewController: BaseViewController {
                    method: type.method,
                    parameters: type.body,
                    encoder: JSONParameterEncoder.default
-        ).responseDecodable(of: BaseModel<MemberResponse>.self) { [weak self] json in
+        ).responseDecodable(of: BaseModel<JoimMemberResponse>.self) { [weak self] json in
             guard let self else { return }
             if let json = json.value {
                 dump(json)
-                guard let userId = json.detail?.userId
+                guard let userId = json.detail?.id
                 else { return }
                 UserDefaultHandler.setUserId(userId: userId)
                 self.dispatchJoinTeam(type: .dispatchJoinTeam(teamId: UserDefaultStorage.teamId))

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/View/AlertViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/View/AlertViewController.swift
@@ -271,7 +271,7 @@ final class AlertViewController: BaseViewController {
             guard let self else { return }
             if let json = json.value {
                 dump(json)
-                guard let userId = json.detail?.id
+                guard let userId = json.detail?.userId
                 else { return }
                 UserDefaultHandler.setUserId(userId: userId)
                 self.dispatchJoinTeam(type: .dispatchJoinTeam(teamId: UserDefaultStorage.teamId))

--- a/Maddori.Apple/Maddori.Apple/Network/EndPoint/AddFeedBackEndPoint.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/EndPoint/AddFeedBackEndPoint.swift
@@ -10,15 +10,15 @@ import Foundation
 import Alamofire
 
 enum AddFeedBackEndPoint<T: Encodable> {
-    case fetchCurrentTeamMember(teamId: Int, userId: Int)
-    case dispatchAddFeedBack(teamId: Int, reflectionId: Int, userId: Int, T)
+    case fetchCurrentTeamMember
+    case dispatchAddFeedBack(reflectionId: Int, T)
     
     var address: String {
         switch self {
-        case .fetchCurrentTeamMember(let teamId, _):
-            return "\(UrlLiteral.baseUrl)/teams/\(teamId)/members"
-        case .dispatchAddFeedBack(let teamId, let reflectionId, _, _):
-            return "\(UrlLiteral.baseUrl)/teams/\(teamId)/reflections/\(reflectionId)/feedbacks"
+        case .fetchCurrentTeamMember:
+            return "\(UrlLiteral.baseUrl)/teams/\(UserDefaultStorage.teamId)/members"
+        case .dispatchAddFeedBack(let reflectionId, _):
+            return "\(UrlLiteral.baseUrl)/teams/\(UserDefaultStorage.teamId)/reflections/\(reflectionId)/feedbacks"
         }
     }
 
@@ -35,18 +35,18 @@ enum AddFeedBackEndPoint<T: Encodable> {
         switch self {
         case .fetchCurrentTeamMember:
             return nil
-        case .dispatchAddFeedBack(_, _, _, let body):
+        case .dispatchAddFeedBack(_, let body):
             return body
         }
     }
     
     var headers: HTTPHeaders? {
         switch self {
-        case .fetchCurrentTeamMember(_, let userId):
-            let headers = ["user_id": "\(userId)"]
+        case .fetchCurrentTeamMember:
+            let headers = ["user_id": "\(UserDefaultStorage.userId)"]
             return HTTPHeaders(headers)
-        case .dispatchAddFeedBack(_, _, let userId, _):
-            let headers = ["user_id": "\(userId)"]
+        case .dispatchAddFeedBack:
+            let headers = ["user_id": "\(UserDefaultStorage.userId)"]
             return HTTPHeaders(headers)
         }
     }

--- a/Maddori.Apple/Maddori.Apple/Network/EndPoint/HomeEndPoint.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/EndPoint/HomeEndPoint.swift
@@ -8,15 +8,15 @@
 import Alamofire
 
 enum HomeEndPoint {
-    case fetchCertainTeamDetail(teamId: Int)
-    case fetchCurrentReflectionDetail(teamId: Int)
+    case fetchCertainTeamDetail
+    case fetchCurrentReflectionDetail
     
     var address: String {
         switch self {
-        case .fetchCertainTeamDetail(let teamId):
-            return "\(UrlLiteral.baseUrl)/teams/\(teamId)"
-        case .fetchCurrentReflectionDetail(let teamId):
-            return "\(UrlLiteral.baseUrl)/teams/\(teamId)/reflections/current"
+        case .fetchCertainTeamDetail:
+            return "\(UrlLiteral.baseUrl)/teams/\(UserDefaultStorage.teamId)"
+        case .fetchCurrentReflectionDetail:
+            return "\(UrlLiteral.baseUrl)/teams/\(UserDefaultStorage.teamId)/reflections/current"
         }
     }
     

--- a/Maddori.Apple/Maddori.Apple/Network/Response/MemberResponse.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/Response/MemberResponse.swift
@@ -17,3 +17,14 @@ struct MemberResponse: Decodable {
         case userName = "username"
     }
 }
+
+// FIXME: - 서버의 response값이 통일되지 않아서 두 가지로 나누어 사용하다 추후에 서버에서 합치면 그 때 둘 중 하나를 없앱니다.
+struct JoimMemberResponse: Decodable {
+    let id: Int?
+    let userName: String?
+    
+    enum CodingKeys: String, CodingKey {
+        case id
+        case userName = "username"
+    }
+}

--- a/Maddori.Apple/Maddori.Apple/Network/Response/MemberResponse.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/Response/MemberResponse.swift
@@ -9,6 +9,11 @@ import Foundation
 
 struct MemberResponse: Decodable {
     // MARK: - userLogin
-    let id: Int?
-    let username: String?
+    let userId: Int?
+    let userName: String?
+    
+    enum CodingKeys: String, CodingKey {
+        case userId = "user_id"
+        case userName = "username"
+    }
 }

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/AddFeedback/AddFeedbackViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/AddFeedback/AddFeedbackViewController.swift
@@ -20,12 +20,14 @@ class AddFeedbackViewController: BaseViewController {
     var type: FeedBackDTO = .continueType
     var toNickname: String
     var toUserId: Int
+    var currentReflectionId: Int
     var keywordHasText: Bool = false
     var contentHasText: Bool = false
     
-    init(to: String, toUserId: Int) {
+    init(to: String, toUserId: Int, reflectionId: Int) {
         self.toNickname = to
         self.toUserId = toUserId
+        self.currentReflectionId = reflectionId
         super.init()
     }
     
@@ -366,7 +368,7 @@ class AddFeedbackViewController: BaseViewController {
         else { return }
         let dto = FeedBackContentDTO(type: type, keyword: keyword, content: content, start_content: startContent, to_id: toUserId)
         // FIXME: - 각 id들 UserDefault에 저장되어 있는 값을 불러와야 함.
-        dispatchAddFeedBack(type: .dispatchAddFeedBack(teamId: 1, reflectionId: 2, userId: 1, dto))
+        dispatchAddFeedBack(type: .dispatchAddFeedBack(reflectionId: currentReflectionId, dto))
     }
     
     // MARK: - api

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/Home/HomeViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/Home/HomeViewController.swift
@@ -11,7 +11,7 @@ import Alamofire
 import SnapKit
 
 final class HomeViewController: BaseViewController {
-    
+    var currentReflectionId: Int = 0
     var keywordList: [String] = [
         TextLiteral.homeViewControllerCollectionViewEmtpyText0,
         TextLiteral.homeViewControllerCollectionViewEmtpyText1,
@@ -121,8 +121,8 @@ final class HomeViewController: BaseViewController {
         super.viewWillAppear(animated)
         
         // FIXME: - teamId 와 userId는 일단은 UserDefaults에서 -> 추후에 토큰으로
-        fetchCertainTeamDetail(type: .fetchCertainTeamDetail(teamId: UserDefaultStorage.teamId))
-        fetchCurrentReflectionDetail(type: .fetchCurrentReflectionDetail(teamId: UserDefaultStorage.teamId))
+        fetchCertainTeamDetail(type: .fetchCertainTeamDetail)
+        fetchCurrentReflectionDetail(type: .fetchCurrentReflectionDetail)
     }
     
     override func configUI() {
@@ -200,7 +200,7 @@ final class HomeViewController: BaseViewController {
     }
     
     private func didTapAddFeedbackButton() {
-        let viewController = UINavigationController(rootViewController: SelectFeedbackMemberViewController())
+        let viewController = UINavigationController(rootViewController: SelectFeedbackMemberViewController(currentReflectionId: self.currentReflectionId))
         viewController.modalPresentationStyle = .fullScreen
         present(viewController, animated: true)
     }
@@ -273,24 +273,31 @@ final class HomeViewController: BaseViewController {
             if let json = json.value {
                 
                 let reflectionDetail = json.detail
-                guard let reflectionDate = reflectionDetail?.reflectionDate?.formatDateString(to: "MM월 dd일 a hh시"),
-                      let reflectionStatus = reflectionDetail?.reflectionStatus,
-                      let reflectionKeywordList = reflectionDetail?.reflectionKeywords else { return }
+                guard let reflectionStatus = reflectionDetail?.reflectionStatus,
+                      let reflectionId = reflectionDetail?.currentReflectionId
+                else { return }
                 
-                if reflectionKeywordList.count > 0 {
-                    self.convertFetchedKeywordList(of: reflectionKeywordList)
-                    DispatchQueue.main.async {
-                        switch reflectionStatus {
-                        case .SettingRequired, .Done:
-                            self.descriptionLabel.text = TextLiteral.homeViewControllerEmptyDescriptionLabel
-                        case .Before:
-                            self.descriptionLabel.text = "다음 회고는 \(reflectionDate)입니다"
-                        case .Progressing:
-                            self.descriptionLabel.text = "다음 회고는 \(reflectionDate)입니다"
-                            self.showStartReflectionView()
+                self.currentReflectionId = reflectionId
+                if let reflectionKeywordList = reflectionDetail?.reflectionKeywords {
+                    if reflectionKeywordList.count > 0 {
+                        self.convertFetchedKeywordList(of: reflectionKeywordList)
+                        DispatchQueue.main.async {
+                            switch reflectionStatus {
+                            case .SettingRequired, .Done:
+                                self.descriptionLabel.text = TextLiteral.homeViewControllerEmptyDescriptionLabel
+                            case .Before:
+                                // FIXME: - 분기 처리 추가
+                                let reflectionDate = reflectionDetail?.reflectionDate?.formatDateString(to: "MM월 dd일 a hh시")
+                                self.descriptionLabel.text = "다음 회고는 \(reflectionDate)입니다"
+                            case .Progressing:
+                                // FIXME: - 분기 처리 추가
+                                let reflectionDate = reflectionDetail?.reflectionDate?.formatDateString(to: "MM월 dd일 a hh시")
+                                self.descriptionLabel.text = "다음 회고는 \(reflectionDate)입니다"
+                                self.showStartReflectionView()
+                            }
+                            self.flowLayout.count = reflectionKeywordList.count
+                            self.keywordCollectionView.reloadData()
                         }
-                        self.flowLayout.count = reflectionKeywordList.count
-                        self.keywordCollectionView.reloadData()
                     }
                 }
             }

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/SelectFeedbackMember/SelectFeedbackMemberViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/SelectFeedbackMember/SelectFeedbackMemberViewController.swift
@@ -11,7 +11,7 @@ import Alamofire
 import SnapKit
 
 final class SelectFeedbackMemberViewController: BaseViewController {
-    
+    var currentReflectionId: Int
     // MARK: - property
     
     private let closeButton = CloseButton(type: .system)
@@ -26,17 +26,24 @@ final class SelectFeedbackMemberViewController: BaseViewController {
     private lazy var memberCollectionView: MemberCollectionView = {
         let collectionView = MemberCollectionView(type: .addFeedback)
         collectionView.didTappedFeedBackMember = { [weak self] user in
-            self?.navigationController?.pushViewController(AddFeedbackViewController(to: user.username ?? "", toUserId: user.id ?? 0), animated: true)
+            self?.navigationController?.pushViewController(AddFeedbackViewController(to: user.userName ?? "", toUserId: user.userId ?? 0, reflectionId: self?.currentReflectionId ?? 0), animated: true)
         }
         return collectionView
     }()
     
     // MARK: - life cycle
     
+    init(currentReflectionId: Int) {
+        self.currentReflectionId = currentReflectionId
+        super.init()
+    }
+    
+    required init?(coder: NSCoder) { nil }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         setupCloseButtonAction()
-        fetchCurrentTeamMember(type: .fetchCurrentTeamMember(teamId: 1, userId: 1))
+        fetchCurrentTeamMember(type: .fetchCurrentTeamMember)
     }
     
     override func render() {
@@ -85,7 +92,7 @@ final class SelectFeedbackMemberViewController: BaseViewController {
             dump(json.value)
             if let data = json.value {
                 guard let allMemberList = data.detail?.members else { return }
-                let memberList = allMemberList.filter { $0.username != UserDefaultStorage.nickname }
+                let memberList = allMemberList.filter { $0.userName != UserDefaultStorage.nickname }
                 DispatchQueue.main.async {
                     self.memberCollectionView.memberList = memberList
                 }

--- a/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackDetail/MyFeedbackDetailViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackDetail/MyFeedbackDetailViewController.swift
@@ -268,7 +268,7 @@ final class MyFeedbackDetailViewController: BaseViewController {
     private func setupMainButton() {
         let action = UIAction { [weak self ] _ in
             // FIXME: - 내 데이터는 유저디폴트로 변경
-            self?.navigationController?.pushViewController(MyFeedbackEditViewController(to: "케미", toUserId: 0), animated: true)
+            self?.navigationController?.pushViewController(MyFeedbackEditViewController(to: "케미", toUserId: 0, reflectionId: 0), animated: true)
         }
         feedbackEditButton.addAction(action, for: .touchUpInside)
     }

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/CreateTeam/CreateTeamViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/CreateTeam/CreateTeamViewController.swift
@@ -109,11 +109,9 @@ final class CreateTeamViewController: BaseTextFieldViewController {
         ).responseDecodable(of: BaseModel<MemberResponse>.self) { json in
             if let json = json.value {
                 dump(json)
-                guard let nickname = json.detail?.userName,
-                      let userId = json.detail?.userId
+                guard let userId = json.detail?.userId
                 else { return }
                 UserDefaultHandler.setUserId(userId : userId)
-                UserDefaultHandler.setNickname(nickname: nickname)
                 DispatchQueue.main.async {
                     self.pushInvitationViewController()
                 }

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/CreateTeam/CreateTeamViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/CreateTeam/CreateTeamViewController.swift
@@ -109,8 +109,8 @@ final class CreateTeamViewController: BaseTextFieldViewController {
         ).responseDecodable(of: BaseModel<MemberResponse>.self) { json in
             if let json = json.value {
                 dump(json)
-                guard let nickname = json.detail?.username,
-                      let userId = json.detail?.id
+                guard let nickname = json.detail?.userName,
+                      let userId = json.detail?.userId
                 else { return }
                 UserDefaultHandler.setUserId(userId : userId)
                 UserDefaultHandler.setNickname(nickname: nickname)


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
테스트 하는 과정에서, 다같이 한 팀에 들어와서 서로에게 피드백을 보내고 그 데이터로 다른 API들을 테스트하기 위함입니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
HomeViewController에서 데이터가 로드 안되는 문제를 해결했습니다. 안되던 이유는 guard let으로 nil값을 풀다가 guard let 구문에 걸려서 실행이 안되는 문제였습니다.
현재 팀의 멤버에게 피드백을 작성할 수 있게 구현했습니다 
`MemberResponse` 모델의 id값이 userId로 변경되어 있어서 그 부분을 수정했습니다 !


## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
테스트할 땐 teamId가 3 이어야합니다. 혹시 다른 작업하다가 UserDefault의 teamId가 바뀌었다면 3번으로 수정 될 수 있게 처리한 후 테스트해주세요 ! 
userId도 현재 팀에 들어와있는 id값 이어야 합니다. 아까 현재 회고에 들어오신 id 값을 사용하시면 됩니다 !

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->

https://user-images.githubusercontent.com/78677571/202709230-d43e354a-95c4-47aa-928a-86ca00b64a8b.MP4



## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
현재 HomeViewController에서 현재 회고에 대한 정보를 불러올 때
<img width="418" alt="image" src="https://user-images.githubusercontent.com/78677571/202708449-5d7d66a6-cb9a-4673-9f0d-5b362e58db92.png">
이 4개의 데이터중 `current_reflection_id`, `reflection_name` 이 두 데이터만 무조건 있고, 나머지 두개 데이터는 값이 비어있거나 없을수가 있어서 `guard let`구문으로 풀면 오류가 생길 수 있습니다. 
현재는 fixme를 적어두고 아래에서 if let으로 처리해두었습니다.

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #133 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
