### PR TITLE
[CHORE] 디테일 상세보기 화면에서 스크롤 안되는 문제 해결

### DIFF
--- a/Maddori.Apple/Maddori.Apple/Screen/Home/InProgress/InProgressViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/InProgress/InProgressViewController.swift
@@ -174,9 +174,9 @@ final class InProgressViewController: BaseViewController {
     }
     
     private func presentDetailView(feedbackInfo: ReflectionInfoModel) {
-         let viewController = InProgressDetailViewController(feedbackInfo: feedbackInfo)
-         self.present(viewController, animated: true)
-     }
+        let viewController = InProgressDetailViewController(feedbackInfo: feedbackInfo)
+        self.present(viewController, animated: true)
+    }
     
     // MARK: - api
     

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/InProgressDetail/InProgressDetailViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/InProgressDetail/InProgressDetailViewController.swift
@@ -45,6 +45,12 @@ final class InProgressDetailViewController: BaseViewController {
         label.textColor = .black100
         return label
     }()
+    private let feedbackScrollView = UIScrollView()
+    private let feedbackStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        return stackView
+    }()
     private lazy var infoLabel: UILabel = {
         let label = UILabel()
         label.text = feedbackInfo.info
@@ -64,7 +70,7 @@ final class InProgressDetailViewController: BaseViewController {
     }()
     
     // MARK: - life cycle
-        
+    
     override func render() {
         view.addSubview(closeButton)
         closeButton.snp.makeConstraints {
@@ -84,17 +90,33 @@ final class InProgressDetailViewController: BaseViewController {
             $0.top.equalTo(sendFromLabel.snp.bottom).offset(10)
         }
         
-        view.addSubview(infoLabel)
+        view.addSubview(feedbackScrollView)
+        feedbackScrollView.snp.makeConstraints {
+            $0.leading.trailing.bottom.equalToSuperview()
+            $0.top.equalTo(keywordLabel.snp.bottom).offset(20)
+        }
+        
+        feedbackScrollView.addSubview(feedbackStackView)
+        feedbackStackView.snp.makeConstraints {
+            $0.edges.width.equalToSuperview()
+        }
+        
+        feedbackStackView.addSubview(infoLabel)
         infoLabel.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
-            $0.top.equalTo(keywordLabel.snp.bottom).offset(32)
+            $0.top.equalToSuperview().inset(32)
         }
         
         if !feedbackInfo.start.isEmpty {
-            view.addSubview(startView)
+            feedbackStackView.addSubview(startView)
             startView.snp.makeConstraints {
                 $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
                 $0.top.equalTo(infoLabel.snp.bottom).offset(28)
+                $0.bottom.equalToSuperview()
+            }
+        } else {
+            infoLabel.snp.makeConstraints {
+                $0.bottom.equalToSuperview()
             }
         }
     }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
회고시간에 내 차례에 보이는 상세 피드백 화면에서, 내용이 길 때 스크롤이 되지 않아서 다 안보이는 문제가 있었습니다.
해당 부분을 손봤습니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
UIStackView를 추가해서 내부 컨텐츠의 크기에 따라 유동적으로 사이즈가 바뀌게 수정했습니다 !

++)
불편한 줄이 있어서 살짝 띄어줬습니다 ! ^__________^

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
회고를 시작했을 때, 순서에서 날 선택하고 받은 피드백들을 보면 됩니다.

애매하다 싶으시면 SceneDelegate에서 
```swift
if isLogined {
            rootViewController = InProgressDetailViewController(feedbackInfo: ReflectionInfoModel(nickname: "호야", feedbackType: .continueType, keyword: "메롱", info:
        """
ㅁㄴㅇ
ㅇ
ㅇ
ㅇ
ㅇ
ㅇ
ㅇ
ㅇ
ㅇ
ㅇ
ㅇ
ㅇ
ㅇ
ㅇ

ㅇ
ㅇ
ㅇ
ㅇ
ㅇ

d
d
d
d

d
d
d
d
d
d

d
d

"""
,
start: """
d
d
d
d
fs
d
fsd
f
sdf
sd
fds

f
sd

fs
d
f
ds

f
sd
f
sd
f
ds

f
sd
fsd
fsd
fs

"""
                                                                                                                                            ))
        } else {
            rootViewController = UINavigationController(rootViewController: LoginViewController())
        }
```

이런식으로 첫 화면을 바꾸셔도 됩니다 !
## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->

https://user-images.githubusercontent.com/78677571/204770547-b9ec6f4a-b5df-4c90-a70f-09e43d22cdce.mp4



## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
다른 UIScrollView를 쓰는곳에도 StackView를 적용해서 내부 property의 크기별로 유동적으로 수정되게 바꾸면 좋을 것 같습니다 !

생각보다 UIScrollView에서 많이 막혔습니다.
계속 레이아웃이 안맞아서 내부의 스크롤이 안되는 문제가 있었습니다.
해결한 방법은, 내부의 제일 마지막 property에 bottom을 StackView의 bottom으로 잡아주어야 합니다 !
크기를 가늠할 수 없기 때문에, 내부 마지막 property의 bottom으로 크기를 산정하는 것 같슷ㅂ니다.

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #199


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
