### PR TITLE
[FEAT] 회원탈퇴 기능 추가

### DIFF
--- a/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
+++ b/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
@@ -119,7 +119,7 @@
 		7E6B662F28FE887300C3BEEF /* UILabel+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6B662E28FE887300C3BEEF /* UILabel+Extension.swift */; };
 		7E7F160B2921CC4800C6BE96 /* CustomTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7F160A2921CC4800C6BE96 /* CustomTabBarController.swift */; };
 		7E7F160F2921CD4A00C6BE96 /* UITabBar+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7F160E2921CD4A00C6BE96 /* UITabBar+Extension.swift */; };
-		7E8CDC67292E19B000984742 /* LogOutButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8CDC66292E19B000984742 /* LogOutButton.swift */; };
+		7E8CDC67292E19B000984742 /* SettingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8CDC66292E19B000984742 /* SettingButton.swift */; };
 		7EB4D58229011EF7001FC396 /* JoinTeamViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EB4D58129011EF7001FC396 /* JoinTeamViewController.swift */; };
 		7EE38BAD2925DDD200FD738D /* EncodeDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EE38BAC2925DDD200FD738D /* EncodeDTO.swift */; };
 		7EE38BB3292623F500FD738D /* MyReflectionEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EE38BB2292623F500FD738D /* MyReflectionEndPoint.swift */; };
@@ -247,7 +247,7 @@
 		7E6B662E28FE887300C3BEEF /* UILabel+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+Extension.swift"; sourceTree = "<group>"; };
 		7E7F160A2921CC4800C6BE96 /* CustomTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTabBarController.swift; sourceTree = "<group>"; };
 		7E7F160E2921CD4A00C6BE96 /* UITabBar+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITabBar+Extension.swift"; sourceTree = "<group>"; };
-		7E8CDC66292E19B000984742 /* LogOutButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogOutButton.swift; sourceTree = "<group>"; };
+		7E8CDC66292E19B000984742 /* SettingButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingButton.swift; sourceTree = "<group>"; };
 		7EB4D58129011EF7001FC396 /* JoinTeamViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinTeamViewController.swift; sourceTree = "<group>"; };
 		7EE38BAC2925DDD200FD738D /* EncodeDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncodeDTO.swift; sourceTree = "<group>"; };
 		7EE38BB2292623F500FD738D /* MyReflectionEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyReflectionEndPoint.swift; sourceTree = "<group>"; };
@@ -520,7 +520,7 @@
 				525E722028FFC9A800EF3FCB /* BackButton.swift */,
 				395C7E1C28FEC8C400FC2FCA /* CloseButton.swift */,
 				395C7E0C28F959A500FC2FCA /* MainButton.swift */,
-				7E8CDC66292E19B000984742 /* LogOutButton.swift */,
+				7E8CDC66292E19B000984742 /* SettingButton.swift */,
 			);
 			path = Button;
 			sourceTree = "<group>";
@@ -1031,7 +1031,7 @@
 				52DC9091291A98CC00904739 /* MyFeedbackEditViewController.swift in Sources */,
 				3EA341E82925E5EA005CBD1C /* String+Extension.swift in Sources */,
 				D7AFB7C72916FF9400E998B7 /* CustomSegmentControl.swift in Sources */,
-				7E8CDC67292E19B000984742 /* LogOutButton.swift in Sources */,
+				7E8CDC67292E19B000984742 /* SettingButton.swift in Sources */,
 				39F5582B2908027500CD6F6E /* UIDevice+Extension.swift in Sources */,
 				395C7E1328F9841A00FC2FCA /* SizeLiteral.swift in Sources */,
 				3EB508902917525600FB77CB /* EmptyReflectionView.swift in Sources */,

