### PR TITLE
[ADD] README 만들기

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# MacC-Team-Maddori.Apple
+<img src="https://user-images.githubusercontent.com/81340603/204945336-287ce115-ac38-409f-8136-039ae4d5e140.png" />
+<h3 align="center">키고: KeyGo</h3>
+<p align="center">KeyGo를 통해 솔직하고 재미있는 팀 회고 시간을 가져 보아요!</p>
+
+<div style="display: flex; flex-direction: column;" align="center" >
+  <a href="https://apps.apple.com/kr/app/%ED%82%A4%EA%B3%A0-keygo/id6444039454?l=en">
+    <img src="https://user-images.githubusercontent.com/81340603/204947353-18c33fe9-c49b-443a-b1e2-7cf9a85bb91b.png" width=180px />
+  </a>
+  <p3>&nbsp;&nbsp;&nbsp;</p3>
+  <a href="https://github.com/hwiwonK/MacC-Team-Maddori.Apple-Server">
+    <img src="https://user-images.githubusercontent.com/81340603/204950025-e1fb934e-8d48-4fb3-a7f3-55dd465ed2f7.png" width=60px/>
+  </a>
+</div>

--- a/README.md
+++ b/README.md
@@ -11,3 +11,56 @@
     <img src="https://user-images.githubusercontent.com/81340603/204950025-e1fb934e-8d48-4fb3-a7f3-55dd465ed2f7.png" width=60px/>
   </a>
 </div>
+
+
+<h2>🧐 Preview</h2>
+<img src="https://user-images.githubusercontent.com/81340603/204951310-45345674-3d00-4d72-a61b-bc6ddc996363.png" />
+
+<div align="center">
+  ➿<br>
+  상황을 키워드와 함께 기록하며, 회고 당일 피드백을 잊지 않고 전할 수 있습니다<br>
+  팀 내에서 등록된 키워드를 확인하며, 예정된 회고 내용을 미리 볼 수 있습니다<br>
+  회고 당일, 내가 받은 키워드를 확인하고 상세 상황을 들어보며 피드백을 나눌 수 있습니다<br>
+  지금까지 내가 받은 피드백을 모아볼 수 있습니다<br>
+  ➿
+</div>
+
+<br>
+
+
+<h2>🗂 Directory Structure</h2>
+<img src="https://user-images.githubusercontent.com/81340603/204957214-2d19ce84-04d6-49c3-9c11-9984be7fd7d6.png" />
+
+
+<br>
+
+
+<h2>🔩 Tech & Skills</h2>
+
+<img width="61" src="https://img.shields.io/badge/UIKit-blue"> <img width="103" src="https://img.shields.io/badge/Alamofire-blue"> <img width="87" src="https://img.shields.io/badge/SnapKit-blue"> <img width="118" src="https://img.shields.io/badge/AppleLogin-blue"> <br>
+<img width="70" src="https://img.shields.io/badge/Figma-red"> <img width="75" src="https://img.shields.io/badge/Github-yellow"> <img width="53" src="https://img.shields.io/badge/Miro-yellow"> <img width="73" src="https://img.shields.io/badge/Notion-yellow"> <img width="64" src="https://img.shields.io/badge/Slack-yellow">
+
+
+<br>
+
+
+<h2>🛠 Development Environment</h2>
+
+<img width="100" src="https://img.shields.io/badge/iOS-14+-silver"> <img width="125" src="https://img.shields.io/badge/Xcode-14.0-blue">
+
+
+<br>
+
+
+<h2>🔏 License</h2>
+<img width="170" src="https://img.shields.io/badge/MIT License-2.0-yellow">
+
+
+<br>
+
+<h2>👨‍🎨 Authors</h2>
+
+|[Ginger / 김유나](https://github.com/Guel-git)|[Hoya / 이성호](https://github.com/Guel-git)|[Id / 이성민](https://github.com/Guel-git)|[Mary / 김휘원](https://github.com/Guel-git)|[Chemi / 최민관](https://github.com/Guel-git)|
+|:---:|:---:|:---:|:---:|:---:|
+| <img width=200px src="https://github.com/Guel-git.png"/> | <img width=200px src="https://github.com/dangsal.png"/> | <img width=200px src="https://github.com/seongmin221.png"/> | <img width=200px src="https://github.com/hwiwonK.png"/> | <img width=200px src="https://github.com/MMMIIIN.png"/> 
+|<center>Project Manager<br>iOS Developer<br>UI/UX Designer</center>|<center>iOS Developer<br>Team Manager</center>|<center>iOS Developer<br>UI/UX Lead Designer</center>|<center>Backend Developer<br>UI/UX Designer</center>|<center>iOS Lead Developer</center>|


### PR DESCRIPTION
## 🌁 Background
맛도리 애플 레포지터리의 간판이 필요했습니다.


## 👩‍💻 Contents
- 상단 Banner / Preview / Directory 이미지 제작
- 기능 설명 추가
- Tech & Skills / Development Environment / License 캡슐 추가
- Author 테이블 추가

## ✅ Testing
레포 메인에서 브랜치를 feature/202-make-read-me 바꿔서 바로 확인하시면 됩니다!


## 📱 Screenshot
<img src="https://user-images.githubusercontent.com/81340603/204963393-a8fdd70f-2991-4674-9556-c3b44ab5b91b.png" width=300px />


## 📝 Review Note
project에 관한 내용을 추가할지 말지 고민이네요,,,
원래 코드/깃 컨벤션을 추가하려고 했는데 양식이 마땅하게 떠오르지 않아요,, 
아이디어 있으시면 의견 제안 부탁드립니다!


## 📣 Related Issue
- close #202 
