### PR TITLE
[CHORE] 회고가 진행중으로 넘어갔을 때, 피드백 수정 삭제 불가능하도록 분기처리

### DIFF
--- a/Maddori.Apple/Maddori.Apple/Global/Literal/TextLiteral.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Literal/TextLiteral.swift
@@ -131,6 +131,7 @@ enum TextLiteral {
     static let myFeedbackDetailViewControllerEditButtonText: String = "수정하러 가기"
     static let myFeedbackDetailViewControllerReflectionIsStartedLabel: String = "회고가 시작되었습니다"
     static let myFeedbackDetailViewControllerBeforeReflectionLabel: String = "담아둔 피드백은 회고 시간 전까지 수정 가능합니다"
+    static let myFeedbackDetailViewControllerBeforeReflectionLabelNotBefore: String = "회고가 시작되어 수정할 수 없습니다"
     
     // MARK: - AlertViewController
     

--- a/Maddori.Apple/Maddori.Apple/Network/Model/FeedbackFromMe/FeedbackFromMeModel.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/Model/FeedbackFromMe/FeedbackFromMeModel.swift
@@ -20,7 +20,6 @@ struct FeedbackFromMeModel {
     let keyword: String
     let info: String
     let start: String?
-    
-    static let mockData = FeedbackFromMeModel(reflectionId: 0, feedbackId: 0, nickname: "곰민", feedbackType: .stopType, keyword: "정리정돈", info: "이번 스프린트 때 유독 행사가 많았는데 그때마다 행사 전후로 정리정돈 잘 해주셔서 감사해요 ! 특히 행사 끝나고 분리수거 깔끔해주신 게 인상 깊어요 ㅋㅋ", start: "새로운 제안이라고 하면 좀 이상할 수도 있지만 앞으로도 계속 청결함을 지켜주는 역할 해주시길.. 최고의 선생님 !!!!")
+    let reflectionStatus: ReflectionStatus
 }
 

--- a/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedback/MyFeedbackViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedback/MyFeedbackViewController.swift
@@ -69,7 +69,8 @@ final class MyFeedbackViewController: BaseViewController {
                                            feedbackType: data.feedbackType,
                                            keyword: data.keyword,
                                            info: data.info,
-                                           start: data.start
+                                           start: data.start,
+                                           reflectionStatus: data.reflectionStatus
             )
             self?.navigationController?.pushViewController(MyFeedbackDetailViewController(feedbackDetail: data), animated: true)
         }

--- a/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedback/UIComponent/MyFeedbackCollectionView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedback/UIComponent/MyFeedbackCollectionView.swift
@@ -130,7 +130,7 @@ extension MyFeedbackCollectionView: UICollectionViewDelegate {
                                                reflectionStatus: reflectionStatus ?? .Before
                 )
                 didTappedCell?(data)
