### PR TITLE
[FEAT] 로그아웃 구현 

### DIFF
--- a/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
+++ b/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
@@ -117,6 +117,7 @@
 		7E6B662F28FE887300C3BEEF /* UILabel+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6B662E28FE887300C3BEEF /* UILabel+Extension.swift */; };
 		7E7F160B2921CC4800C6BE96 /* CustomTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7F160A2921CC4800C6BE96 /* CustomTabBarController.swift */; };
 		7E7F160F2921CD4A00C6BE96 /* UITabBar+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7F160E2921CD4A00C6BE96 /* UITabBar+Extension.swift */; };
+		7E8CDC67292E19B000984742 /* LogOutButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8CDC66292E19B000984742 /* LogOutButton.swift */; };
 		7EB4D58229011EF7001FC396 /* JoinTeamViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EB4D58129011EF7001FC396 /* JoinTeamViewController.swift */; };
 		7EE38BAD2925DDD200FD738D /* EncodeDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EE38BAC2925DDD200FD738D /* EncodeDTO.swift */; };
 		7EE38BB3292623F500FD738D /* MyReflectionEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EE38BB2292623F500FD738D /* MyReflectionEndPoint.swift */; };
@@ -241,6 +242,7 @@
 		7E6B662E28FE887300C3BEEF /* UILabel+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+Extension.swift"; sourceTree = "<group>"; };
 		7E7F160A2921CC4800C6BE96 /* CustomTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTabBarController.swift; sourceTree = "<group>"; };
 		7E7F160E2921CD4A00C6BE96 /* UITabBar+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITabBar+Extension.swift"; sourceTree = "<group>"; };
+		7E8CDC66292E19B000984742 /* LogOutButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogOutButton.swift; sourceTree = "<group>"; };
 		7EB4D58129011EF7001FC396 /* JoinTeamViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinTeamViewController.swift; sourceTree = "<group>"; };
 		7EE38BAC2925DDD200FD738D /* EncodeDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncodeDTO.swift; sourceTree = "<group>"; };
 		7EE38BB2292623F500FD738D /* MyReflectionEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyReflectionEndPoint.swift; sourceTree = "<group>"; };
@@ -512,6 +514,7 @@
 				525E722028FFC9A800EF3FCB /* BackButton.swift */,
 				395C7E1C28FEC8C400FC2FCA /* CloseButton.swift */,
 				395C7E0C28F959A500FC2FCA /* MainButton.swift */,
+				7E8CDC66292E19B000984742 /* LogOutButton.swift */,
 			);
 			path = Button;
 			sourceTree = "<group>";
@@ -1021,6 +1024,7 @@
 				3EA341E82925E5EA005CBD1C /* String+Extension.swift in Sources */,
 				D7AFB7C72916FF9400E998B7 /* CustomSegmentControl.swift in Sources */,
 				52FA42A02906608E00C35824 /* Date+Extension.swift in Sources */,
+				7E8CDC67292E19B000984742 /* LogOutButton.swift in Sources */,
 				39F5582B2908027500CD6F6E /* UIDevice+Extension.swift in Sources */,
 				395C7E1328F9841A00FC2FCA /* SizeLiteral.swift in Sources */,
 				3EB508902917525600FB77CB /* EmptyReflectionView.swift in Sources */,

--- a/Maddori.Apple/Maddori.Apple/Global/Literal/ImageLiteral.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Literal/ImageLiteral.swift
@@ -11,6 +11,7 @@ enum ImageLiterals {
     
     // MARK: - icon
     
+    static var icLogOut: UIImage { .load(systemName: "rectangle.portrait.and.arrow.right") }
     static var icClose: UIImage { .load(systemName: "xmark") }
     static var icBack: UIImage { .load(systemName: "chevron.left") }
     static var icWarning: UIImage { .load(systemName: "exclamationmark.circle.fill") }

--- a/Maddori.Apple/Maddori.Apple/Global/Supports/SceneDelegate.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Supports/SceneDelegate.swift
@@ -68,6 +68,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
 extension SceneDelegate {
     func logout() {
-        window?.rootViewController = LoginViewController()
+        window?.rootViewController = UINavigationController(rootViewController: LoginViewController())
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Global/Supports/SceneDelegate.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Supports/SceneDelegate.swift
@@ -66,3 +66,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
 }
 
+extension SceneDelegate {
+    func logout() {
+        window?.rootViewController = LoginViewController()
+    }
+}

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/Button/LogOutButton.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/Button/LogOutButton.swift
@@ -1,0 +1,34 @@
+//
+//  LogOutButton.swift
+//  Maddori.Apple
+//
+//  Created by LeeSungHo on 2022/11/23.
+//
+
+import UIKit
+
+import SnapKit
+
+final class LogOut: UIButton {
+    
+    // MARK: - life cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configUI()
+        render()
+    }
+    
+    required init?(coder: NSCoder) { nil }
+    
+    private func configUI() {
+        self.setImage(ImageLiterals.icLogOut, for: .normal)
+        self.tintColor = .black100
+    }
+    
+    private func render() {
+        self.snp.makeConstraints {
+            $0.width.height.equalTo(44)
+        }
+    }
+}

--- a/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflection/MyReflectionViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflection/MyReflectionViewController.swift
@@ -27,6 +27,7 @@ final class MyReflectionViewController: BaseViewController {
     
     // MARK: - property
     
+    private let logOutButton = LogOut(type: .system)
     private lazy var myReflectionTitleLabel: UILabel = {
         let label = UILabel()
         label.setTitleFont(text: user + "님의 회고")
@@ -45,9 +46,16 @@ final class MyReflectionViewController: BaseViewController {
     
     // MARK: - life cycle
     
+    override func setupNavigationBar() {
+        super.setupNavigationBar()
+        let logOutButton = makeBarButtonItem(with: logOutButton)
+        navigationItem.rightBarButtonItem = logOutButton
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         setUpDelegation()
+        setUpLogOutButtonAction()               
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -75,6 +83,18 @@ final class MyReflectionViewController: BaseViewController {
     private func setUpDelegation() {
         reflectionCollectionView.delegate = self
         reflectionCollectionView.dataSource = self
+    }
+    
+    private func setUpLogOutButtonAction() {
+        let action = UIAction { [weak self] _ in
+            self?.makeRequestAlert(title: "로그아웃 하시겠습니까?", message: "", okTitle: "확인", cancelTitle: "취소") { _ in
+                UserDefaultHandler.clearAllData()
+                guard let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate
+                        as? SceneDelegate else { return }
+                sceneDelegate.logout()
+            }
+        }
+        logOutButton.addAction(action, for: .touchUpInside)
     }
     
     // MARK: - api


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
너무나 놀랐습니다.. 저희가 로그아웃이 없더군요.... 흐흐.. 그래서 일단 로그아웃을 구현했습니다. 
(디자인 적으로 설정뷰가 앞으로 필요할것이라고 생각합니다. 디자인이 새로 나온다면 바꾸는 것으로 생각하겠습니다!)

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 로그아웃 버튼 생성
- 로그아웃 기능 구현


## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
- 나의 회고 탭에 넵비게이션 우측 아이콘에 로그아웃 아이콘을 넣어 놨습니다. 로그아웃을 해보십쇼 후후


## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<img src = "https://user-images.githubusercontent.com/59243274/203521189-61f4e237-2a3f-4d71-8128-72f779eba666.mp4" width = "350">



## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->



## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #165 

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
