### PR TITLE
[CHORE] HomeView invitationCode 복사 구현

### DIFF
--- a/Maddori.Apple/Maddori.Apple/Screen/Home/Home/HomeViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/Home/HomeViewController.swift
@@ -213,6 +213,7 @@ final class HomeViewController: BaseViewController {
     private func showToastPopUp(of type: ToastType) {
         if !isTouched {
             isTouched = true
+            UIDevice.vibrate()
             DispatchQueue.main.async {
                 self.toastContentView.toastType = type
             }
@@ -340,7 +341,6 @@ extension HomeViewController: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        UIDevice.vibrate()
         showToastPopUp(of: .warning)
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/Home/HomeViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/Home/HomeViewController.swift
@@ -210,9 +210,12 @@ final class HomeViewController: BaseViewController {
         toastView.setGradient(colorTop: .gradientGrayTop, colorBottom: .gradientGrayBottom)
     }
     
-    private func showToastPopUp() {
+    private func showToastPopUp(of type: ToastType) {
         if !isTouched {
             isTouched = true
+            DispatchQueue.main.async {
+                self.toastContentView.toastType = type
+            }
             UIView.animate(withDuration: 0.5, delay: 0, animations: {
                 self.toastView.transform = CGAffineTransform(translationX: 0, y: 115)
             }, completion: {_ in
@@ -223,6 +226,14 @@ final class HomeViewController: BaseViewController {
                 })
             })
         }
+    }
+    
+    private func setupCopyCodeButton(code: String) {
+        let action = UIAction { [weak self] _ in
+            UIPasteboard.general.string = code
+            self?.showToastPopUp(of: .complete)
+        }
+        invitationCodeButton.addAction(action, for: .touchUpInside)
     }
     
     private func presentCreateReflectionViewController() {
@@ -258,8 +269,10 @@ final class HomeViewController: BaseViewController {
         ).responseDecodable(of: BaseModel<CertainTeamDetailResponse>.self) { json in
             if let json = json.value {
                 guard let teamName = json.detail?.teamName else { return }
+                guard let invitationCode = json.detail?.invitationCode else { return }
                 DispatchQueue.main.async {
                     self.teamNameLabel.setTitleFont(text: teamName)
+                    self.setupCopyCodeButton(code: invitationCode)
                 }
             }
         }
@@ -328,7 +341,7 @@ extension HomeViewController: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         UIDevice.vibrate()
-        showToastPopUp()
+        showToastPopUp(of: .warning)
     }
 }
 

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/Home/HomeViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/Home/HomeViewController.swift
@@ -42,7 +42,7 @@ final class HomeViewController: BaseViewController {
     }()
     private let toastContentView: ToastContentView = {
         let view = ToastContentView()
-        view.toastType = .warning
+        view.toastType = .complete
         return view
     }()
     private lazy var flowLayout: KeywordCollectionViewFlowLayout = {
@@ -213,7 +213,6 @@ final class HomeViewController: BaseViewController {
     private func showToastPopUp(of type: ToastType) {
         if !isTouched {
             isTouched = true
-            UIDevice.vibrate()
             DispatchQueue.main.async {
                 self.toastContentView.toastType = type
             }
@@ -341,6 +340,7 @@ extension HomeViewController: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        UIDevice.vibrate()
         showToastPopUp(of: .warning)
     }
 }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
백로그의 <초대코드 복사 로직 추가하기>의 HomeView 파트입니다!

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
HomeView의 상단 초대코드 버튼을 터치하면 코드가 복사되고, 햅틱도 추가해뒀습니다!

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
그냥 아무 팀에 들어가서 실행해보세요!!

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->

https://user-images.githubusercontent.com/72431640/202890877-ea3dc062-c83f-4e6f-95f7-ac1ffb3f716a.MP4



## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
showToastPopup이 현재는 warning만 지원했는데, type을 지정해서 warning 일 때, complete 일 때 선택할 수 있도록 바꿔뒀습니다!

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #143 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
