### PR TITLE
[FIX] 초대코드 복사 토스트가 계속 내려오는 문제 해결

### DIFF
--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/InvitationCode/InvitationCodeViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/InvitationCode/InvitationCodeViewController.swift
@@ -14,6 +14,7 @@ final class InvitationCodeViewController: BaseViewController {
     
     let teamName: String
     let invitationCode: String
+    private var isTappedCopyButton: Bool = false
     
     init(teamName: String, invitationCode: String) {
         self.teamName = teamName
@@ -138,13 +139,18 @@ final class InvitationCodeViewController: BaseViewController {
     // MARK: - func
     
     private func showToastPopUp() {
+        if !isTappedCopyButton {
+            isTappedCopyButton = true
             UIView.animate(withDuration: 0.5, delay: 0, animations: {
                 self.toastView.transform = CGAffineTransform(translationX: 0, y: 115)
-            }, completion: {_ in
+            }, completion: { _ in
                 UIView.animate(withDuration: 1, delay: 0.8, animations: {
                     self.toastView.transform = .identity
+                }, completion: { _ in
+                    self.isTappedCopyButton = false
                 })
             })
+        }
     }
     
     private func setGradientToastView() {

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/InvitationCode/InvitationCodeViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/InvitationCode/InvitationCodeViewController.swift
@@ -43,7 +43,7 @@ final class InvitationCodeViewController: BaseViewController {
         button.setTitleColor(UIColor.blue200, for: .normal)
         button.titleLabel?.font = .label2
         button.backgroundColor = .gray100
-        button.layer.cornerRadius = 4
+        button.layer.cornerRadius = 7
         return button
     }()
     private lazy var startButton: MainButton = {


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
팀을 생성하고 팀원 초대를 위해 초대코드를 복사했을 때, 토스트뷰가 뜨는데 계속 클릭하면 쭉쭉 내려가는 문제가 있었습니다.

https://user-images.githubusercontent.com/78677571/204723095-7ddc1624-15ec-4c3f-8f34-9d7ec51a3d32.mp4


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
1. 토스트뷰가 `isTappedCopyButton = false`일때만 보이게 조건을 걸어뒀습니다.
2. 토스트뷰가 보이기 시작할 때, `isTappedCopyButton`을 true로 바꿉니다.
3. 토스트뷰가 완전히 사라졌을 때 `isTappedCopyButton`을 false로 변경합니다.

++)
코드 복사하기 버튼이 좀 딱딱해 보여서 살짝 수정한 뒤 최고의 디자이너 선생님들께 어떤지 제안하려고 했는데, 저희 피그마엔 cornerRadius가 7로 되어있고, 실제론 4로 되어있어서 7로 반영했습니다.
## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
새로 방을 만들려면 다시 회원탈퇴를 해야해서 SceneDelegate를 수정했습니다.
```swift
if isLogined {
    rootViewController = UINavigationController(rootViewController: InvitationCodeViewController(teamName: "", invitationCode: "ABCDEF"))
} else {
    rootViewController = UINavigationController(rootViewController: LoginViewController())
}
```

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->

https://user-images.githubusercontent.com/78677571/204723872-964d3734-8554-48d9-a794-a7b19d393658.mp4



## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
버튼이 눌렀는지 확인하는 변수를 만드는 방법도 있지만, 버튼을 비활성화 하는 방법도 있는 것 같아 만들어봤습니다.

https://user-images.githubusercontent.com/78677571/204723962-57cfce19-6405-4f58-b831-c32527fb6f37.mp4
(코드 복사하기 버튼을 매우 연타중입니다)

근데 이렇게 만들고 보니, 토스트가 보이는 동안에 "코드 복사하기" 버튼을 누를 수 없는게 이상한 것 같아서 현재의 방법으로 구현했습니다.
혹시 이게 더 괜찮은 것 같다면 말씀해주세요 !


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #197 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
