### PR TITLE
[CHORE] MyReflectionDetail의 Cell에 이름 lable 사이즈 재조정

### DIFF
--- a/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflectionDetail/Cell/MyReflectionDetailTableViewCell.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflectionDetail/Cell/MyReflectionDetailTableViewCell.swift
@@ -63,7 +63,6 @@ final class MyReflectionDetailTableViewCell: BaseTableViewCell {
         fromLabelBackView.snp.makeConstraints {
             $0.leading.equalTo(titleLabel.snp.trailing).offset(6)
             $0.centerY.equalTo(titleLabel.snp.centerY)
-            $0.height.equalTo(20)
         }
         
         fromLabelBackView.addSubview(fromLabel)

--- a/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflectionDetail/Cell/MyReflectionDetailTableViewCell.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflectionDetail/Cell/MyReflectionDetailTableViewCell.swift
@@ -63,13 +63,14 @@ final class MyReflectionDetailTableViewCell: BaseTableViewCell {
         fromLabelBackView.snp.makeConstraints {
             $0.leading.equalTo(titleLabel.snp.trailing).offset(6)
             $0.centerY.equalTo(titleLabel.snp.centerY)
-            $0.width.equalTo(33)
             $0.height.equalTo(20)
         }
         
         fromLabelBackView.addSubview(fromLabel)
         fromLabel.snp.makeConstraints {
-            $0.center.equalToSuperview()
+            $0.top.equalToSuperview().inset(3)
+            $0.bottom.equalToSuperview().inset(2)
+            $0.horizontalEdges.equalToSuperview().inset(4)
         }
         
         contentView.addSubview(contentLabel)


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
백로그의 <나의 회고 디테일에서 이름 뷰 잘림>을 해결하기 위해 나온 PR 입니다!

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- constraints 조정

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
```swift
UserDefaultHandler.clearAllData()
UserData.setValue(11, forKey: .userId)
UserData.setValue(6, forKey: .teamId)
UserData.setValue(true, forKey: .isLogin)
```
를 SceneDelegate에 넣어서 '나의 회고' 아무 회고 들어가서 확인하시면 됩니다!

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<img src="https://user-images.githubusercontent.com/72431640/203496081-af4633fe-dc92-4607-a782-6a387140fda1.png" width="400">



## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #163


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
