### PR TITLE
[FIX] 키보드에 따라 버튼이 올라오지 않았던 문제 해결 + 그에 따른 애니메이션 꼬임 해결 

### DIFF
--- a/Maddori.Apple/Maddori.Apple/Screen/Home/CreateReflection/CreateReflectionViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/CreateReflection/CreateReflectionViewController.swift
@@ -189,6 +189,10 @@ final class CreateReflectionViewController: BaseViewController {
         return combinedDate
     }
     
+    override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        return true
+    }
+    
     // MARK: - selector
     
     @objc private func keyboardWillShow(notification:NSNotification) {

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/CreateReflection/CreateReflectionViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/CreateReflection/CreateReflectionViewController.swift
@@ -50,6 +50,9 @@ final class CreateReflectionViewController: BaseViewController {
         let action = UIAction { [weak self] _ in
             picker.subviews.first?.subviews.first?.subviews.first?.backgroundColor = .white300
         }
+        let hideKeyboardAction = UIAction { [weak self] _ in
+            self?.view.endEditing(true)
+        }
         picker.datePickerMode = .date
         picker.locale = Locale(identifier: "ko_KR")
         picker.preferredDatePickerStyle = .compact
@@ -57,12 +60,16 @@ final class CreateReflectionViewController: BaseViewController {
         picker.subviews.first?.subviews.first?.subviews.first?.layer.borderWidth = 1
         picker.subviews.first?.subviews.first?.subviews.first?.layer.borderColor = UIColor.gray100.cgColor
         picker.addAction(action, for: .valueChanged)
+        picker.addAction(hideKeyboardAction, for: .editingDidBegin)
         return picker
     }()
     private lazy var timePicker: UIDatePicker = {
         let picker = UIDatePicker()
         let action = UIAction { [weak self] _ in
             picker.subviews.first?.subviews.first?.subviews.first?.backgroundColor = .white300
+        }
+        let hideKeyboardAction = UIAction { [weak self] _ in
+            self?.view.endEditing(true)
         }
         picker.datePickerMode = .time
         picker.locale = Locale(identifier: "ko_KR")
@@ -71,6 +78,7 @@ final class CreateReflectionViewController: BaseViewController {
         picker.subviews.first?.subviews.first?.layer.borderWidth = 1
         picker.subviews.first?.subviews.first?.layer.borderColor = UIColor.gray100.cgColor
         picker.addAction(action, for: .valueChanged)
+        picker.addAction(hideKeyboardAction, for: .editingDidBegin)
         return picker
     }()
     private let mainButton: MainButton = {

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/CreateReflection/CreateReflectionViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/CreateReflection/CreateReflectionViewController.swift
@@ -84,6 +84,7 @@ final class CreateReflectionViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupAddReflection()
+        setupNotificationCenter()
     }
     
     override func render() {
@@ -131,6 +132,11 @@ final class CreateReflectionViewController: BaseViewController {
     }
     
     // MARK: - setup
+    
+    private func setupNotificationCenter() {
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
     
     private func setupAddReflection() {
         let action = UIAction { [weak self] _ in
@@ -181,6 +187,22 @@ final class CreateReflectionViewController: BaseViewController {
         guard let combinedDate = calendar.date(from: combinedDateComponents) else { return Date() }
         
         return combinedDate
+    }
+    
+    // MARK: - selector
+    
+    @objc private func keyboardWillShow(notification:NSNotification) {
+        if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
+            UIView.animate(withDuration: 0.2, animations: {
+                self.mainButton.transform = CGAffineTransform(translationX: 0, y: -keyboardSize.height + 10)
+            })
+        }
+    }
+    
+    @objc private func keyboardWillHide(notification:NSNotification) {
+        UIView.animate(withDuration: 0.2, animations: {
+            self.mainButton.transform = .identity
+        })
     }
     
     // MARK: - api


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
<img src = "https://user-images.githubusercontent.com/59243274/204430940-cbe27e10-71c9-4c59-a46b-5cdcee425367.jpeg" width = "350">

이런 상태로 키보드에 따라 버튼이 올라오지 않았던 문제가 있었습니다. 그 문제를 해결하기 위한 PR입니다.

그런데 이렇게 고친 후 키보드가 올라와 있는 상태로 데이트 픽커와 타임픽커를 누를때 키보드가 내려가지 않아서 생기는 애니메이션이 꼬이는 현상이 발생했습니다. 

https://user-images.githubusercontent.com/59243274/204431674-e53f7e28-6ab4-4332-a779-d1ae1ec040c1.mp4


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 메인버튼 키보드 위치에 따라 올라올 수 있도록 변경
- 키보드가 올라왔을때 화면 어디든 터치해도 내리도록 수정 
---------------------------------
- 키보드가 올라와있는 상태로 데이트 픽커와 타임픽커를 누를때 키보드가 내려가지 않아서 생기는 애니메이션 꼬임 현상 해결


## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
로그인 후 방장이 되어야합니다. 그리고 회고 일정을 들어가서 텍스트 필드를 누르시면서 확인해보시면 됩니다.


## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<img src = "https://user-images.githubusercontent.com/59243274/204431537-abaa4a58-7311-4729-b7ed-d14e91f8e52d.png" width = "350">


https://user-images.githubusercontent.com/59243274/204431751-cb7c8ba2-2303-4f71-a6c4-8e9ffc219dab.mp4





## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
이 뷰는 워낙 처음에 만든 뷰라, 그리고 BaseTextField를 사용하지 않았기 때문에 이런 버그가 있었습니다. 


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #187 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
