### PR TITLE
[CHORE] 회고 일정 추가 후 dismiss되게 변경

### DIFF
--- a/Maddori.Apple/Maddori.Apple/Screen/Home/CreateReflection/CreateReflectionViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/CreateReflection/CreateReflectionViewController.swift
@@ -145,7 +145,6 @@ final class CreateReflectionViewController: BaseViewController {
                     reflection_date: String(describing: reflectionDate)
                 )
             ))
-            self?.dismiss(animated: true)
         }
         mainButton.addAction(action, for: .touchUpInside)
     }
@@ -191,9 +190,10 @@ final class CreateReflectionViewController: BaseViewController {
                    parameters: type.body,
                    encoder: JSONParameterEncoder.default,
                    headers: type.header
-        ).responseDecodable(of: BaseModel<AddReflectionResponse>.self) {
-            json in
-            dump(json)
+        ).responseDecodable(of: BaseModel<AddReflectionResponse>.self) { [weak self] json in
+            if let _ = json.value {
+                self?.dismiss(animated: true)
+            }
         }
     }
 }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
리더가 회고일정을 설정했음에도 homeView에서 바로 반영되지 않는 문제가 있었습니다.
회고 일정을 설정하는 request를 보냄과 동시에 해당 view를 dismiss해서 돌아가는 view에서 viewWillAppear가 돌아갈 때 해당 request가 반영되지 않아있는 문제였습니다.
API통신이 완료되었을 때 dismiss되게끔 순서를 보장해줬습니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
API통신이 제대로 됐을 때 dismiss되게 변경했습니다.


## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
새로 방을 만드시고 회고 일정을 등록해보시면 됩니다.


## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->

https://user-images.githubusercontent.com/78677571/204683093-a8ae26b5-0f0f-499a-8983-ec534e9a901c.mp4




## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
지난번에 Alamofire에서 responseDecodable를 쓰기 애매한데 사용하는 경우에 대해 말씀드렸었는데, 현재 PR에선 if let 으로 return되는 데이터가 있다면 해당 코드를 실행하게 함으로써 순서를 보장해줬습니다. 



```swift
AF.request(type.address,
           method: type.method,
           parameters: type.body,
           encoder: JSONParameterEncoder.default,
           headers: type.header
)
.validate(statusCode: 200..<400)
.response { [weak self] json in
    if let _ = json.value {
        self?.dismiss(animated: true)
    }
}
```
하지만 responseDecodable을 사용하지 않고 순서를 보장하는 방법으론, Alamofire에서 지원하는 validate로 정상 통신이 되었는지 확인하고 response 코드를 실행시키는 방법이 있습니다.

현재 PR에 작성한 방법대로 해도 되고, 위와 같은 방법으로 해도 상관없습니다.
단지 통일성을 위해 decodable로 만들었을 뿐입니다 ^________^
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #194 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
