### PR TITLE
[FIX] 나의 회고 디테일에 세그먼트가 겹치는 문제 해결

### DIFF
--- a/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
+++ b/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
@@ -119,6 +119,7 @@
 		7E6B662F28FE887300C3BEEF /* UILabel+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6B662E28FE887300C3BEEF /* UILabel+Extension.swift */; };
 		7E7F160B2921CC4800C6BE96 /* CustomTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7F160A2921CC4800C6BE96 /* CustomTabBarController.swift */; };
 		7E7F160F2921CD4A00C6BE96 /* UITabBar+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7F160E2921CD4A00C6BE96 /* UITabBar+Extension.swift */; };
+		7E8753E129348BB000FBBF83 /* MyReflectionDetailViewLastCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8753E029348BB000FBBF83 /* MyReflectionDetailViewLastCell.swift */; };
 		7E8CDC67292E19B000984742 /* LogOutButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8CDC66292E19B000984742 /* LogOutButton.swift */; };
 		7EB4D58229011EF7001FC396 /* JoinTeamViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EB4D58129011EF7001FC396 /* JoinTeamViewController.swift */; };
 		7EE38BAD2925DDD200FD738D /* EncodeDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EE38BAC2925DDD200FD738D /* EncodeDTO.swift */; };
@@ -247,6 +248,7 @@
 		7E6B662E28FE887300C3BEEF /* UILabel+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+Extension.swift"; sourceTree = "<group>"; };
 		7E7F160A2921CC4800C6BE96 /* CustomTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTabBarController.swift; sourceTree = "<group>"; };
 		7E7F160E2921CD4A00C6BE96 /* UITabBar+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITabBar+Extension.swift"; sourceTree = "<group>"; };
+		7E8753E029348BB000FBBF83 /* MyReflectionDetailViewLastCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyReflectionDetailViewLastCell.swift; sourceTree = "<group>"; };
 		7E8CDC66292E19B000984742 /* LogOutButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogOutButton.swift; sourceTree = "<group>"; };
 		7EB4D58129011EF7001FC396 /* JoinTeamViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinTeamViewController.swift; sourceTree = "<group>"; };
 		7EE38BAC2925DDD200FD738D /* EncodeDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncodeDTO.swift; sourceTree = "<group>"; };
@@ -774,6 +776,7 @@
 			isa = PBXGroup;
 			children = (
 				D7AFB7C42916EDC300E998B7 /* MyReflectionDetailTableViewCell.swift */,
+				7E8753E029348BB000FBBF83 /* MyReflectionDetailViewLastCell.swift */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -1021,6 +1024,7 @@
 				7EE38BB3292623F500FD738D /* MyReflectionEndPoint.swift in Sources */,
 				39F52C6E2924742E00B19A77 /* ReflectionResponse.swift in Sources */,
 				52988B742921EAD50044A77F /* MyReflectionFeedbackViewController.swift in Sources */,
+				7E8753E129348BB000FBBF83 /* MyReflectionDetailViewLastCell.swift in Sources */,
 				395C7E1828F9912700FC2FCA /* UIButton+Extension.swift in Sources */,
 				39AC287F29269BC6006CFEE6 /* Endpointable.swift in Sources */,
 				7EE38BAD2925DDD200FD738D /* EncodeDTO.swift in Sources */,

--- a/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflectionDetail/Cell/MyReflectionDetailViewLastCell.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflectionDetail/Cell/MyReflectionDetailViewLastCell.swift
@@ -1,0 +1,15 @@
+//
+//  MyReflectionDetailViewLastCell.swift
+//  Maddori.Apple
+//
+//  Created by LeeSungHo on 2022/11/28.
+//
+
+import UIKit
+
+final class MyReflectionDetailViewLastCell: BaseTableViewCell {
+    
+    override func configUI() {
+        backgroundColor = .backgroundWhite
+    }
+}

--- a/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflectionDetail/MyReflectionDetailViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflectionDetail/MyReflectionDetailViewController.swift
@@ -141,7 +141,7 @@ final class MyReflectionDetailViewController: BaseViewController {
 
 extension MyReflectionDetailViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return contentArray.isEmpty ? 1 : contentArray.count
+        return contentArray.isEmpty ? 1 : contentArray.count + 1
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -154,12 +154,20 @@ extension MyReflectionDetailViewController: UITableViewDataSource {
             return emptyCell
         } else {
             guard let cell = tableView.dequeueReusableCell(withIdentifier: MyReflectionDetailTableViewCell.className, for: indexPath) as? MyReflectionDetailTableViewCell else { return UITableViewCell() }
-            guard let keyword = contentArray[indexPath.row].keyword,
-                  let fromLabelText = contentArray[indexPath.row].fromUser?.userName,
-                  let content = contentArray[indexPath.row].content else { return UITableViewCell() }
-            cell.configLabel(title: keyword, fromLabel: fromLabelText, content: content)
-            tableView.isScrollEnabled = true
-            return cell
+            if indexPath.row == contentArray.count {
+                cell.rightImage.isHidden = true
+                cell.fromLabelBackView.isHidden = true
+                cell.isUserInteractionEnabled = false
+                return cell
+            }
+            else {
+                guard let keyword = contentArray[indexPath.row].keyword,
+                      let fromLabelText = contentArray[indexPath.row].fromUser?.userName,
+                      let content = contentArray[indexPath.row].content else { return UITableViewCell() }
+                cell.configLabel(title: keyword, fromLabel: fromLabelText, content: content)
+                tableView.isScrollEnabled = true
+                return cell
+            }
         }
     }
 }