-            } else {s
+            } else {
                 let continueArray = data.continueArray
                 let stopArray = data.stopArray
                 let reflectionStatus = ReflectionStatus.init(rawValue: data.reflectionStatus ?? "Before")

--- a/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedback/UIComponent/MyFeedbackCollectionView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedback/UIComponent/MyFeedbackCollectionView.swift
@@ -130,7 +130,7 @@ extension MyFeedbackCollectionView: UICollectionViewDelegate {
                                                reflectionStatus: reflectionStatus ?? .Before
                 )
                 didTappedCell?(data)
-            } else {
+            } else {s
                 let continueArray = data.continueArray
                 let stopArray = data.stopArray
                 let reflectionStatus = ReflectionStatus.init(rawValue: data.reflectionStatus ?? "Before")

--- a/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedback/UIComponent/MyFeedbackCollectionView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedback/UIComponent/MyFeedbackCollectionView.swift
@@ -101,21 +101,23 @@ extension MyFeedbackCollectionView: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard let data = feedbackInfo else { return }
         if !(data.continueArray.isEmpty && data.stopArray.isEmpty) {
-            if collectionView.numberOfSections == 2 {
-                let reflectionId = feedbackInfo?.reflectionId ?? 0
-                let feedbackId = indexPath.section == 0
-                ? feedbackInfo?.continueArray[indexPath.item].id ?? 0
-                : feedbackInfo?.stopArray[indexPath.item].id ?? 0
-                let nickName = feedbackInfo?.toUsername ?? ""
-                let keyword = indexPath.section == 0
-                ? feedbackInfo?.continueArray[indexPath.item].keyword ?? ""
-                : feedbackInfo?.stopArray[indexPath.item].keyword ?? ""
-                let info = indexPath.section == 0
-                ? feedbackInfo?.continueArray[indexPath.item].content ?? ""
-                : feedbackInfo?.stopArray[indexPath.item].content ?? ""
-                let start = indexPath.section == 0
-                ? feedbackInfo?.continueArray[indexPath.item].startContent
-                : feedbackInfo?.stopArray[indexPath.item].startContent
+            let hasContinueStop = collectionView.numberOfSections == 2
+            let isContinueSection = indexPath.section == 0
+            if hasContinueStop {
+                let reflectionId = data.reflectionId ?? 0
+                let feedbackId = isContinueSection
+                ? data.continueArray[indexPath.item].id ?? 0
+                : data.stopArray[indexPath.item].id ?? 0
+                let nickName = data.toUsername ?? ""
+                let keyword = isContinueSection
+                ? data.continueArray[indexPath.item].keyword ?? ""
+                : data.stopArray[indexPath.item].keyword ?? ""
+                let info = isContinueSection
+                ? data.continueArray[indexPath.item].content ?? ""
+                : data.stopArray[indexPath.item].content ?? ""
+                let start = isContinueSection
+                ? data.continueArray[indexPath.item].startContent
+                : data.stopArray[indexPath.item].startContent
                 let reflectionStatus = ReflectionStatus.init(rawValue: feedbackInfo?.reflectionStatus ?? "Before")
                 
                 let data = FeedbackFromMeModel(reflectionId: reflectionId,
@@ -129,32 +131,31 @@ extension MyFeedbackCollectionView: UICollectionViewDelegate {
                 )
                 didTappedCell?(data)
             } else {
-                if let continueArray = feedbackInfo?.continueArray,
-                   let stopArray = feedbackInfo?.stopArray {
-                    let reflectionStatus = ReflectionStatus.init(rawValue: feedbackInfo?.reflectionStatus ?? "Before")
-                    if !continueArray.isEmpty {
-                        let data = FeedbackFromMeModel(reflectionId: feedbackInfo?.reflectionId ?? 0,
-                                                       feedbackId: continueArray[indexPath.item].id ?? 0,
-                                                       nickname: feedbackInfo?.toUsername ?? "",
-                                                       feedbackType: .continueType,
-                                                       keyword: continueArray[indexPath.item].keyword ?? "",
-                                                       info: continueArray[indexPath.item].content ?? "",
-                                                       start: continueArray[indexPath.item].startContent,
-                                                       reflectionStatus: reflectionStatus ?? .Before
-                        )
-                        didTappedCell?(data)
-                    } else {
-                        let data = FeedbackFromMeModel(reflectionId: feedbackInfo?.reflectionId ?? 0,
-                                                       feedbackId: stopArray[indexPath.item].id ?? 0,
-                                                       nickname: feedbackInfo?.toUsername ?? "",
-                                                       feedbackType: .stopType,
-                                                       keyword: stopArray[indexPath.item].keyword ?? "",
-                                                       info: stopArray[indexPath.item].content ?? "",
-                                                       start: stopArray[indexPath.item].startContent,
-                                                       reflectionStatus: reflectionStatus ?? .Before
-                        )
-                        didTappedCell?(data)
-                    }
+                let continueArray = data.continueArray
+                let stopArray = data.stopArray
+                let reflectionStatus = ReflectionStatus.init(rawValue: data.reflectionStatus ?? "Before")
+                if !continueArray.isEmpty {
+                    let data = FeedbackFromMeModel(reflectionId: data.reflectionId ?? 0,
+                                                   feedbackId: continueArray[indexPath.item].id ?? 0,
+                                                   nickname: data.toUsername ?? "",
+                                                   feedbackType: .continueType,
+                                                   keyword: continueArray[indexPath.item].keyword ?? "",
+                                                   info: continueArray[indexPath.item].content ?? "",
+                                                   start: continueArray[indexPath.item].startContent,
+                                                   reflectionStatus: reflectionStatus ?? .Before
+                    )
+                    didTappedCell?(data)
+                } else {
+                    let data = FeedbackFromMeModel(reflectionId: data.reflectionId ?? 0,
+                                                   feedbackId: stopArray[indexPath.item].id ?? 0,
+                                                   nickname: data.toUsername ?? "",
+                                                   feedbackType: .stopType,
+                                                   keyword: stopArray[indexPath.item].keyword ?? "",
+                                                   info: stopArray[indexPath.item].content ?? "",
+                                                   start: stopArray[indexPath.item].startContent,
+                                                   reflectionStatus: reflectionStatus ?? .Before
+                    )
+                    didTappedCell?(data)
                 }
             }
         }

--- a/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedback/UIComponent/MyFeedbackCollectionView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedback/UIComponent/MyFeedbackCollectionView.swift
@@ -116,6 +116,7 @@ extension MyFeedbackCollectionView: UICollectionViewDelegate {
                 let start = indexPath.section == 0
                 ? feedbackInfo?.continueArray[indexPath.item].startContent
                 : feedbackInfo?.stopArray[indexPath.item].startContent
+                let reflectionStatus = ReflectionStatus.init(rawValue: feedbackInfo?.reflectionStatus ?? "Before")
                 
                 let data = FeedbackFromMeModel(reflectionId: reflectionId,
                                                feedbackId: feedbackId,
@@ -123,11 +124,14 @@ extension MyFeedbackCollectionView: UICollectionViewDelegate {
                                                feedbackType: indexPath.section == 0 ? .continueType : .stopType,
                                                keyword: keyword,
                                                info: info,
-                                               start: start)
+                                               start: start,
+                                               reflectionStatus: reflectionStatus ?? .Before
+                )
                 didTappedCell?(data)
             } else {
                 if let continueArray = feedbackInfo?.continueArray,
                    let stopArray = feedbackInfo?.stopArray {
+                    let reflectionStatus = ReflectionStatus.init(rawValue: feedbackInfo?.reflectionStatus ?? "Before")
                     if !continueArray.isEmpty {
                         let data = FeedbackFromMeModel(reflectionId: feedbackInfo?.reflectionId ?? 0,
                                                        feedbackId: continueArray[indexPath.item].id ?? 0,
@@ -135,7 +139,9 @@ extension MyFeedbackCollectionView: UICollectionViewDelegate {
                                                        feedbackType: .continueType,
                                                        keyword: continueArray[indexPath.item].keyword ?? "",
                                                        info: continueArray[indexPath.item].content ?? "",
-                                                       start: continueArray[indexPath.item].startContent)
+                                                       start: continueArray[indexPath.item].startContent,
+                                                       reflectionStatus: reflectionStatus ?? .Before
+                        )
                         didTappedCell?(data)
                     } else {
                         let data = FeedbackFromMeModel(reflectionId: feedbackInfo?.reflectionId ?? 0,
@@ -144,7 +150,9 @@ extension MyFeedbackCollectionView: UICollectionViewDelegate {
                                                        feedbackType: .stopType,
                                                        keyword: stopArray[indexPath.item].keyword ?? "",
                                                        info: stopArray[indexPath.item].content ?? "",
-                                                       start: stopArray[indexPath.item].startContent)
+                                                       start: stopArray[indexPath.item].startContent,
+                                                       reflectionStatus: reflectionStatus ?? .Before
+                        )
                         didTappedCell?(data)
                     }
                 }

--- a/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackDetail/MyFeedbackDetailViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackDetail/MyFeedbackDetailViewController.swift
@@ -105,7 +105,6 @@ final class MyFeedbackDetailViewController: BaseViewController {
     private lazy var editFeedbackUntilLabel: UILabel = {
         let label = UILabel()
         label.setTextWithLineHeight(text: TextLiteral.myFeedbackDetailViewControllerBeforeReflectionLabel, lineHeight: 22)
-        label.text = TextLiteral.myFeedbackDetailViewControllerBeforeReflectionLabel
         label.textColor = .gray400
         label.font = .body2
         return label
@@ -130,6 +129,7 @@ final class MyFeedbackDetailViewController: BaseViewController {
         super.viewDidLoad()
         setupCloseButton()
         setupMainButton()
+        setupIsProgressingStatus()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -265,6 +265,15 @@ final class MyFeedbackDetailViewController: BaseViewController {
         if feedbackDetail.start == nil || feedbackDetail.start == "" {
             feedbackStartLabel.isHidden = true
             feedbackStartText.isHidden = true
+        }
+    }
+    
+    private func setupIsProgressingStatus() {
+        if feedbackDetail.reflectionStatus != .Before {
+            navigationItem.setRightBarButton(nil, animated: false)
+            
+            editFeedbackUntilLabel.setTextWithLineHeight(text: TextLiteral.myFeedbackDetailViewControllerBeforeReflectionLabelNotBefore, lineHeight: 22)
+            feedbackEditButton.isDisabled = true
         }
     }
     


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
회고가 시작되었음에도 불구하고, 피드백이 수정 삭제가 가능했던 문제가 있었습니다.


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 현재 회고 상태가 진행중이라면 삭제 버튼이 표시되게 끔 만들었고, 진행중이라면 삭제 버튼이 사라지게 만들었습니다.
- guard let 으로 옵셔널값을 확인했던 코드를 사용하고 있지 않았어서, 그 부분을 사용했습니다.

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
직접 DB를 수정하면서 테스트해보는게 직빵이긴 합니다. 
회고가 시작전일때와 진행중일때 피드백 상세정보를 확인해보시면 됩니다.

그게 아니라면 
```swift
    //  FeedbackFromMeDetailViewController.swift

    private func setupIsProgressingStatus() {
        if feedbackDetail.reflectionStatus != .Before {
            navigationItem.setRightBarButton(nil, animated: false)
            
            editFeedbackUntilLabel.setTextWithLineHeight(text: TextLiteral.myFeedbackDetailViewControllerBeforeReflectionLabelNotBefore, lineHeight: 22)
            feedbackEditButton.isDisabled = true
        }
    }
```
요기 271번째 줄에서 != .Before 되어있는 걸 변경해보시면 상태에 따라 바뀐다는걸 확인할 순 있습니다. 
DB바꾸는게 직빵이긴해요... ㅎ


## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
## 회고 시작전

https://user-images.githubusercontent.com/78677571/204434154-3f3ca953-759a-4610-a719-5f8cfbce2069.mp4

## 회고 진행중


https://user-images.githubusercontent.com/78677571/204434242-6d4e8188-f0d6-4059-860c-c0b2bb300176.mp4


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
"회고가 시작되어 수정할 수 없습니다" 라는 Writing이 옳은지는 조금 애매하긴 합니다... (명확한 근거를 찾으면 공유하겠습니다)
추후에 UXWriting에서 수정하면 좋을 것 같네요 !

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #188


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