--- a/Maddori.Apple/Maddori.Apple/Global/Literal/ImageLiteral.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Literal/ImageLiteral.swift
@@ -19,6 +19,7 @@ enum ImageLiterals {
     static var icPin: UIImage { .load(systemName: "pin.circle.fill") }
     static var icBox: UIImage { .load(systemName: "archivebox.circle.fill") }
     static var icRight: UIImage { .load(systemName: "chevron.right") }
+    static var icEllipsis: UIImage { .load(systemName: "ellipsis") }
     
     // MARK: - image
     

--- a/Maddori.Apple/Maddori.Apple/Global/Literal/TextLiteral.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Literal/TextLiteral.swift
@@ -173,5 +173,6 @@ enum TextLiteral {
     static let myReflectionViewControllerLogOutTitle: String = "로그아웃"
     static let myReflectionViewControllerLogOutMessage: String = "로그아웃 하시겠습니까?"
     static let myReflectionViewControllerDeleteUser: String = "회원탈퇴"
-    
+    static let myReflectionViewControllerDeleteUserAlertTitle: String = "회원탈퇴 하시겠습니까?"
+    static let myReflectionViewControllerDeleteUserAlertMessage: String = "모든 회고와 피드백 정보가 사라지며, \n되돌릴 수 없습니다."
 }

--- a/Maddori.Apple/Maddori.Apple/Global/Literal/TextLiteral.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Literal/TextLiteral.swift
@@ -167,4 +167,11 @@ enum TextLiteral {
     
     static let joinReflectionButtonStatusText: String = "회고가 시작되었습니다!"
     static let joinReflectionTouchToEnterLabel: String = "터치하여 회고에 참여해주세요"
+    
+    // MARK: - MyReflectionViewController
+    
+    static let myReflectionViewControllerLogOutTitle: String = "로그아웃"
+    static let myReflectionViewControllerLogOutMessage: String = "로그아웃 하시겠습니까?"
+    static let myReflectionViewControllerDeleteUser: String = "회원탈퇴"
+    
 }

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/Button/LogOutButton.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/Button/LogOutButton.swift
@@ -9,7 +9,7 @@ import UIKit
 
 import SnapKit
 
-final class LogOut: UIButton {
+final class SettingButton: UIButton {
     
     // MARK: - life cycle
     
@@ -22,7 +22,7 @@ final class LogOut: UIButton {
     required init?(coder: NSCoder) { nil }
     
     private func configUI() {
-        self.setImage(ImageLiterals.icLogOut, for: .normal)
+        self.setImage(.load(systemName: "ellipsis"), for: .normal)
         self.tintColor = .black100
     }
     

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/Button/SettingButton.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/Button/SettingButton.swift
@@ -1,5 +1,5 @@
 //
-//  LogOutButton.swift
+//  SettingButton.swift
 //  Maddori.Apple
 //
 //  Created by LeeSungHo on 2022/11/23.

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/Button/SettingButton.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/Button/SettingButton.swift
@@ -22,7 +22,7 @@ final class SettingButton: UIButton {
     required init?(coder: NSCoder) { nil }
     
     private func configUI() {
-        self.setImage(.load(systemName: "ellipsis"), for: .normal)
+        self.setImage(ImageLiterals.icEllipsis, for: .normal)
         self.tintColor = .black100
     }
     

--- a/Maddori.Apple/Maddori.Apple/Network/EndPoint/MyReflectionEndPoint.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/EndPoint/MyReflectionEndPoint.swift
@@ -10,6 +10,7 @@ import Alamofire
 enum MyReflectionEndPoint<T: Encodable>: EndPointable {
     case fetchPastReflectionList(teamId: Int)
     case fetchCertainTypeFeedbackAllID(reflectionId: Int, cssType: FeedBackDTO)
+    case deleteUser
     
     var address: String {
         switch self {
@@ -17,6 +18,8 @@ enum MyReflectionEndPoint<T: Encodable>: EndPointable {
             return "\(UrlLiteral.baseUrl)/teams/\(teamId)/reflections"
         case .fetchCertainTypeFeedbackAllID(let reflectionId, let cssType):
             return "\(UrlLiteral.baseUrl)/teams/\(UserDefaultStorage.teamId)/reflections/\(reflectionId)/feedbacks?type=\(cssType.rawValue)"
+        case .deleteUser:
+            return "\(UrlLiteral.baseUrl)/login/signout"
         }
     }
     
@@ -26,6 +29,8 @@ enum MyReflectionEndPoint<T: Encodable>: EndPointable {
             return .get
         case .fetchCertainTypeFeedbackAllID:
             return .get
+        case .deleteUser:
+            return .delete
         }
     }
     
@@ -34,6 +39,8 @@ enum MyReflectionEndPoint<T: Encodable>: EndPointable {
         case .fetchPastReflectionList:
             return nil
         case .fetchCertainTypeFeedbackAllID:
+            return nil
+        case .deleteUser:
             return nil
         }
     }
@@ -47,6 +54,12 @@ enum MyReflectionEndPoint<T: Encodable>: EndPointable {
             ]
             return HTTPHeaders(headers)
         case .fetchCertainTypeFeedbackAllID(_, _):
+            let headers = [
+                "access_token": "\(UserDefaultStorage.accessToken)",
+                "refresh_token": "\(UserDefaultStorage.refreshToken)"
+            ]
+            return HTTPHeaders(headers)
+        case .deleteUser:
             let headers = [
                 "access_token": "\(UserDefaultStorage.accessToken)",
                 "refresh_token": "\(UserDefaultStorage.refreshToken)"

--- a/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflection/MyReflectionViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflection/MyReflectionViewController.swift
@@ -27,7 +27,7 @@ final class MyReflectionViewController: BaseViewController {
     
     // MARK: - property
     
-    private let logOutButton = LogOut(type: .system)
+    private let ellipsisButton = SettingButton(type: .system)
     private lazy var myReflectionTitleLabel: UILabel = {
         let label = UILabel()
         label.setTitleFont(text: user + "님의 회고")
@@ -48,14 +48,14 @@ final class MyReflectionViewController: BaseViewController {
     
     override func setupNavigationBar() {
         super.setupNavigationBar()
-        let logOutButton = makeBarButtonItem(with: logOutButton)
-        navigationItem.rightBarButtonItem = logOutButton
+        let rightItemButton = makeBarButtonItem(with: ellipsisButton)
+        navigationItem.rightBarButtonItem = rightItemButton
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
         setUpDelegation()
-        setUpLogOutButtonAction()               
+        setUpEllipsisButtonMenu()               
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -85,16 +85,26 @@ final class MyReflectionViewController: BaseViewController {
         reflectionCollectionView.dataSource = self
     }
     
-    private func setUpLogOutButtonAction() {
-        let action = UIAction { [weak self] _ in
-            self?.makeRequestAlert(title: "로그아웃 하시겠습니까?", message: "", okTitle: "확인", cancelTitle: "취소") { _ in
-                UserDefaultHandler.clearAllData()
-                guard let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate
-                        as? SceneDelegate else { return }
-                sceneDelegate.logout()
-            }
+    private func setUpEllipsisButtonMenu() {
+        let menu = UIMenu(options: .displayInline, children: [
+            UIAction(title: TextLiteral.myReflectionViewControllerLogOutTitle, handler: { [weak self] _ in
+                self?.logoutUser()
+            }),
+            UIAction(title: TextLiteral.myReflectionViewControllerDeleteUser, attributes: .destructive, handler: { _ in
+                
+            })
+        ])
+        ellipsisButton.showsMenuAsPrimaryAction = true
+        ellipsisButton.menu = menu
+    }
+    
+    private func logoutUser() {
+        makeRequestAlert(title: TextLiteral.myReflectionViewControllerLogOutMessage, message: "", okTitle: "확인", cancelTitle: "취소") { _ in  
+            UserDefaultHandler.clearAllData()
+            guard let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate
+                    as? SceneDelegate else { return }
+            sceneDelegate.logout()
         }
-        logOutButton.addAction(action, for: .touchUpInside)
     }
     
     // MARK: - api

--- a/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflection/MyReflectionViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflection/MyReflectionViewController.swift
@@ -90,8 +90,10 @@ final class MyReflectionViewController: BaseViewController {
             UIAction(title: TextLiteral.myReflectionViewControllerLogOutTitle, handler: { [weak self] _ in
                 self?.logoutUser()
             }),
-            UIAction(title: TextLiteral.myReflectionViewControllerDeleteUser, attributes: .destructive, handler: { _ in
-                
+            UIAction(title: TextLiteral.myReflectionViewControllerDeleteUser, attributes: .destructive, handler: { [weak self] _ in
+                self?.makeRequestAlert(title: "회원탈퇴 하시겠습니까?", message: "모든 회고와 피드백 정보가 사라지며, \n되돌릴 수 없습니다.", okAction: { [weak self] _ in
+                    self?.deleteUser(type: .deleteUser)
+                })
             })
         ])
         ellipsisButton.showsMenuAsPrimaryAction = true
@@ -99,11 +101,26 @@ final class MyReflectionViewController: BaseViewController {
     }
     
     private func logoutUser() {
-        makeRequestAlert(title: TextLiteral.myReflectionViewControllerLogOutMessage, message: "", okTitle: "확인", cancelTitle: "취소") { _ in  
+        makeRequestAlert(title: TextLiteral.myReflectionViewControllerLogOutMessage, message: "", okTitle: "확인", cancelTitle: "취소") { _ in
             UserDefaultHandler.clearAllData()
             guard let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate
                     as? SceneDelegate else { return }
             sceneDelegate.logout()
+        }
+    }
+    
+    private func deleteUser(type: MyReflectionEndPoint<VoidModel>) {
+        AF.request(type.address,
+                   method: type.method,
+                   headers: type.headers
+        )
+        .responseDecodable(of: BaseModel<VoidModel>.self) { json in
+            if let _ = json.value {
+                UserDefaultHandler.clearAllData()
+                guard let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate
+                        as? SceneDelegate else { return }
+                sceneDelegate.logout()
+            }
         }
     }
     

--- a/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflection/MyReflectionViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflection/MyReflectionViewController.swift
@@ -91,7 +91,7 @@ final class MyReflectionViewController: BaseViewController {
                 self?.logoutUser()
             }),
             UIAction(title: TextLiteral.myReflectionViewControllerDeleteUser, attributes: .destructive, handler: { [weak self] _ in
-                self?.makeRequestAlert(title: "회원탈퇴 하시겠습니까?", message: "모든 회고와 피드백 정보가 사라지며, \n되돌릴 수 없습니다.", okAction: { [weak self] _ in
+                self?.makeRequestAlert(title: TextLiteral.myReflectionViewControllerDeleteUserAlertTitle, message: TextLiteral.myReflectionViewControllerDeleteUserAlertMessage, okAction: { [weak self] _ in
                     self?.deleteUser(type: .deleteUser)
                 })
             })


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
<img width="949" alt="image" src="https://user-images.githubusercontent.com/78677571/204236186-746e6332-5f5e-4e8c-85f4-98a400365cff.png">

앱 심사 리젝 사유로 회원 탈퇴 문제가 나왔습니다. 그로 인해 해당 기능을 추가했습니다.


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
회원 탈퇴 기능을 추가했습니다.

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
나의 회고 탭에서 오른쪽위 네비게이션 아이템에 들어있는 ellipsis 버튼을 눌러서 회원 탈퇴를 진행하시면 됩니다.
실제 DB에서 회원탈퇴가 진행됩니다 !

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->

https://user-images.githubusercontent.com/78677571/204236492-c9f0263c-58d3-425c-8733-1a421e70a1a3.mp4



## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
현재는 설정페이지가 따로 없기 때문에 UIMenu로 구현을 했습니다.
추후에 수정된다면 좋을 것 같습니다 !
UXWriting을 제 생각대로 했기 때문에, 수정해야할 것 같다면 말해주십셔 !

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #183 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