@@ -168,6 +176,8 @@ extension MyReflectionDetailViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         if contentArray.isEmpty {
             return tableView.frame.height - 90
+        } else if indexPath.row == contentArray.count {
+            return 44
         } else {
             return 100
         }

--- a/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflectionDetail/MyReflectionDetailViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflectionDetail/MyReflectionDetailViewController.swift
@@ -15,6 +15,8 @@ final class MyReflectionDetailViewController: BaseViewController {
     private var reflectionName: String
     private let reflectionId: Int
     private var contentArray: [FeedBackResponse] = []
+    private var continueArray: [FeedBackResponse] = []
+    private var stopArray: [FeedBackResponse] = []
     
     // MARK: - property
     
@@ -40,6 +42,7 @@ final class MyReflectionDetailViewController: BaseViewController {
         tableView.dataSource = self
         tableView.register(MyReflectionDetailTableViewCell.self, forCellReuseIdentifier: MyReflectionDetailTableViewCell.className)
         tableView.register(EmptyTableFeedbackView.self, forCellReuseIdentifier: EmptyTableFeedbackView.className)
+        tableView.register(MyReflectionDetailViewLastCell.self, forCellReuseIdentifier: MyReflectionDetailViewLastCell.className)
         return tableView
     }()
     private lazy var segmentControl: CustomSegmentControl = {
@@ -109,7 +112,6 @@ final class MyReflectionDetailViewController: BaseViewController {
         else {
             fetchCertainTypeFeedbackAll(type: .fetchCertainTypeFeedbackAllID(reflectionId: reflectionId, cssType: .stopType))
         }
-        tableView.reloadData()
     }
     
     // MARK: - api
@@ -153,14 +155,13 @@ extension MyReflectionDetailViewController: UITableViewDataSource {
             tableView.isScrollEnabled = false
             return emptyCell
         } else {
-            guard let cell = tableView.dequeueReusableCell(withIdentifier: MyReflectionDetailTableViewCell.className, for: indexPath) as? MyReflectionDetailTableViewCell else { return UITableViewCell() }
             if indexPath.row == contentArray.count {
-                cell.rightImage.isHidden = true
-                cell.fromLabelBackView.isHidden = true
+                guard let cell = tableView.dequeueReusableCell(withIdentifier: MyReflectionDetailViewLastCell.className, for: indexPath) as? MyReflectionDetailViewLastCell else { return UITableViewCell() }
                 cell.isUserInteractionEnabled = false
                 return cell
             }
             else {
+                guard let cell = tableView.dequeueReusableCell(withIdentifier: MyReflectionDetailTableViewCell.className, for: indexPath) as? MyReflectionDetailTableViewCell else { return UITableViewCell() }
                 guard let keyword = contentArray[indexPath.row].keyword,
                       let fromLabelText = contentArray[indexPath.row].fromUser?.userName,
                       let content = contentArray[indexPath.row].content else { return UITableViewCell() }

--- a/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflectionDetail/MyReflectionDetailViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflectionDetail/MyReflectionDetailViewController.swift
@@ -15,8 +15,6 @@ final class MyReflectionDetailViewController: BaseViewController {
     private var reflectionName: String
     private let reflectionId: Int
     private var contentArray: [FeedBackResponse] = []
-    private var continueArray: [FeedBackResponse] = []
-    private var stopArray: [FeedBackResponse] = []
     
     // MARK: - property
     


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->

<img src = "https://user-images.githubusercontent.com/59243274/204202729-cfe44b6d-c989-4bb1-ba1f-c39c772e98ca.png" width = "350">

마지막 셀일때는 세그먼트 컨트롤이 위치가 겹치는 현상이 있었습니다.
그래서 뱅크셀러드를 참고해보니 마지막 부분은 빈 셀이 있는거 처럼 구현이 되어 있어서 그렇게 수정 완료 했습니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 빈 셀 (MyReflectionDetailViewLastCell) 생성
- 마지막 셀 생성 
- 저번에 재사용문제는 아예 셀 자체를 재사용하지 않고 새로 등록해서 사용하는 것으로 처리 하였습니다.


## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
feature/184-segement-control-position-fix 로 오셔서 실행 후 나의 회고 디테일 부분(세그먼트 컨트롤 있는부분)으로 오셔서 스크롤을 내려서 마지막에 셀과 세그먼트 컨트롤이 겹치는지 확인해주시면 됩니다.

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->

https://user-images.githubusercontent.com/59243274/204229589-cd0af8d3-bcd3-4a33-ae93-a35c41635637.mp4


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- 현재 세그먼트 컨트롤이 눌릴때마다 api 통신을 하고 있는데 이건 굉장히 안좋은 낭비라고 생각합니다. 이부분을 고치고 싶었는데 
이 이슈랑 조금은 결이 다르다고 생각해서

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #184


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
