### PR TITLE
[CHORE] 탈퇴한 멤버에게 받은 피드백 정보 안뜨는 문제 해결

### DIFF
--- a/Maddori.Apple/Maddori.Apple/Global/Literal/TextLiteral.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Literal/TextLiteral.swift
@@ -175,4 +175,5 @@ enum TextLiteral {
     static let myReflectionViewControllerDeleteUser: String = "회원탈퇴"
     static let myReflectionViewControllerDeleteUserAlertTitle: String = "회원탈퇴 하시겠습니까?"
     static let myReflectionViewControllerDeleteUserAlertMessage: String = "모든 회고와 피드백 정보가 사라지며, \n되돌릴 수 없습니다."
+    static let myReflectionViewControllerDeleteUserTitle: String = "탈퇴한 멤버"
 }

--- a/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflection/MyReflectionViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflection/MyReflectionViewController.swift
@@ -60,7 +60,7 @@ final class MyReflectionViewController: BaseViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        dispatchAllReflection(type: .fetchPastReflectionList(teamId: UserDefaultStorage.teamId))
+        fetchAllReflection(type: .fetchPastReflectionList(teamId: UserDefaultStorage.teamId))
     }
     
     override func render() {
@@ -126,7 +126,7 @@ final class MyReflectionViewController: BaseViewController {
     
     // MARK: - api
     
-    private func dispatchAllReflection(type: MyReflectionEndPoint<EncodeDTO>) {
+    private func fetchAllReflection(type: MyReflectionEndPoint<EncodeDTO>) {
         AF.request(type.address,
                    method: type.method,
                    headers: type.headers

--- a/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflectionDetail/MyReflectionDetailViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflectionDetail/MyReflectionDetailViewController.swift
@@ -161,8 +161,8 @@ extension MyReflectionDetailViewController: UITableViewDataSource {
             else {
                 guard let cell = tableView.dequeueReusableCell(withIdentifier: MyReflectionDetailTableViewCell.className, for: indexPath) as? MyReflectionDetailTableViewCell else { return UITableViewCell() }
                 guard let keyword = contentArray[indexPath.row].keyword,
-                      let fromLabelText = contentArray[indexPath.row].fromUser?.userName,
                       let content = contentArray[indexPath.row].content else { return UITableViewCell() }
+                let fromLabelText = contentArray[indexPath.row].fromUser?.userName ?? TextLiteral.myReflectionViewControllerDeleteUserTitle
                 cell.configLabel(title: keyword, fromLabel: fromLabelText, content: content)
                 tableView.isScrollEnabled = true
                 return cell

--- a/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflectionFeedback/MyReflectionFeedbackViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflectionFeedback/MyReflectionFeedbackViewController.swift
@@ -56,7 +56,7 @@ final class MyReflectionFeedbackViewController: BaseViewController {
     }()
     private lazy var feedbackFromText: UILabel = {
         let label = UILabel()
-        label.setTextWithLineHeight(text: model.fromUser?.userName, lineHeight: 24)
+        label.setTextWithLineHeight(text: model.fromUser?.userName ?? TextLiteral.myReflectionViewControllerDeleteUserTitle, lineHeight: 24)
         label.textColor = .gray400
         label.font = .body1
         return label


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
<img src="https://user-images.githubusercontent.com/78677571/204477876-f38aa248-c4a0-48da-86b5-a54fbedae01b.png" width="350">
탈퇴한 멤버에게 받은 피드백이 상세 정보로 들어가면 잘 보이지만 TableView에서 표시되지 않는 문제가 있었습니다.
그 문제를 해결하기 위한 PR입니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- TableView에서 피드백 정보 안보이던 문제 해결했습니다.
guard let으로 userName이 없다면 제한하고 있었는데, userName이 nil이라면 "탈퇴한 멤버" 가 표시되게 구현했습니다 !
- 지난 회고목록을 불러오는 함수의 이름이 dispatch로 되어있어서 fetch로 변경했습니다 !

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
나에게 피드백을 준 사람을 탈퇴시켜보면 됩니다... 하하
그리고 내가 받은 회고에서 확인하시면 됩니당 ^________^

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->

https://user-images.githubusercontent.com/78677571/204478521-a225a459-2453-4415-a02c-360d090d7b1b.mp4



## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
탈퇴한 멤버 라는 워딩이 나름 괜찮다 생각이 드는데, 다른 멤버들과 같은 UI를 가지는게 조금은 어색한 느낌이 드네요.
![image](https://user-images.githubusercontent.com/78677571/204479081-4f1cc4e1-7805-486c-8e13-88b3d5ea9730.png)
탈퇴한 멤버의 표시가 평소와 같은 UI가 아닌 다른 방식으로 표시되어야 할 것 같아요 !


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #191


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
