### PR TITLE
[FIX] 회고 디테일 뷰 API 분리

### DIFF
--- a/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflectionDetail/MyReflectionDetailViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflectionDetail/MyReflectionDetailViewController.swift
@@ -18,14 +18,7 @@ final class MyReflectionDetailViewController: BaseViewController {
     
     // MARK: - property
     
-    private lazy var backButton: BackButton = {
-        let button = BackButton(type: .system)
-        let action = UIAction { [weak self] _ in
-            // FIXME
-        }
-        button.addAction(action, for: .touchUpInside)
-        return button
-    }()
+    private lazy var backButton = BackButton(type: .system)
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
         label.textColor = .black100

--- a/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflectionDetail/MyReflectionDetailViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflectionDetail/MyReflectionDetailViewController.swift
@@ -103,10 +103,14 @@ final class MyReflectionDetailViewController: BaseViewController {
     private func didChangeValue(segment: UISegmentedControl) {
         if segment.selectedSegmentIndex == 0 {
             contentArray = continueArray
-            tableView.reloadData()
+            DispatchQueue.main.async {
+                self.tableView.reloadData()
+            }
         } else {
             contentArray = stopArray
-            tableView.reloadData()
+            DispatchQueue.main.async {
+                self.tableView.reloadData()
+            }
         }
     }
     

--- a/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflectionDetail/MyReflectionDetailViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflectionDetail/MyReflectionDetailViewController.swift
@@ -15,6 +15,8 @@ final class MyReflectionDetailViewController: BaseViewController {
     private var reflectionName: String
     private let reflectionId: Int
     private var contentArray: [FeedBackResponse] = []
+    private var continueArray: [FeedBackResponse] = []
+    private var stopArray: [FeedBackResponse] = []
     
     // MARK: - property
     
@@ -61,6 +63,7 @@ final class MyReflectionDetailViewController: BaseViewController {
         super.viewDidLoad()
         setupBackButton()
         fetchCertainTypeFeedbackAll(type: .fetchCertainTypeFeedbackAllID(reflectionId: reflectionId, cssType: .continueType))
+        fetchCertainTypeFeedbackAll(type: .fetchCertainTypeFeedbackAllID(reflectionId: reflectionId, cssType: .stopType))
     }
     
     override func render() {
@@ -87,6 +90,7 @@ final class MyReflectionDetailViewController: BaseViewController {
     }
     
     // MARK: - func
+    
     override func setupNavigationBar() {
         super.setupNavigationBar()
         
@@ -98,10 +102,11 @@ final class MyReflectionDetailViewController: BaseViewController {
     
     private func didChangeValue(segment: UISegmentedControl) {
         if segment.selectedSegmentIndex == 0 {
-            fetchCertainTypeFeedbackAll(type: .fetchCertainTypeFeedbackAllID(reflectionId: reflectionId, cssType: .continueType))
-        }
-        else {
-            fetchCertainTypeFeedbackAll(type: .fetchCertainTypeFeedbackAllID(reflectionId: reflectionId, cssType: .stopType))
+            contentArray = continueArray
+            tableView.reloadData()
+        } else {
+            contentArray = stopArray
+            tableView.reloadData()
         }
     }
     
@@ -114,7 +119,11 @@ final class MyReflectionDetailViewController: BaseViewController {
         ).responseDecodable(of: BaseModel<AllCertainTypeFeedBackResponse>.self) { json in
             if let json = json.value {
                 guard let jsonDetail = json.detail else { return }
-                self.contentArray = jsonDetail.feedback
+                self.contentArray.append(contentsOf: jsonDetail.feedback)
+                self.continueArray = self.contentArray.filter { $0.type == "Continue" }
+                self.stopArray = self.contentArray.filter{ $0.type == "Stop" }
+                
+                self.contentArray = self.continueArray
                 DispatchQueue.main.async {
                     self.tableView.reloadData()
                 }

--- a/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflectionDetail/MyReflectionDetailViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflectionDetail/MyReflectionDetailViewController.swift
@@ -135,10 +135,7 @@ final class MyReflectionDetailViewController: BaseViewController {
                 self.continueArray = self.contentArray.filter { $0.type == "Continue" }
                 self.stopArray = self.contentArray.filter{ $0.type == "Stop" }
                 
-                self.contentArray = self.continueArray
-                DispatchQueue.main.async {
-                    self.tableView.reloadData()
-                }
+                self.reloadTableView(type: FeedBackDTO.continueType.rawValue)
             }
         }
     }

--- a/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflectionDetail/MyReflectionDetailViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflectionDetail/MyReflectionDetailViewController.swift
@@ -91,6 +91,20 @@ final class MyReflectionDetailViewController: BaseViewController {
     
     // MARK: - func
     
+    private func reloadTableView(type: String) {
+        if type == FeedBackDTO.continueType.rawValue {
+            contentArray = continueArray
+            DispatchQueue.main.async {
+                self.tableView.reloadData()
+            }
+        } else {
+            contentArray = stopArray
+            DispatchQueue.main.async {
+                self.tableView.reloadData()
+            }
+        }
+    }
+    
     override func setupNavigationBar() {
         super.setupNavigationBar()
         
@@ -102,15 +116,9 @@ final class MyReflectionDetailViewController: BaseViewController {
     
     private func didChangeValue(segment: UISegmentedControl) {
         if segment.selectedSegmentIndex == 0 {
-            contentArray = continueArray
-            DispatchQueue.main.async {
-                self.tableView.reloadData()
-            }
+            reloadTableView(type: FeedBackDTO.continueType.rawValue)
         } else {
-            contentArray = stopArray
-            DispatchQueue.main.async {
-                self.tableView.reloadData()
-            }
+            reloadTableView(type: FeedBackDTO.stopType.rawValue)
         }
     }
     


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
https://user-images.githubusercontent.com/59243274/204475827-cc743126-1b09-4cff-a241-0938b7b9c8ca.mp4

현재에는 세그먼트 컨트롤의 값이 변경 됨에 따라 Continue 목록 불러오기, Stop 목록 불러오기 2가지 API를 계속해서 호출하는 방식으로 구현이 되어 있었습니다. 그로 인해 테이블 뷰가 리로드 될때 버벅거리는 현상이 있었습니다.

제가 생각하는 이 버그의 문제는 2가지 였습니다.
첫째, 나의 회고 뷰는 이미 끝난 회고를 받아와서 그 중 Continue, Stop을 보여주는 뷰기 때문에 세그먼트 컨트롤이 바뀔때마다 API 통신을 하는것은 굉장히 바보같은 일이다. 

둘째, 버벅거림의 버그는 우리가 개발자로서 Continue와 Stop을 (세그먼트를) 막 눌러서 얘가 지금 reload 되지도 않았는데 다른걸 reload 하는 과정에서 생기는 부분같다.

첫번째 문제의 해결책으로 API 통신을 viewDidLoad에서 한번에 둘다 하고 Continue는 ContinueArray라는 배열에 Stop은 StopArray라는 배열에 담아두고 세그먼트가 바꼈을 때 각각의 배열을 사용하는것으로 처리했습니다. 

두번째 문제의 해결책은 사실 아직 고민중입니다. 
일단 메인 쓰레드 보장을 해줬고, 음.. 어떤 방식이 있을까요? (디퍼블..?)

----------------------------------------------

** 2022년 12월 1일 **
팀원들과 논의한 결과, 딸각거림은 새로운 이슈를 파서 해결하는것으로 하겠습니다. 

현재 PR은 첫번째 문제를 해결한 PR입니다.



## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 버튼이 잡혀있지 않은 액션이 있었습니다. 삭제했습니다.
- API를 한번에 호출하고 보여주는 식으로 변경했습니다.
- 메인 쓰레드 보장을 해줬습니다.

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
feature/192-segement-api-bug-fix 로 오셔서 나의회고에서 한 회고를 들어가고 세그먼트 컨트롤을 변경해보면 됩니다.

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->





## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #192


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
