### PR TITLE
[FIX] Start Content Post 로직 수정하기

### DIFF
--- a/Maddori.Apple/Maddori.Apple/Screen/Home/AddFeedback/AddFeedbackViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/AddFeedback/AddFeedbackViewController.swift
@@ -381,7 +381,7 @@ class AddFeedbackViewController: BaseViewController {
     }
     
     func didTappedDoneButton() {
-        let startContent = feedbackStartSwitch.isOn ? feedbackStartTextView.text : ""
+        let startContent = !feedbackStartSwitch.isOn || feedbackStartTextView.text == TextLiteral.addFeedbackViewControllerStartTextViewPlaceholder ? nil : feedbackStartTextView.text
         guard let keyword = feedbackKeywordTextField.text,
               let content = feedbackContentTextView.text
         else { return }

--- a/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackEdit/MyFeedbackEditViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackEdit/MyFeedbackEditViewController.swift
@@ -143,7 +143,7 @@ final class MyFeedbackEditViewController: AddFeedbackViewController {
         let dto = EditFeedBackDTO(type: feedbackType,
                                   keyword: super.feedbackKeywordTextField.text ?? "",
                                   content: super.feedbackContentTextView.text ?? "",
-                                  start_content: super.feedbackStartSwitch.isOn ? super.feedbackStartTextView.text ?? "" : "")
+                                  start_content: !super.feedbackStartSwitch.isOn || super.feedbackStartTextView.text == TextLiteral.addFeedbackViewControllerStartTextViewPlaceholder ? nil : super.feedbackStartTextView.text)
         putEditFeedBack(type: .putEditFeedBack(reflectionId: feedbackDetail.reflectionId, feedBackId: feedbackDetail.feedbackId, dto))
     }
     

--- a/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackEdit/MyFeedbackEditViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackEdit/MyFeedbackEditViewController.swift
@@ -143,7 +143,7 @@ final class MyFeedbackEditViewController: AddFeedbackViewController {
         let dto = EditFeedBackDTO(type: feedbackType,
                                   keyword: super.feedbackKeywordTextField.text ?? "",
                                   content: super.feedbackContentTextView.text ?? "",
-                                  start_content: !super.feedbackStartSwitch.isOn || super.feedbackStartTextView.text == TextLiteral.addFeedbackViewControllerStartTextViewPlaceholder ? nil : super.feedbackStartTextView.text)
+                                  start_content: !super.feedbackStartSwitch.isOn || super.feedbackStartTextView.text == TextLiteral.addFeedbackViewControllerStartTextViewPlaceholder ? "" : super.feedbackStartTextView.text)
         putEditFeedBack(type: .putEditFeedBack(reflectionId: feedbackDetail.reflectionId, feedBackId: feedbackDetail.feedbackId, dto))
     }
     


### PR DESCRIPTION
## 🌁 Background
원래 api 상에서 Start 에 nil을 전달하면 에러가 떴지만 nil도 허용하도록 수정되어 시작된 issue입니다.
코드를 작성하다보니 Start 토글이 켜저 있지만 아무 값도 입력하지 않으면 placeholder text가 start 값으로 전달되는 문제가 발생하여 이 부분도 반영하여 수정했습니다!

## 👩‍💻 Contents
Start TextView의 Text 가 place holder 와 동일하거나 Start 토글이 꺼져 있을 경우
AddFeedback 에서는 Start content 를 nil로
MyFeedbackEdit에서는 Start Content를 ""로 전달하는 로직 추가


## ✅ Testing
feature/179-fix-start-content-result로 오셔서 
1.새로운 피드백을 Start 없이 작성해보고
2. 그 피드백에 Start 를 추가해보고
3. 다시 Start 토글을 꺼서 Start를 삭제해보세용!

## 📱 Screenshot
https://user-images.githubusercontent.com/81340603/203935694-d21bad84-9b8c-45bf-9537-64eccf2175a7.mp4


## 📣 Related Issue
- close #179 
