### PR TITLE
[FEAT] 보관함 탭 API + View 연결

### DIFF
--- a/Maddori.Apple/Maddori.Apple/Network/EndPoint/MyFeedBackEndPoint.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/EndPoint/MyFeedBackEndPoint.swift
@@ -8,15 +8,15 @@
 import Alamofire
 
 enum MyFeedBackEndPoint<T: Encodable> {
-    case fetchCurrentTeamMember(teamId: Int, userId: Int)
+    case fetchCurrentTeamMember
     case fetchCertainMemberFeedBack(teamId: Int, memberId: Int, userId: Int)
     case deleteFeedBack(teamId: Int, reflectionId: Int, feedBackId: Int, userId: Int)
     case putEditFeedBack(teamId: Int, reflectionId: Int, feedBackId: Int, T, userId: Int)
     
     var address: String {
         switch self {
-        case .fetchCurrentTeamMember(let teamId, _):
-            return "\(UrlLiteral.baseUrl)/teams/\(teamId)/members"
+        case .fetchCurrentTeamMember:
+            return "\(UrlLiteral.baseUrl)/teams/\(UserDefaultStorage.teamId)/members"
         case .fetchCertainMemberFeedBack(let teamId, let memberId, _):
             return "\(UrlLiteral.baseUrl)/teams/\(teamId)/reflections/current/feedbacks/from-me?members=\(memberId)"
         case .deleteFeedBack(let teamId, let reflectionId, let feedBackId, _):
@@ -54,8 +54,8 @@ enum MyFeedBackEndPoint<T: Encodable> {
     
     var headers: HTTPHeaders? {
         switch self {
-        case .fetchCurrentTeamMember(_, let userId):
-            let headers = ["user_id": "\(userId)"]
+        case .fetchCurrentTeamMember:
+            let headers = ["user_id": "\(UserDefaultStorage.userId)"]
             return HTTPHeaders(headers)
         case .fetchCertainMemberFeedBack(_, _, let userId):
             let headers = ["user_id": "\(userId)"]

--- a/Maddori.Apple/Maddori.Apple/Network/EndPoint/MyFeedBackEndPoint.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/EndPoint/MyFeedBackEndPoint.swift
@@ -9,7 +9,7 @@ import Alamofire
 
 enum MyFeedBackEndPoint<T: Encodable> {
     case fetchCurrentTeamMember
-    case fetchCertainMemberFeedBack(teamId: Int, memberId: Int, userId: Int)
+    case fetchCertainMemberFeedBack(memberId: Int)
     case deleteFeedBack(teamId: Int, reflectionId: Int, feedBackId: Int, userId: Int)
     case putEditFeedBack(teamId: Int, reflectionId: Int, feedBackId: Int, T, userId: Int)
     
@@ -17,8 +17,8 @@ enum MyFeedBackEndPoint<T: Encodable> {
         switch self {
         case .fetchCurrentTeamMember:
             return "\(UrlLiteral.baseUrl)/teams/\(UserDefaultStorage.teamId)/members"
-        case .fetchCertainMemberFeedBack(let teamId, let memberId, _):
-            return "\(UrlLiteral.baseUrl)/teams/\(teamId)/reflections/current/feedbacks/from-me?members=\(memberId)"
+        case .fetchCertainMemberFeedBack(let memberId):
+            return "\(UrlLiteral.baseUrl)/teams/\(UserDefaultStorage.teamId)/reflections/current/feedbacks/from-me?members=\(memberId)"
         case .deleteFeedBack(let teamId, let reflectionId, let feedBackId, _):
             return "\(UrlLiteral.baseUrl)/teams/\(teamId)/reflections/\(reflectionId)/feedbacks/\(feedBackId)"
         case .putEditFeedBack(let teamId, let reflectionId, let feedBackId, _, _):
@@ -57,8 +57,8 @@ enum MyFeedBackEndPoint<T: Encodable> {
         case .fetchCurrentTeamMember:
             let headers = ["user_id": "\(UserDefaultStorage.userId)"]
             return HTTPHeaders(headers)
-        case .fetchCertainMemberFeedBack(_, _, let userId):
-            let headers = ["user_id": "\(userId)"]
+        case .fetchCertainMemberFeedBack:
+            let headers = ["user_id": "\(UserDefaultStorage.userId)"]
             return HTTPHeaders(headers)
         case .deleteFeedBack(_, _, _, let userId):
             let headers = ["user_id": "\(userId)"]

--- a/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedback/MyFeedbackViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedback/MyFeedbackViewController.swift
@@ -122,7 +122,7 @@ final class MyFeedbackViewController: BaseViewController {
         ).responseDecodable(of: BaseModel<FeedBackInfoResponse>.self) { json in
             if let data = json.value {
                 guard let detail = data.detail else { return }
-                self.feedbackCollectionView.mockData = detail
+                self.feedbackCollectionView.feedbackInfo = detail
                 dump(data)
             }
         }

--- a/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedback/MyFeedbackViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedback/MyFeedbackViewController.swift
@@ -70,7 +70,6 @@ final class MyFeedbackViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         fetchCurrentTeamMember(type: .fetchCurrentTeamMember)
-//        fetchCertainMemberFeedBack(type: .fetchCertainMemberFeedBack(memberId: 2))
     }
     
     override func render() {
@@ -122,7 +121,6 @@ final class MyFeedbackViewController: BaseViewController {
                    headers: type.headers
         ).responseDecodable(of: BaseModel<FeedBackInfoResponse>.self) { json in
             if let data = json.value {
-                // FIXME: - collectionView에 데이터 전달
                 guard let detail = data.detail else { return }
                 self.feedbackCollectionView.mockData = detail
                 dump(data)

--- a/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedback/MyFeedbackViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedback/MyFeedbackViewController.swift
@@ -70,7 +70,7 @@ final class MyFeedbackViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         fetchCurrentTeamMember(type: .fetchCurrentTeamMember)
-        fetchCertainMemberFeedBack(type: .fetchCertainMemberFeedBack(teamId: 1, memberId: 2, userId: 1))
+//        fetchCertainMemberFeedBack(type: .fetchCertainMemberFeedBack(memberId: 2))
     }
     
     override func render() {
@@ -123,6 +123,8 @@ final class MyFeedbackViewController: BaseViewController {
         ).responseDecodable(of: BaseModel<FeedBackInfoResponse>.self) { json in
             if let data = json.value {
                 // FIXME: - collectionView에 데이터 전달
+                guard let detail = data.detail else { return }
+                self.feedbackCollectionView.mockData = detail
                 dump(data)
             }
         }
@@ -131,7 +133,12 @@ final class MyFeedbackViewController: BaseViewController {
 
 // MARK: - extension
 
-extension MyFeedbackViewController: UICollectionViewDelegate { }
+extension MyFeedbackViewController: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard let memberId = memberList[indexPath.item].userId else { return }
+        fetchCertainMemberFeedBack(type: .fetchCertainMemberFeedBack(memberId: memberId))
+    }
+}
 
 extension MyFeedbackViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {

--- a/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedback/UIComponent/MyFeedbackCollectionView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedback/UIComponent/MyFeedbackCollectionView.swift
@@ -123,7 +123,6 @@ extension MyFeedbackCollectionView: UICollectionViewDataSource {
             cell.emptyFeedbackLabel.text = TextLiteral.emptyViewMyBox
             return cell
         } else {
-            
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MyFeedbackCollectionViewCell.className, for: indexPath) as? MyFeedbackCollectionViewCell else { return UICollectionViewCell() }
             guard let data = mockData else { return UICollectionViewCell() }
             let hasContinue = !data.continueArray.isEmpty
@@ -165,7 +164,7 @@ extension MyFeedbackCollectionView: UICollectionViewDelegateFlowLayout {
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        guard let data = mockData else { return .zero}
+        guard let data = mockData else { return .zero }
         if data.continueArray.isEmpty && data.stopArray.isEmpty {
             return CGSize(width: 300, height: 400)
         } else {

--- a/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedback/UIComponent/MyFeedbackCollectionView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedback/UIComponent/MyFeedbackCollectionView.swift
@@ -11,7 +11,7 @@ import SnapKit
 
 final class MyFeedbackCollectionView: UIView {
     var didTappedCell: ((Int) -> ())?
-    var mockData: FeedBackInfoResponse? {
+    var feedbackInfo: FeedBackInfoResponse? {
         didSet {
             feedbackCollectionView.reloadData()
         }
@@ -71,14 +71,14 @@ final class MyFeedbackCollectionView: UIView {
 extension MyFeedbackCollectionView: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
         guard let header = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: MyFeedbackHeaderView.className, for: indexPath) as? MyFeedbackHeaderView else { return UICollectionReusableView() }
-        if let mockData {
+        if let feedbackInfo {
             if indexPath.section == 0 {
                 header.setDividerHidden(true)
             } else {
                 header.setDividerHidden(false)
             }
-            let hasContinue = !mockData.continueArray.isEmpty
-            let hasOnlyStop = !mockData.stopArray.isEmpty
+            let hasContinue = !feedbackInfo.continueArray.isEmpty
+            let hasOnlyStop = !feedbackInfo.stopArray.isEmpty
             if hasContinue {
                 header.isHidden = false
                 header.setCssLabelText(with: indexPath.section)
@@ -104,7 +104,7 @@ extension MyFeedbackCollectionView: UICollectionViewDelegate {
 }
 extension MyFeedbackCollectionView: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        guard let data = mockData else { return 0 }
+        guard let data = feedbackInfo else { return 0 }
         if data.continueArray.isEmpty && data.stopArray.isEmpty {
             return 1
         }
@@ -117,14 +117,14 @@ extension MyFeedbackCollectionView: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let data = mockData else { return UICollectionViewCell() }
+        guard let data = feedbackInfo else { return UICollectionViewCell() }
         if data.continueArray.isEmpty && data.stopArray.isEmpty {
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: EmptyFeedbackView.className, for: indexPath) as? EmptyFeedbackView else { return UICollectionViewCell() }
             cell.emptyFeedbackLabel.text = TextLiteral.emptyViewMyBox
             return cell
         } else {
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MyFeedbackCollectionViewCell.className, for: indexPath) as? MyFeedbackCollectionViewCell else { return UICollectionViewCell() }
-            guard let data = mockData else { return UICollectionViewCell() }
+            guard let data = feedbackInfo else { return UICollectionViewCell() }
             let hasContinue = !data.continueArray.isEmpty
             switch indexPath.section {
             case 0:
@@ -149,7 +149,7 @@ extension MyFeedbackCollectionView: UICollectionViewDataSource {
     }
     
     func numberOfSections(in collectionView: UICollectionView) -> Int {
-        guard let data = mockData else { return 1 }
+        guard let data = feedbackInfo else { return 1 }
         if !data.continueArray.isEmpty && !data.stopArray.isEmpty {
             return 2
         } else {
@@ -164,21 +164,21 @@ extension MyFeedbackCollectionView: UICollectionViewDelegateFlowLayout {
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        guard let data = mockData else { return .zero }
+        guard let data = feedbackInfo else { return .zero }
         if data.continueArray.isEmpty && data.stopArray.isEmpty {
             return CGSize(width: 300, height: 300)
         } else {
             var feedbackList: [String] = []
-            guard let data = mockData else { return .zero}
+            guard let data = feedbackInfo else { return .zero}
             let hasContinue = !data.continueArray.isEmpty
             if hasContinue {
                 if indexPath.section == 0 {
-                    feedbackList = mockData?.continueArray.map { $0.content ?? "" } ?? []
+                    feedbackList = feedbackInfo?.continueArray.map { $0.content ?? "" } ?? []
                 } else {
-                    feedbackList = mockData?.stopArray.map { $0.content ?? "" } ?? []
+                    feedbackList = feedbackInfo?.stopArray.map { $0.content ?? "" } ?? []
                 }
             } else {
-                feedbackList = mockData?.stopArray.map { $0.content ?? "" } ?? []
+                feedbackList = feedbackInfo?.stopArray.map { $0.content ?? "" } ?? []
             }
             let cellHeight = UILabel.textSize(font: .body2, text: feedbackList[indexPath.item], width: Size.cellContentWidth - 24, height: 0).height
             let isOneTextLine = cellHeight < 18

--- a/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedback/UIComponent/MyFeedbackCollectionView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedback/UIComponent/MyFeedbackCollectionView.swift
@@ -166,7 +166,7 @@ extension MyFeedbackCollectionView: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         guard let data = mockData else { return .zero }
         if data.continueArray.isEmpty && data.stopArray.isEmpty {
-            return CGSize(width: 300, height: 400)
+            return CGSize(width: 300, height: 300)
         } else {
             var feedbackList: [String] = []
             guard let data = mockData else { return .zero}

--- a/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedback/UIComponent/MyFeedbackCollectionView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedback/UIComponent/MyFeedbackCollectionView.swift
@@ -169,7 +169,7 @@ extension MyFeedbackCollectionView: UICollectionViewDelegateFlowLayout {
             return CGSize(width: 300, height: 300)
         } else {
             var feedbackList: [String] = []
-            guard let data = feedbackInfo else { return .zero}
+            guard let data = feedbackInfo else { return .zero }
             let hasContinue = !data.continueArray.isEmpty
             if hasContinue {
                 if indexPath.section == 0 {

--- a/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedback/UIComponent/MyFeedbackCollectionView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedback/UIComponent/MyFeedbackCollectionView.swift
@@ -78,10 +78,15 @@ extension MyFeedbackCollectionView: UICollectionViewDelegate {
                 header.setDividerHidden(false)
             }
             let hasContinue = !mockData.continueArray.isEmpty
+            let hasOnlyStop = !mockData.stopArray.isEmpty
             if hasContinue {
+                header.isHidden = false
                 header.setCssLabelText(with: indexPath.section)
-            } else {
+            } else if hasOnlyStop {
+                header.isHidden = false
                 header.setCssLabelText(with: 1)
+            } else {
+                header.isHidden = true
             }
             switch kind {
             case UICollectionView.elementKindSectionHeader:


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
보관함 탭 부분에 테스트할 DB가 없어서 테스트를 못하고 있었는데, 앞선 PR들로 테스트 할 수 있게 연결되어서 테스트 후 정상 작동하는 걸 확인하고 PR날립니다
항상 감사합니다 선생님들..❤️


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
보관함 탭에서 현재 팀원들의 멤버 목록 불러오는 API랑 View 랑 연결시켜뒀습니다 !
해당 멤버의 cell을 누르면 내가 해당 멤버에게 보낸 피드백을 볼 수 있습니다 !

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
feature/136-myfeedback-view-api 브랜치로 오셔서 실행시키면 됩니다 !
현재 회고중 상태라서 테스트가 가능한데, 상태가 변경되면 어떻게 될 지 모르겠습니다 !
피드백 추가해서 반영되는지 확인하려 했지만, 현재 회고가 진행중이라 피드백 추가가 안되더라구요 ... ㅠ 아마 잘 될겁니다 !

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->

https://user-images.githubusercontent.com/78677571/202775167-de494ccd-cdef-40b4-bd65-adb2809728f0.mov



## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
현재 탭으로 바로 들어왔을 때 첫번째 셀 (케미) 부분이 자동으로 load되지 않는데 어떤 방법을 쓰면 좋을지 생각중입니다..
피드백을 보여주는 collectionView 부분을 급하게 수정하느라 중복되는 코드들이 좀 있는데, 이 PR이 머지되기 전에 수정하겠습니다.

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #136 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
