### PR TITLE
[CHORE] HomeView isAdmin 인지에 따라 분기처리 완료

### DIFF
--- a/Maddori.Apple/Maddori.Apple/Screen/Home/Home/HomeViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/Home/HomeViewController.swift
@@ -11,7 +11,7 @@ import Alamofire
 import SnapKit
 
 final class HomeViewController: BaseViewController {
-    var currentReflectionId: Int = 0
+    
     var keywordList: [String] = [
         TextLiteral.homeViewControllerCollectionViewEmtpyText0,
         TextLiteral.homeViewControllerCollectionViewEmtpyText1,
@@ -31,6 +31,9 @@ final class HomeViewController: BaseViewController {
         static let subButtonHeight: CGFloat = 20
         static let planReflectionViewHeight: CGFloat = 40
     }
+    
+    var currentReflectionId: Int = 0
+    var isAdmin: Bool = false
     
     // MARK: - property
     
@@ -91,7 +94,14 @@ final class HomeViewController: BaseViewController {
         }
         labelButton.subText = TextLiteral.mainViewControllerPlanLabelButtonSubText
         labelButton.subButtonText = TextLiteral.mainViewControllerPlanLabelButtonSubButtonText
+        labelButton.tag = 100
         return labelButton
+    }()
+    private lazy var planLableButtonBackgroundView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .backgroundWhite
+        view.tag = 100
+        return view
     }()
     private lazy var addFeedbackButton: UIButton = {
         let button = UIButton()
@@ -183,13 +193,6 @@ final class HomeViewController: BaseViewController {
             $0.leading.trailing.equalTo(view.safeAreaLayoutGuide)
             $0.bottom.equalTo(addFeedbackButton.snp.top).offset(-10)
         }
-        
-        view.addSubview(planLabelButtonView)
-        planLabelButtonView.snp.makeConstraints {
-            $0.centerX.equalToSuperview()
-            $0.bottom.equalTo(addFeedbackButton.snp.top)
-            $0.height.equalTo(SizeLiteral.minimumTouchArea)
-        }
     }
     
     // MARK: - func
