### PR TITLE
[ADD] 내가 쓴 피드백 상세 보기 화면에서의 키워드 UI를 변경했습니다.

### DIFF
--- a/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
+++ b/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		396334D7292DADBE00E74B77 /* AppleLoginDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396334D6292DADBE00E74B77 /* AppleLoginDTO.swift */; };
 		396334D9292DAE0000E74B77 /* AppleLoginResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396334D8292DAE0000E74B77 /* AppleLoginResponse.swift */; };
 		396334DB292DAE8300E74B77 /* UserResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396334DA292DAE8300E74B77 /* UserResponse.swift */; };
+		3975CEAF293EEDD6002D4F1A /* KeywordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3975CEAE293EEDD6002D4F1A /* KeywordView.swift */; };
 		397E49572924D93F004220D6 /* UrlLiteral.swift in Sources */ = {isa = PBXBuildFile; fileRef = 397E49562924D93F004220D6 /* UrlLiteral.swift */; };
 		397E495A2924F871004220D6 /* UserDefaultStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 397E49592924F871004220D6 /* UserDefaultStorage.swift */; };
 		397E495C2924F8A2004220D6 /* UserDefaultHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 397E495B2924F8A2004220D6 /* UserDefaultHandler.swift */; };
@@ -171,6 +172,7 @@
 		396334D8292DAE0000E74B77 /* AppleLoginResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginResponse.swift; sourceTree = "<group>"; };
 		396334DA292DAE8300E74B77 /* UserResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserResponse.swift; sourceTree = "<group>"; };
 		396334DC292DB07100E74B77 /* Maddori.Apple.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Maddori.Apple.entitlements; sourceTree = "<group>"; };
+		3975CEAE293EEDD6002D4F1A /* KeywordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordView.swift; sourceTree = "<group>"; };
 		397E49562924D93F004220D6 /* UrlLiteral.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UrlLiteral.swift; sourceTree = "<group>"; };
 		397E49592924F871004220D6 /* UserDefaultStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultStorage.swift; sourceTree = "<group>"; };
 		397E495B2924F8A2004220D6 /* UserDefaultHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultHandler.swift; sourceTree = "<group>"; };
@@ -553,6 +555,7 @@
 				3E557FC428FE854600714E46 /* KeywordLabel.swift */,
 				52F0CB5129178C2700E39C50 /* AlertViewController.swift */,
 				3EA341C029221998005CBD1C /* ToastContentView.swift */,
+				3975CEAE293EEDD6002D4F1A /* KeywordView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1078,6 +1081,7 @@
 				39F52C53292330D200B19A77 /* MemberResponse.swift in Sources */,
 				39F52C6A292473A800B19A77 /* ReflectionInfoResponse.swift in Sources */,
 				39F52C68292472EB00B19A77 /* AllFeedBackResponse.swift in Sources */,
