### PR TITLE
[FIX] 보관함 탭 멤버 리스트 쌓이는 문제 해결

### DIFF
--- a/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedback/MyFeedbackViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedback/MyFeedbackViewController.swift
@@ -118,12 +118,14 @@ final class MyFeedbackViewController: BaseViewController {
                    headers: type.headers
         ).responseDecodable(of: BaseModel<TeamMembersResponse>.self) { [weak self] json in
             if let data = json.value {
+                var memberArray: [MemberResponse] = []
                 guard let members = json.value?.detail?.members else { return }
                 members.forEach {
                     if $0.userName != UserDefaultStorage.nickname {
-                        self?.memberList.append($0)
+                        memberArray.append($0)
                     }
                 }
+                self?.memberList = memberArray
                 dump(data)
             }
         }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
어제 급하게 merge하다가 미처 확인 못한 버그를 발견하고 급하게 수정했습니다 !

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
viewWillAppear에서 멤버 리스트를 불러오는 함수를 실행시키는데, 그 함수내에선 memberList에 append 하는 형식으로 추가를 했었습니다.
다른탭을 갔다온다해서 viewController가 새로 그려지는게 아니라 이미 존재하는 배열의 데이터가 사라지지 않습니다. 근데 viewWillAppear에서 계속 append해서 무한정 길어지는 문제가 생겼습니다 !

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
다른탭 눌렀다가 보관함 탭 눌렀다가 하시면 됩니다 !

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
### 기존 버그상황

https://user-images.githubusercontent.com/78677571/203674478-c7e6fdc3-af31-4323-a3d7-a0294fa53d9d.mp4


### 해결 완료 !

https://user-images.githubusercontent.com/78677571/203674455-427f35ab-79e7-411d-b023-8194bda36a35.mp4



## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
어제 너무 급하게 수정하고 급하게 Approve받았는데, 그 과정에서 놓친 문제네요...
조금은 여유를 갖고 했어야 했네요.. 죄송합니다 .. 하하


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #167 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