@@ -197,6 +200,20 @@ final class HomeViewController: BaseViewController {
     private func setUpDelegation() {
         keywordCollectionView.delegate = self
         keywordCollectionView.dataSource = self
+    }
+    
+    private func renderPlanLabelButton() {
+        view.addSubview(planLableButtonBackgroundView)
+        planLableButtonBackgroundView.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview()
+            $0.bottom.equalTo(addFeedbackButton.snp.top)
+            $0.height.equalTo(SizeLiteral.minimumTouchArea)
+        }
+        
+        planLableButtonBackgroundView.addSubview(planLabelButtonView)
+        planLabelButtonView.snp.makeConstraints {
+            $0.top.bottom.centerX.equalToSuperview()
+        }
     }
     
     private func didTapAddFeedbackButton() {
@@ -258,8 +275,12 @@ final class HomeViewController: BaseViewController {
         ).responseDecodable(of: BaseModel<CertainTeamDetailResponse>.self) { json in
             if let json = json.value {
                 guard let teamName = json.detail?.teamName else { return }
+                guard let isAdmin = json.detail?.admin else { return }
                 DispatchQueue.main.async {
                     self.teamNameLabel.setTitleFont(text: teamName)
+                    if isAdmin {
+                        self.renderPlanLabelButton()
+                    }
                 }
             }
         }
@@ -286,11 +307,13 @@ final class HomeViewController: BaseViewController {
                             case .SettingRequired, .Done:
                                 self.descriptionLabel.text = TextLiteral.homeViewControllerEmptyDescriptionLabel
                             case .Before:
-                                // FIXME: - 분기 처리 추가
+                                let view = self.view.viewWithTag(100)
+                                view?.removeFromSuperview()
                                 let reflectionDate = reflectionDetail?.reflectionDate?.formatDateString(to: "MM월 dd일 a hh시")
                                 self.descriptionLabel.text = "다음 회고는 \(reflectionDate)입니다"
                             case .Progressing:
-                                // FIXME: - 분기 처리 추가
+                                let view = self.view.viewWithTag(100)
+                                view?.removeFromSuperview()
                                 let reflectionDate = reflectionDetail?.reflectionDate?.formatDateString(to: "MM월 dd일 a hh시")
                                 self.descriptionLabel.text = "다음 회고는 \(reflectionDate)입니다"
                                 self.showStartReflectionView()

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/Home/HomeViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/Home/HomeViewController.swift
@@ -96,7 +96,7 @@ final class HomeViewController: BaseViewController {
         labelButton.subButtonText = TextLiteral.mainViewControllerPlanLabelButtonSubButtonText
         return labelButton
     }()
-    private lazy var planLableButtonBackgroundView: UIView = {
+    private let planLableButtonBackgroundView: UIView = {
         let view = UIView()
         view.backgroundColor = .backgroundWhite
         return view

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/Home/HomeViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/Home/HomeViewController.swift
@@ -94,13 +94,11 @@ final class HomeViewController: BaseViewController {
         }
         labelButton.subText = TextLiteral.mainViewControllerPlanLabelButtonSubText
         labelButton.subButtonText = TextLiteral.mainViewControllerPlanLabelButtonSubButtonText
-        labelButton.tag = 100
         return labelButton
     }()
     private lazy var planLableButtonBackgroundView: UIView = {
         let view = UIView()
         view.backgroundColor = .backgroundWhite
-        view.tag = 100
         return view
     }()
     private lazy var addFeedbackButton: UIButton = {
@@ -258,6 +256,11 @@ final class HomeViewController: BaseViewController {
         // FIXME: - 모달 띄우고 시작하기만 가능한 건 동작을 너무 제한시킴 -> 추가하기 버튼이 채워지면서 시작하기로 바뀌는건 어떨까?
     }
     
+    private func hidePlanLabelButton() {
+        planLabelButtonView.isHidden = true
+        planLableButtonBackgroundView.isHidden = true
+    }
+    
     private func convertFetchedKeywordList(of list: [String]) {
         keywordList = []
         for i in 0..<list.count {
@@ -274,8 +277,9 @@ final class HomeViewController: BaseViewController {
                    headers: type.header
         ).responseDecodable(of: BaseModel<CertainTeamDetailResponse>.self) { json in
             if let json = json.value {
-                guard let teamName = json.detail?.teamName else { return }
-                guard let isAdmin = json.detail?.admin else { return }
+                guard let teamName = json.detail?.teamName,
+                      let isAdmin = json.detail?.admin
+                else { return }
                 DispatchQueue.main.async {
                     self.teamNameLabel.setTitleFont(text: teamName)
                     if isAdmin {
@@ -307,13 +311,11 @@ final class HomeViewController: BaseViewController {
                             case .SettingRequired, .Done:
                                 self.descriptionLabel.text = TextLiteral.homeViewControllerEmptyDescriptionLabel
                             case .Before:
-                                let view = self.view.viewWithTag(100)
-                                view?.removeFromSuperview()
+                                self.hidePlanLabelButton()
                                 let reflectionDate = reflectionDetail?.reflectionDate?.formatDateString(to: "MM월 dd일 a hh시")
                                 self.descriptionLabel.text = "다음 회고는 \(reflectionDate)입니다"
                             case .Progressing:
-                                let view = self.view.viewWithTag(100)
-                                view?.removeFromSuperview()
+                                self.hidePlanLabelButton()
                                 let reflectionDate = reflectionDetail?.reflectionDate?.formatDateString(to: "MM월 dd일 a hh시")
                                 self.descriptionLabel.text = "다음 회고는 \(reflectionDate)입니다"
                                 self.showStartReflectionView()

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/Home/HomeViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/Home/HomeViewController.swift
@@ -96,7 +96,7 @@ final class HomeViewController: BaseViewController {
         labelButton.subButtonText = TextLiteral.mainViewControllerPlanLabelButtonSubButtonText
         return labelButton
     }()
-    private let planLableButtonBackgroundView: UIView = {
+    private let planLabelButtonBackgroundView: UIView = {
         let view = UIView()
         view.backgroundColor = .backgroundWhite
         return view
@@ -201,14 +201,14 @@ final class HomeViewController: BaseViewController {
     }
     
     private func renderPlanLabelButton() {
-        view.addSubview(planLableButtonBackgroundView)
-        planLableButtonBackgroundView.snp.makeConstraints {
+        view.addSubview(planLabelButtonBackgroundView)
+        planLabelButtonBackgroundView.snp.makeConstraints {
             $0.horizontalEdges.equalToSuperview()
             $0.bottom.equalTo(addFeedbackButton.snp.top)
             $0.height.equalTo(SizeLiteral.minimumTouchArea)
         }
         
-        planLableButtonBackgroundView.addSubview(planLabelButtonView)
+        planLabelButtonBackgroundView.addSubview(planLabelButtonView)
         planLabelButtonView.snp.makeConstraints {
             $0.top.bottom.centerX.equalToSuperview()
         }
@@ -258,7 +258,7 @@ final class HomeViewController: BaseViewController {
     
     private func hidePlanLabelButton() {
         planLabelButtonView.isHidden = true
-        planLableButtonBackgroundView.isHidden = true
+        planLabelButtonBackgroundView.isHidden = true
     }
     
     private func convertFetchedKeywordList(of list: [String]) {


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
백로그의 <뒤에 버튼 뷰넣기! 버튼용 백그라운드 뷰!>를 하는 김에
<회고 일정 생성과 관련된 리더/멤버 분기 처리 구현하기>도 같이 구현해뒀습니다!


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 회고 일정 만들기 뒤에 백그라운드 뷰 생성
- 회고 일정 생성 관련 리더 / 멤버 분기처리

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
총 3가지 상태가 있는데, 헷갈리지 않게 DB와 UserDefaults의 userId를 잘 바꿔가면서 테스트 해봐야 합니다!
1. teamId = 3, userId = 6 (맛도리테스트 팀에 admin일 때), DB에 회고 일정 SettingRequired일 때
2. teamId = 6, userId = 11 (홀리몰리 팀에 admin일 때), DB에 회고 일정 Before일 때 (다른거 테스트 하고 있는 관계로 홀리몰리팀으로 진행했습니다!)
3. teamId = 3, userId = 9 (맛도리테스트 팀에 admin 아닐 때)

1, 2 상황은 SceneDelegate에 
`UserData.setValue(6, forKey: .userId)`
`UserData.setValue(3, forKey: .teamId)`
를 넣고 실행하면 되구요,
**(2 상황은 값 다릅니다! 위에 2 상황 확인하고 넣어주세요!!)**

3번 상황은  SceneDelegate에 
`UserData.setValue(9, forKey: .userId)`
`UserData.setValue(3, forKey: .teamId)`
를 넣고 실행하면 됩니다!

DB는... 저한테 요청을 해주세요!! 밥먹을 때 아니면 슬랙 잘 보고 있을겁니다 하핳

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
|<img src="https://user-images.githubusercontent.com/72431640/202888920-71d7b301-3149-4ad5-8026-37f81d12ac58.png" width="300">|<img src="https://user-images.githubusercontent.com/72431640/202889301-217e9778-2618-4a18-ad42-d4590d0445d6.png" width="300">|<img src="https://user-images.githubusercontent.com/72431640/202888958-7bd168fb-c4f4-42b9-b272-39e4ad315bcc.png" width="300">|
|:---:|:---:|:---:|
|<center>1 상황</center>|<center>2 상황</center>|<center>3 상황</center>|

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
회고 일정 편집하는것도 넣을까.. 했는데 아직은 안넣어뒀습니다!
사실 그냥 회고 생성하는 API랑 같은거 호출하면 되는 것 같은데 UX writing과 위치 때문에 일단은 빼뒀습니다!!

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #141 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