+				3975CEAF293EEDD6002D4F1A /* KeywordView.swift in Sources */,
 				39257DF128F93C2A00201E0B /* ImageLiteral.swift in Sources */,
 				395C7E252900E74700FC2FCA /* StartReflectionViewController.swift in Sources */,
 				3E557FF82901CD3400714E46 /* KeywordCollectionViewFlowLayout.swift in Sources */,

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/View/KeywordView.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/View/KeywordView.swift
@@ -1,0 +1,48 @@
+//
+//  KeywordView.swift
+//  Maddori.Apple
+//
+//  Created by Mingwan Choi on 2022/12/06.
+//
+
+import UIKit
+
+import SnapKit
+
+final class FeedbackKeyword: UIView {
+    let title: String
+    
+    private lazy var feedbackLabel: UILabel = {
+        let label = UILabel()
+        label.text = title
+        label.textColor = .gray200
+        label.font = .main
+        return label
+    }()
+    
+    // MARK: - life cycle
+    
+    init(title: String) {
+        self.title = title
+        super.init(frame: .zero)
+        render()
+        configUI()
+    }
+    
+    required init?(coder: NSCoder) { nil }
+    
+    private func configUI() {
+        self.backgroundColor = .blue200
+        self.layer.cornerRadius = 24
+        self.makeShadow(color: .black, opacity: 0.25, offset: .zero, radius: 4)
+    }
+    
+    private func render() {
+        self.addSubview(feedbackLabel)
+        feedbackLabel.snp.makeConstraints {
+            $0.verticalEdges.equalToSuperview().inset(13)
+            $0.horizontalEdges.equalToSuperview().inset(16)
+        }
+    }
+}
+

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/View/KeywordView.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/View/KeywordView.swift
@@ -10,12 +10,15 @@ import UIKit
 import SnapKit
 
 final class FeedbackKeyword: UIView {
+    let keywordType: KeywordType = .previewKeyword
     let title: String
+    
+    // MARK: - property
     
     private lazy var feedbackLabel: UILabel = {
         let label = UILabel()
         label.text = title
-        label.textColor = .gray200
+        label.textColor = keywordType.textColor
         label.font = .main
         return label
     }()
@@ -32,9 +35,13 @@ final class FeedbackKeyword: UIView {
     required init?(coder: NSCoder) { nil }
     
     private func configUI() {
-        self.backgroundColor = .blue200
+        self.backgroundColor = keywordType.labelColor[0]
         self.layer.cornerRadius = 24
-        self.makeShadow(color: .black, opacity: 0.25, offset: .zero, radius: 4)
+        self.layer.maskedCorners = keywordType.maskedCorners
+        self.makeShadow(color: .black,
+                        opacity: keywordType.shadowOpacity,
+                        offset: .zero,
+                        radius: keywordType.shadowRadius)
     }
     
     private func render() {

--- a/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackDetail/MyFeedbackDetailViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackDetail/MyFeedbackDetailViewController.swift
@@ -57,13 +57,7 @@ final class MyFeedbackDetailViewController: BaseViewController {
         label.font = .label2
         return label
     }()
-    private lazy var feedbackKeywordText: UILabel = {
-        let label = UILabel()
-        label.setTextWithLineHeight(text: feedbackDetail.keyword, lineHeight: 24)
-        label.textColor = .gray400
-        label.font = .body1
-        return label
-    }()
+    private lazy var feedbackKeyword = FeedbackKeyword(title: feedbackDetail.keyword)
     private let feedbackContentLabel: UILabel = {
         let label = UILabel()
         label.text = TextLiteral.feedbackContentLabel
@@ -176,15 +170,15 @@ final class MyFeedbackDetailViewController: BaseViewController {
             $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
         }
         
-        feedbackFromMeDetailContentView.addSubview(feedbackKeywordText)
-        feedbackKeywordText.snp.makeConstraints {
+        feedbackFromMeDetailContentView.addSubview(feedbackKeyword)
+        feedbackKeyword.snp.makeConstraints {
             $0.top.equalTo(feedbackKeywordLabel.snp.bottom).offset(SizeLiteral.labelComponentPadding)
             $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
         }
         
         feedbackFromMeDetailContentView.addSubview(feedbackContentLabel)
         feedbackContentLabel.snp.makeConstraints {
-            $0.top.equalTo(feedbackKeywordText.snp.bottom).offset(SizeLiteral.componentIntervalPadding)
+            $0.top.equalTo(feedbackKeyword.snp.bottom).offset(SizeLiteral.componentIntervalPadding)
             $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
         }
         


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
새로 기획한 내용중의 일부인 상세 키워드 UI를 변경하는 PR입니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
내가 쓴 피드백 수정하러 가기전, 상세 화면이 보이는 부분에서의 키워드 UI를 변경했습니다.
HomeViewController에서 사용하는 키워드들의 enum 값을 사용했습니다.


## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
보관함 탭에서 내가 쓴 피드백을 클릭해보시면 됩니다.



## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<img width=350 src = "https://user-images.githubusercontent.com/78677571/205840569-999c7610-6fc8-4151-8ab8-4c05eb923c66.png">

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
<img width="400" alt="image" src="https://user-images.githubusercontent.com/78677571/205841231-dd8377b6-3dd6-439f-8bab-1da52c3aa93a.png">
요기 왼쪽 아래부분의 corner값이 다르기 때문에 그런지, shadow가 살짝 다르게 들어가있는 듯한 느낌입니다.
현재 이 부분까지 수정하기엔 급한 상황이라, 공유만 드리고 넘어가겠습니다 !

수정하러 가기 버튼을 누르면 나오는 view에서는 이드가 작업하고있는 키워드 TextField를 가져와 사용할 예정입니다.


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #217 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
