### PR TITLE
[CHORE] 피드백 돌아보기 view에서 start 내용 삭제

### DIFF
--- a/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflectionFeedback/MyReflectionFeedbackViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflectionFeedback/MyReflectionFeedbackViewController.swift
@@ -11,7 +11,7 @@ import SnapKit
 
 final class MyReflectionFeedbackViewController: BaseViewController {
     
-    var model: FeedBackResponse
+    let model: FeedBackResponse
     
     // MARK: - property
     
@@ -76,21 +76,6 @@ final class MyReflectionFeedbackViewController: BaseViewController {
         label.numberOfLines = 0
         return label
     }()
-    private let feedbackStartLabel: UILabel = {
-        let label = UILabel()
-        label.text = TextLiteral.myReflectionFeedbackViewControllerFeedbackStartLabel
-        label.textColor = .black100
-        label.font = .label2
-        return label
-    }()
-    private lazy var feedbackStartText: UILabel = {
-        let label = UILabel()
-        label.setTextWithLineHeight(text: model.startContent, lineHeight: 24)
-        label.textColor = .gray400
-        label.font = .body1
-        label.numberOfLines = 0
-        return label
-    }()
     
     // MARK: - life cycle
     
@@ -100,11 +85,6 @@ final class MyReflectionFeedbackViewController: BaseViewController {
     }
     
     required init?(coder: NSCoder) { nil }
-    
-    override func configUI() {
-        super.configUI()
-        setupStartLabel()
-    }
     
     override func render() {
         view.addSubview(myReflectionScrollView)
@@ -158,19 +138,6 @@ final class MyReflectionFeedbackViewController: BaseViewController {
             $0.top.equalTo(feedbackContentLabel.snp.bottom).offset(SizeLiteral.labelComponentPadding)
             $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
         }
-        
-        myReflectionContentView.addSubview(feedbackStartLabel)
-        feedbackStartLabel.snp.makeConstraints {
-            $0.top.equalTo(feedbackContentText.snp.bottom).offset(SizeLiteral.componentIntervalPadding)
-            $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
-        }
-        
-        myReflectionContentView.addSubview(feedbackStartText)
-        feedbackStartText.snp.makeConstraints {
-            $0.top.equalTo(feedbackStartLabel.snp.bottom).offset(SizeLiteral.labelComponentPadding)
-            $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
-            $0.bottom.equalToSuperview().inset(20)
-        }
     }
     
     // MARK: - func
@@ -184,11 +151,5 @@ final class MyReflectionFeedbackViewController: BaseViewController {
         navigationController?.navigationBar.prefersLargeTitles = false
         navigationItem.largeTitleDisplayMode = .never
         navigationItem.leftBarButtonItem = backButton
-    }
-    
-    private func setupStartLabel() {
-        if model.startContent == nil || model.startContent == "" {
-            feedbackStartLabel.isHidden = true
-        }
     }
 }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
피드백을 추가하는 과정이 수정됨에 따라, start를 작성하는 부분이 자연스럽게 내용에 합쳐졌습니다.
그에따라 피드백 돌아보기 view를 수정하는 PR입니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
1. 단순히 start 부분을 삭제했습니다.
2. 회고에 대한 정보를 model로 받아서 사용하는 부분이 변하지 않는데 `var`로 설정되어 있어서 `let`으로 수정했습니다.

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
지난회고에서 start가 있는 feedback의 view로 들어갔을때 start내용이 안보이면 됩니다 !

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<img width="784" alt="image" src="https://user-images.githubusercontent.com/78677571/206429632-e4653e47-372a-4379-8a13-e3e54e4099ab.png">

<img width="300" alt="image" src="https://user-images.githubusercontent.com/78677571/206429658-45b7b7cb-5bc0-4006-a3d6-b35095d77441.png">

실제로 DB에 start가 있는데 view에선 표시되지 않습니다 !

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
지우기만하면 되서 아주 편했습니다 !
개꿀 ! ^________^


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #225


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
