### PR TITLE
[ADD] 피드백 수정하기 UI변경에 따라 상속 삭제

### DIFF
--- a/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
+++ b/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
@@ -89,7 +89,7 @@
 		3E557FFA2901CD4200714E46 /* KeywordCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E557FF92901CD4200714E46 /* KeywordCollectionViewCell.swift */; };
 		3E557FFD2901CD7400714E46 /* Keyword.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E557FFC2901CD7400714E46 /* Keyword.swift */; };
 		3E5580072906A7B200714E46 /* InProgressViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E5580062906A7B200714E46 /* InProgressViewController.swift */; };
-		3E66777529419C8300BB5670 /* KeywordTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E66777429419C8300BB5670 /* KeywordTextField.swift */; };
+		3E66777529419C8300BB5670 /* KeywordTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E66777429419C8300BB5670 /* KeywordTextFieldView.swift */; };
 		3E8052DF2906E09100A6449D /* KeywordSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E8052DE2906E09100A6449D /* KeywordSectionHeaderView.swift */; };
 		3EA341C129221998005CBD1C /* ToastContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA341C029221998005CBD1C /* ToastContentView.swift */; };
 		3EA341E62924E2AD005CBD1C /* HomeEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA341E52924E2AD005CBD1C /* HomeEndPoint.swift */; };
@@ -222,7 +222,7 @@
 		3E557FF92901CD4200714E46 /* KeywordCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordCollectionViewCell.swift; sourceTree = "<group>"; };
 		3E557FFC2901CD7400714E46 /* Keyword.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keyword.swift; sourceTree = "<group>"; };
 		3E5580062906A7B200714E46 /* InProgressViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InProgressViewController.swift; sourceTree = "<group>"; };
-		3E66777429419C8300BB5670 /* KeywordTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordTextField.swift; sourceTree = "<group>"; };
+		3E66777429419C8300BB5670 /* KeywordTextFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordTextFieldView.swift; sourceTree = "<group>"; };
 		3E8052DE2906E09100A6449D /* KeywordSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordSectionHeaderView.swift; sourceTree = "<group>"; };
 		3EA341C029221998005CBD1C /* ToastContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastContentView.swift; sourceTree = "<group>"; };
 		3EA341E52924E2AD005CBD1C /* HomeEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeEndPoint.swift; sourceTree = "<group>"; };
@@ -724,7 +724,7 @@
 		3E66777329419C7500BB5670 /* UIComponent */ = {
 			isa = PBXGroup;
 			children = (
-				3E66777429419C8300BB5670 /* KeywordTextField.swift */,
+				3E66777429419C8300BB5670 /* KeywordTextFieldView.swift */,
 			);
 			path = UIComponent;
 			sourceTree = "<group>";
@@ -1053,7 +1053,7 @@
 				D7AFB7C72916FF9400E998B7 /* CustomSegmentControl.swift in Sources */,
 				3EB508692913560A00FB77CB /* Reflection.swift in Sources */,
 				52DC9091291A98CC00904739 /* MyFeedbackEditViewController.swift in Sources */,
-				3E66777529419C8300BB5670 /* KeywordTextField.swift in Sources */,
+				3E66777529419C8300BB5670 /* KeywordTextFieldView.swift in Sources */,
 				3EA341E82925E5EA005CBD1C /* String+Extension.swift in Sources */,
 				D7AFB7C72916FF9400E998B7 /* CustomSegmentControl.swift in Sources */,
 				7E8CDC67292E19B000984742 /* SettingButton.swift in Sources */,

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/View/FeedbackTypeButtonView.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/View/FeedbackTypeButtonView.swift
@@ -11,7 +11,7 @@ import SnapKit
 
 final class FeedbackTypeButtonView: UIView {
     var changeFeedbackType: ((FeedbackButtonType) -> ())?
-    var feedbackType: FeedBackType? {
+    var feedbackType: FeedbackButtonType? {
         didSet {
             guard let type = feedbackType else { return }
             applyFeedbackButtonStyle(type)
@@ -145,14 +145,12 @@ final class FeedbackTypeButtonView: UIView {
     
     // MARK: - func
     
-    private func applyFeedbackButtonStyle(_ type: FeedBackType) {
+    private func applyFeedbackButtonStyle(_ type: FeedbackButtonType) {
         switch type {
         case .continueType:
             applyBorderStyle(selectedButton: continueButton, unselectedButton: stopButton)
         case .stopType:
             applyBorderStyle(selectedButton: stopButton, unselectedButton: continueButton)
-        default:
-            break
         }
     }
     
@@ -165,7 +163,7 @@ final class FeedbackTypeButtonView: UIView {
         unselectedButton.makeShadow(color: .black, opacity: 0.15, offset: .zero, radius: 1)
     }
     
-    private func applyButtonLabelStyle(_ type: FeedBackType) {
+    private func applyButtonLabelStyle(_ type: FeedbackButtonType) {
         switch type {
         case .continueType:
             continueTitleLabel.textColor = .blue200
@@ -177,8 +175,6 @@ final class FeedbackTypeButtonView: UIView {
             stopSubTitleLabel.textColor = .blue200
             continueTitleLabel.textColor = .black100
             continueSubTitleLabel.textColor = .gray500
-        default:
-            break
         }
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/AddFeedback/AddFeedbackKeywordViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/AddFeedback/AddFeedbackKeywordViewController.swift
@@ -74,7 +74,7 @@ final class AddFeedbackKeywordViewController: BaseViewController {
         label.numberOfLines = 2
         return label
     }()
-    private let keywordTextField = KeywordTextField()
+    private let keywordTextField = KeywordTextFieldView(placeHolder: TextLiteral.addFeedbackKeywordViewControllerPlaceholder)
     private let containerScrollView: UIScrollView = {
         let view = UIScrollView()
         view.backgroundColor = .blue300

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/AddFeedback/UIComponent/KeywordTextFieldView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/AddFeedback/UIComponent/KeywordTextFieldView.swift
@@ -7,10 +7,9 @@
 
 import UIKit
 
-import Alamofire
 import SnapKit
 
-final class KeywordTextField: UIView {
+final class KeywordTextFieldView: UIView {
     
     private enum Length {
         static let keywordMaxLength: Int = 10
@@ -24,9 +23,9 @@ final class KeywordTextField: UIView {
     }
     
     var textFieldWidth: CGFloat = 0
-    var placeholder = TextLiteral.addFeedbackKeywordViewControllerPlaceholder
+    var placeholder: String
     var placeholderWidth: CGFloat {
-        let placeholder = TextLiteral.addFeedbackKeywordViewControllerPlaceholder
+        let placeholder = placeholder
         let fontAttributes = [NSAttributedString.Key.font: UIFont.main]
         let width = (placeholder as NSString).size(withAttributes: fontAttributes).width
         return width
@@ -68,8 +67,9 @@ final class KeywordTextField: UIView {
     
     // MARK: - life cycle
     
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    init(placeHolder: String) {
+        self.placeholder = placeHolder
+        super.init(frame: .zero)
         render()
         setupDelegate()
         setupTextFieldObserver()
@@ -168,7 +168,7 @@ final class KeywordTextField: UIView {
     }
 }
 
-extension KeywordTextField: UITextFieldDelegate {
+extension KeywordTextFieldView: UITextFieldDelegate {
     func textFieldDidChangeSelection(_ textField: UITextField) {
         checkMaxLength(textField: keywordTextField, maxLength: Length.keywordMaxLength)
     }

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/AddFeedback/UIComponent/KeywordTextFieldView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/AddFeedback/UIComponent/KeywordTextFieldView.swift
@@ -27,7 +27,7 @@ final class KeywordTextFieldView: UIView {
     var placeholderWidth: CGFloat {
         let placeholder = placeholder
         let fontAttributes = [NSAttributedString.Key.font: UIFont.main]
-        let width = (placeholder as NSString).size(withAttributes: fontAttributes).width
+        let width = (placeholder as NSString).size(withAttributes: fontAttributes).width + 1
         return width
     }
     

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/AddFeedback/UIComponent/KeywordTextFieldView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/AddFeedback/UIComponent/KeywordTextFieldView.swift
@@ -110,7 +110,7 @@ final class KeywordTextFieldView: UIView {
         keywordTextField.addTarget(self, action: #selector(textFieldChangeEnd), for: .editingDidEnd)
     }
     
-    private func checkMaxLength(textField: UITextField, maxLength: Int) {
+    func checkMaxLength(textField: UITextField, maxLength: Int) {
         if let text = textField.text {
             if text.count > maxLength {
                 let endIndex = text.index(text.startIndex, offsetBy: maxLength)

--- a/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackDetail/MyFeedbackDetailViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackDetail/MyFeedbackDetailViewController.swift
@@ -246,7 +246,11 @@ final class MyFeedbackDetailViewController: BaseViewController {
     private func setupMainButton() {
         let action = UIAction { [weak self ] _ in
             if let feedbackDetail = self?.feedbackDetail {
-                let viewController = UINavigationController(rootViewController: MyFeedbackEditViewController(feedbackDetail: feedbackDetail, parentNavigationViewController: self?.navigationController ?? UINavigationController()))
+                let viewController = UINavigationController(rootViewController: MyFeedbackEditViewController(
+                    feedbackDetail: feedbackDetail,
+                    parentNavigationViewController: self?.navigationController ?? UINavigationController(),
+                    to: feedbackDetail.nickname
+                ))
                 viewController.modalPresentationStyle = .fullScreen
                 self?.present(viewController, animated: true)
             }

--- a/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackDetail/MyFeedbackDetailViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackDetail/MyFeedbackDetailViewController.swift
@@ -225,7 +225,7 @@ final class MyFeedbackDetailViewController: BaseViewController {
     }
     
     private func setupIsProgressingStatus() {
-        if feedbackDetail.reflectionStatus != .Before {
+        if feedbackDetail.reflectionStatus == .Progressing {
             navigationItem.setRightBarButton(nil, animated: false)
             
             editFeedbackUntilLabel.setTextWithLineHeight(text: TextLiteral.myFeedbackDetailViewControllerBeforeReflectionLabelNotBefore, lineHeight: 22)

--- a/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackEdit/MyFeedbackEditViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackEdit/MyFeedbackEditViewController.swift
@@ -71,11 +71,7 @@ final class MyFeedbackEditViewController: BaseViewController {
         label.font = .label2
         return label
     }()
-    private let feedbackContentTextView: CustomTextView = {
-        let textView = CustomTextView()
-        textView.placeholder = TextLiteral.addFeedbackViewControllerFeedbackContentTextViewPlaceholder
-        return textView
-    }()
+    private let feedbackContentTextView = CustomTextView()
     private let feedbackDoneButtonView: UIView = {
         let view = UIView()
         view.backgroundColor = .white200
@@ -251,26 +247,12 @@ final class MyFeedbackEditViewController: BaseViewController {
         }
     }
     
-    func didTappedDoneButton() {
+    private func didTappedDoneButton() {
         let dto = EditFeedBackDTO(type: feedbackType,
                                   keyword: keywordTextFieldView.keywordTextField.text ?? "",
                                   content: feedbackContentTextView.text ?? "",
                                   start_content: nil)
         putEditFeedBack(type: .putEditFeedBack(reflectionId: feedbackDetail.reflectionId, feedBackId: feedbackDetail.feedbackId, dto))
-    }
-    
-    func checkMaxLength(textField: UITextField, maxLength: Int) {
-        if let text = textField.text {
-            if text.count > maxLength {
-                let endIndex = text.index(text.startIndex, offsetBy: maxLength)
-                let fixedText = text[text.startIndex..<endIndex]
-                textField.text = fixedText + " "
-                
-                DispatchQueue.main.async {
-                    self.keywordTextFieldView.keywordTextField.text = String(fixedText)
-                }
-            }
-        }
     }
     
     // MARK: - selector
@@ -286,7 +268,7 @@ final class MyFeedbackEditViewController: BaseViewController {
         }
     }
     
-    @objc func willHideKeyboard(notification: NSNotification) {
+    @objc private func willHideKeyboard(notification: NSNotification) {
         UIView.animate(withDuration: 0.2, animations: {
             self.feedbackDoneButtonView.transform = .identity
         })

--- a/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackEdit/MyFeedbackEditViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackEdit/MyFeedbackEditViewController.swift
@@ -12,9 +12,7 @@ import SnapKit
 
 final class MyFeedbackEditViewController: BaseViewController {
     private enum Length {
-        static let keywordMinLength: Int = 0
         static let keywordMaxLength: Int = 10
-        static let textViewMaxLength: Int = 200
     }
     private var type: FeedBackDTO = .continueType
     private let toNickname: String
@@ -337,7 +335,7 @@ final class MyFeedbackEditViewController: BaseViewController {
 
 extension MyFeedbackEditViewController: UITextFieldDelegate {
     func textFieldDidChangeSelection(_ textField: UITextField) {
-        checkMaxLength(textField: keywordTextFieldView.keywordTextField, maxLength: Length.keywordMaxLength)
+        keywordTextFieldView.checkMaxLength(textField: keywordTextFieldView.keywordTextField, maxLength: Length.keywordMaxLength)
         feedbackDoneButton.isDisabled = !isTextInputChanged()
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackEdit/MyFeedbackEditViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackEdit/MyFeedbackEditViewController.swift
@@ -94,7 +94,7 @@ final class MyFeedbackEditViewController: BaseViewController {
         label.font = .label2
         return label
     }()
-    private lazy var keywordTextFieldView = KeywordTextField(placeHolder: feedbackDetail.keyword)
+    private lazy var keywordTextFieldView = KeywordTextFieldView(placeHolder: feedbackDetail.keyword)
     private lazy var textLimitLabel: UILabel = {
         let label = UILabel()
         label.setTextWithLineHeight(text: "\(Length.keywordMinLength)/\(Length.keywordMaxLength)", lineHeight: 22)

--- a/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackEdit/MyFeedbackEditViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackEdit/MyFeedbackEditViewController.swift
@@ -111,6 +111,7 @@ final class MyFeedbackEditViewController: BaseViewController {
         setupFeedbackContent()
         setupDelegate()
         detectChangeOfFeedbackType()
+        addTapGestureContentView()
     }
     
     override func render() {
@@ -121,7 +122,7 @@ final class MyFeedbackEditViewController: BaseViewController {
         
         addFeedbackScrollView.addSubview(addFeedbackContentView)
         addFeedbackContentView.snp.makeConstraints {
-            $0.width.top.bottom.equalToSuperview()
+            $0.width.edges.equalToSuperview()
         }
         
         addFeedbackContentView.addSubview(addFeedbackTitleLabel)
@@ -259,6 +260,15 @@ final class MyFeedbackEditViewController: BaseViewController {
                                   content: feedbackContentTextView.text ?? "",
                                   start_content: nil)
         putEditFeedBack(type: .putEditFeedBack(reflectionId: feedbackDetail.reflectionId, feedBackId: feedbackDetail.feedbackId, dto))
+    }
+    
+    private func addTapGestureContentView() {
+        let tap = UITapGestureRecognizer(target: self, action: #selector(endEditingView))
+        addFeedbackContentView.addGestureRecognizer(tap)
+    }
+    
+    @objc override func endEditingView() {
+        view.endEditing(true)
     }
     
     // MARK: - selector

--- a/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackEdit/MyFeedbackEditViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackEdit/MyFeedbackEditViewController.swift
@@ -82,13 +82,6 @@ final class MyFeedbackEditViewController: BaseViewController {
         return label
     }()
     private lazy var keywordTextFieldView = KeywordTextFieldView(placeHolder: feedbackDetail.keyword)
-    private lazy var textLimitLabel: UILabel = {
-        let label = UILabel()
-        label.setTextWithLineHeight(text: "\(Length.keywordMinLength)/\(Length.keywordMaxLength)", lineHeight: 22)
-        label.font = .body2
-        label.textColor = .gray500
-        return label
-    }()
     private let feedbackContentLabel: UILabel = {
         let label = UILabel()
         label.text = TextLiteral.feedbackContentLabel
@@ -182,12 +175,6 @@ final class MyFeedbackEditViewController: BaseViewController {
             $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
         }
         
-        addFeedbackContentView.addSubview(textLimitLabel)
-        textLimitLabel.snp.makeConstraints {
-            $0.top.equalTo(keywordTextFieldView.snp.bottom).offset(4)
-            $0.trailing.equalToSuperview().inset(27)
-        }
-        
         addFeedbackContentView.addSubview(feedbackContentLabel)
         feedbackContentLabel.snp.makeConstraints {
             $0.top.equalTo(keywordTextFieldView.snp.bottom).offset(SizeLiteral.componentIntervalPadding)
@@ -252,7 +239,6 @@ final class MyFeedbackEditViewController: BaseViewController {
     
     private func setupFeedbackKeyword() {
         keywordTextFieldView.keywordTextField.text = feedbackDetail.keyword
-        setCounter(count: feedbackDetail.keyword.count)
     }
     
     private func setupFeedbackContent() {
@@ -289,15 +275,6 @@ final class MyFeedbackEditViewController: BaseViewController {
                                   content: feedbackContentTextView.text ?? "",
                                   start_content: nil)
         putEditFeedBack(type: .putEditFeedBack(reflectionId: feedbackDetail.reflectionId, feedBackId: feedbackDetail.feedbackId, dto))
-    }
-    
-    func setCounter(count: Int) {
-        if count <= Length.keywordMaxLength {
-            textLimitLabel.text = "\(count)/\(Length.keywordMaxLength)"
-        }
-        else {
-            textLimitLabel.text = "\(Length.keywordMaxLength)/\(Length.keywordMaxLength)"
-        }
     }
     
     func checkMaxLength(textField: UITextField, maxLength: Int) {
@@ -360,7 +337,6 @@ final class MyFeedbackEditViewController: BaseViewController {
 
 extension MyFeedbackEditViewController: UITextFieldDelegate {
     func textFieldDidChangeSelection(_ textField: UITextField) {
-        setCounter(count: textField.text?.count ?? 0)
         checkMaxLength(textField: keywordTextFieldView.keywordTextField, maxLength: Length.keywordMaxLength)
         feedbackDoneButton.isDisabled = !isTextInputChanged()
     }

--- a/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackEdit/MyFeedbackEditViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackEdit/MyFeedbackEditViewController.swift
@@ -105,6 +105,7 @@ final class MyFeedbackEditViewController: BaseViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        setupNotificationCenter()
         setupFeedbackType()
         setupFeedbackKeyword()
         setupFeedbackContent()
@@ -193,6 +194,11 @@ final class MyFeedbackEditViewController: BaseViewController {
     
     // MARK: - func
     
+    private func setupNotificationCenter() {
+        NotificationCenter.default.addObserver(self, selector: #selector(willShowKeyboard), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(willHideKeyboard), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+    
     private func setupDelegate() {
         feedbackContentTextView.delegate = self
         keywordTextFieldView.keywordTextField.delegate = self
@@ -262,9 +268,10 @@ final class MyFeedbackEditViewController: BaseViewController {
             UIView.animate(withDuration: 0.2, animations: {
                 self.feedbackDoneButtonView.transform = CGAffineTransform(translationX: 0, y: -keyboardSize.height + 25)
             })
-        }
-        feedbackDoneButtonView.snp.updateConstraints {
-            $0.height.equalTo(100)
+            feedbackContentTextView.snp.updateConstraints {
+                $0.bottom.equalToSuperview().inset(keyboardSize.height + 150)
+            }
+            addFeedbackScrollView.setContentOffset(CGPoint(x: 0, y: 100), animated: true)
         }
     }
     
@@ -272,8 +279,8 @@ final class MyFeedbackEditViewController: BaseViewController {
         UIView.animate(withDuration: 0.2, animations: {
             self.feedbackDoneButtonView.transform = .identity
         })
-        feedbackDoneButtonView.snp.updateConstraints {
-            $0.height.equalTo(134)
+        feedbackContentTextView.snp.updateConstraints {
+            $0.bottom.equalToSuperview()
         }
     }
     

--- a/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackEdit/MyFeedbackEditViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackEdit/MyFeedbackEditViewController.swift
@@ -55,23 +55,7 @@ final class MyFeedbackEditViewController: BaseViewController {
         label.font = .label2
         return label
     }()
-    private lazy var feedbackTypeButtonView: FeedbackTypeButtonView = {
-        let view = FeedbackTypeButtonView()
-        view.changeFeedbackType = { [weak self] type in
-            if let typeValue = FeedBackDTO.init(rawValue: type.rawValue) {
-                self?.type = typeValue
-                guard let keyword = self?.keywordTextFieldView.keywordTextField.text,
-                      let content = self?.feedbackContentTextView.text
-                else { return }
-                let hasKeyword = keyword.isEmpty,
-                    hasContent = content == TextLiteral.addFeedbackViewControllerFeedbackContentTextViewPlaceholder
-                if !hasKeyword && !hasContent {
-                    self?.feedbackDoneButton.isDisabled = false
-                }
-            }
-        }
-        return view
-    }()
+    private let feedbackTypeButtonView = FeedbackTypeButtonView()
     private let feedbackKeywordLabel: UILabel = {
         let label = UILabel()
         label.text = TextLiteral.feedbackKeywordLabel

--- a/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackEdit/MyFeedbackEditViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackEdit/MyFeedbackEditViewController.swift
@@ -21,7 +21,7 @@ final class MyFeedbackEditViewController: BaseViewController {
     private let feedbackDetail: FeedbackFromMeModel
     private var isFeedbackTypeChanged: Bool = false {
         didSet {
-            if !isTextInputChanged() {
+            if !isFeedbackChanged() {
                 feedbackDoneButton.isDisabled = true
             } else {
                 feedbackDoneButton.isDisabled = false
@@ -231,7 +231,7 @@ final class MyFeedbackEditViewController: BaseViewController {
         feedbackContentTextView.textColor = .black100
     }
     
-    private func isTextInputChanged() -> Bool {
+    private func isFeedbackChanged() -> Bool {
         if feedbackContentTextView.text == feedbackDetail.info &&
             keywordTextFieldView.keywordTextField.text == feedbackDetail.keyword &&
             !isFeedbackTypeChanged {
@@ -319,13 +319,13 @@ final class MyFeedbackEditViewController: BaseViewController {
 extension MyFeedbackEditViewController: UITextFieldDelegate {
     func textFieldDidChangeSelection(_ textField: UITextField) {
         keywordTextFieldView.checkMaxLength(textField: keywordTextFieldView.keywordTextField, maxLength: Length.keywordMaxLength)
-        feedbackDoneButton.isDisabled = !isTextInputChanged()
+        feedbackDoneButton.isDisabled = !isFeedbackChanged()
     }
 }
 
 extension MyFeedbackEditViewController: UITextViewDelegate {
     func textViewDidChangeSelection(_ textView: UITextView) {
-        feedbackDoneButton.isDisabled = !isTextInputChanged()
+        feedbackDoneButton.isDisabled = !isFeedbackChanged()
     }
     
     func textViewDidBeginEditing(_ textView: UITextView) {

--- a/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackEdit/MyFeedbackEditViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackEdit/MyFeedbackEditViewController.swift
@@ -23,8 +23,10 @@ final class MyFeedbackEditViewController: BaseViewController {
         didSet {
             if !isFeedbackChanged() {
                 feedbackDoneButton.isDisabled = true
+                isEmptyKeywordOrContent()
             } else {
                 feedbackDoneButton.isDisabled = false
+                isEmptyKeywordOrContent()
             }
         }
     }
@@ -241,6 +243,16 @@ final class MyFeedbackEditViewController: BaseViewController {
         }
     }
     
+    private func isEmptyKeywordOrContent() {
+        if let keyword = keywordTextFieldView.keywordTextField.text {
+            if keyword.isEmpty || feedbackContentTextView.text.isEmpty {
+                feedbackDoneButton.isDisabled = true
+            }
+        } else {
+            feedbackDoneButton.isDisabled = true
+        }
+    }
+    
     private func detectChangeOfFeedbackType() {
         feedbackTypeButtonView.changeFeedbackType = { [weak self] type in
             guard let feedbackType = FeedBackDTO.init(rawValue: type.rawValue) else { return }
@@ -320,12 +332,16 @@ extension MyFeedbackEditViewController: UITextFieldDelegate {
     func textFieldDidChangeSelection(_ textField: UITextField) {
         keywordTextFieldView.checkMaxLength(textField: keywordTextFieldView.keywordTextField, maxLength: Length.keywordMaxLength)
         feedbackDoneButton.isDisabled = !isFeedbackChanged()
+        isEmptyKeywordOrContent()
+//        feedbackDoneButton.isDisabled = isEmptyKeywordOrContent()
     }
 }
 
 extension MyFeedbackEditViewController: UITextViewDelegate {
     func textViewDidChangeSelection(_ textView: UITextView) {
         feedbackDoneButton.isDisabled = !isFeedbackChanged()
+        isEmptyKeywordOrContent()
+//        feedbackDoneButton.isDisabled = isEmptyKeywordOrContent()
     }
     
     func textViewDidBeginEditing(_ textView: UITextView) {

--- a/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackEdit/MyFeedbackEditViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackEdit/MyFeedbackEditViewController.swift
@@ -74,11 +74,6 @@ final class MyFeedbackEditViewController: BaseViewController {
         return label
     }()
     private let feedbackContentTextView = CustomTextView()
-//    private let feedbackDoneButtonView: UIView = {
-//        let view = UIView()
-//        view.backgroundColor = .white200
-//        return view
-//    }()
     private lazy var feedbackDoneButton: MainButton = {
         let button = MainButton()
         button.title = TextLiteral.addFeedbackViewControllerDoneButtonTitle
@@ -170,13 +165,6 @@ final class MyFeedbackEditViewController: BaseViewController {
             $0.height.equalTo(150)
             $0.bottom.equalToSuperview()
         }
-        
-//        view.addSubview(feedbackDoneButtonView)
-//        feedbackDoneButtonView.snp.makeConstraints {
-//            $0.bottom.equalTo(view.snp.bottom)
-//            $0.leading.trailing.equalToSuperview()
-//            $0.height.equalTo(134)
-//        }
         
         view.addSubview(feedbackDoneButton)
         feedbackDoneButton.snp.makeConstraints {
@@ -333,7 +321,6 @@ extension MyFeedbackEditViewController: UITextFieldDelegate {
         keywordTextFieldView.checkMaxLength(textField: keywordTextFieldView.keywordTextField, maxLength: Length.keywordMaxLength)
         feedbackDoneButton.isDisabled = !isFeedbackChanged()
         isEmptyKeywordOrContent()
-//        feedbackDoneButton.isDisabled = isEmptyKeywordOrContent()
     }
 }
 
@@ -341,7 +328,6 @@ extension MyFeedbackEditViewController: UITextViewDelegate {
     func textViewDidChangeSelection(_ textView: UITextView) {
         feedbackDoneButton.isDisabled = !isFeedbackChanged()
         isEmptyKeywordOrContent()
-//        feedbackDoneButton.isDisabled = isEmptyKeywordOrContent()
     }
     
     func textViewDidBeginEditing(_ textView: UITextView) {

--- a/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackEdit/MyFeedbackEditViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackEdit/MyFeedbackEditViewController.swift
@@ -10,36 +10,141 @@ import UIKit
 import Alamofire
 import SnapKit
 
-final class MyFeedbackEditViewController: AddFeedbackViewController {
-    var parentNavigationViewController: UINavigationController
+final class MyFeedbackEditViewController: BaseViewController {
+    private enum Length {
+        static let keywordMinLength: Int = 0
+        static let keywordMaxLength: Int = 10
+        static let textViewMaxLength: Int = 200
+    }
+    private var type: FeedBackDTO = .continueType
+    private let toNickname: String
+    private let toUserId: Int
+    private let currentReflectionId: Int
+    private var keywordHasText: Bool = false
+    private var contentHasText: Bool = false
+    private let parentNavigationViewController: UINavigationController
     private var feedbackType: FeedBackDTO
     private let feedbackDetail: FeedbackFromMeModel
     private var isStartSwitchToggleChanged: Bool = false {
         didSet {
             if !(isTextInputChanged() || isFeedbackTypeChanged || isStartSwitchToggleChanged) {
-                super.feedbackDoneButton.isDisabled = true
+                feedbackDoneButton.isDisabled = true
             } else {
-                super.feedbackDoneButton.isDisabled = false
+                feedbackDoneButton.isDisabled = false
             }
         }
     }
     private var isFeedbackTypeChanged: Bool = false {
         didSet {
             if !(isTextInputChanged() || isFeedbackTypeChanged || isStartSwitchToggleChanged) {
-                super.feedbackDoneButton.isDisabled = true
+                feedbackDoneButton.isDisabled = true
             } else {
-                super.feedbackDoneButton.isDisabled = false
+                feedbackDoneButton.isDisabled = false
             }
         }
     }
     
+    // MARK: - property
+    
+    private lazy var closeButton: CloseButton = {
+        let button = CloseButton(type: .system)
+        let action = UIAction { [weak self] _ in
+            self?.didTappedCloseButton()
+        }
+        button.addAction(action, for: .touchUpInside)
+        return button
+    }()
+    private let addFeedbackScrollView = UIScrollView()
+    private let addFeedbackContentView = UIView()
+    private lazy var addFeedbackTitleLabel: UILabel = {
+        let label = UILabel()
+        label.text = toNickname + TextLiteral.addFeedbackViewControllerTitleLabel
+        label.textColor = .black100
+        label.font = .title
+        return label
+    }()
+    private let feedbackTypeLabel: UILabel = {
+        let label = UILabel()
+        label.text = TextLiteral.feedbackTypeLabel
+        label.textColor = .black100
+        label.font = .label2
+        return label
+    }()
+    private lazy var feedbackTypeButtonView: FeedbackTypeButtonView = {
+        let view = FeedbackTypeButtonView()
+        view.changeFeedbackType = { [weak self] type in
+            if let typeValue = FeedBackDTO.init(rawValue: type.rawValue) {
+                self?.type = typeValue
+                guard let keyword = self?.keywordTextFieldView.keywordTextField.text,
+                      let content = self?.feedbackContentTextView.text
+                else { return }
+                let hasKeyword = keyword.isEmpty,
+                    hasContent = content == TextLiteral.addFeedbackViewControllerFeedbackContentTextViewPlaceholder
+                if !hasKeyword && !hasContent {
+                    self?.feedbackDoneButton.isDisabled = false
+                }
+            }
+        }
+        return view
+    }()
+    private let feedbackKeywordLabel: UILabel = {
+        let label = UILabel()
+        label.text = TextLiteral.feedbackKeywordLabel
+        label.textColor = .black100
+        label.font = .label2
+        return label
+    }()
+    private lazy var keywordTextFieldView = KeywordTextField(placeHolder: feedbackDetail.keyword)
+    private lazy var textLimitLabel: UILabel = {
+        let label = UILabel()
+        label.setTextWithLineHeight(text: "\(Length.keywordMinLength)/\(Length.keywordMaxLength)", lineHeight: 22)
+        label.font = .body2
+        label.textColor = .gray500
+        return label
+    }()
+    private let feedbackContentLabel: UILabel = {
+        let label = UILabel()
+        label.text = TextLiteral.feedbackContentLabel
+        label.textColor = .black100
+        label.font = .label2
+        return label
+    }()
+    private let feedbackContentTextView: CustomTextView = {
+        let textView = CustomTextView()
+        textView.placeholder = TextLiteral.addFeedbackViewControllerFeedbackContentTextViewPlaceholder
+        return textView
+    }()
+    private let feedbackDoneButtonView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .white200
+        return view
+    }()
+    private lazy var feedbackDoneButton: MainButton = {
+        let button = MainButton()
+        button.title = TextLiteral.addFeedbackViewControllerDoneButtonTitle
+        button.isDisabled = true
+        let action = UIAction { [weak self] _ in
+            self?.didTappedDoneButton()
+        }
+        button.addAction(action, for: .touchUpInside)
+        return button
+    }()
+    
     // MARK: - life cycle
     
-    init(feedbackDetail: FeedbackFromMeModel, parentNavigationViewController: UINavigationController) {
+    init(feedbackDetail: FeedbackFromMeModel,
+         parentNavigationViewController: UINavigationController,
+         to: String,
+         toUserId: Int,
+         reflectionId: Int
+    ) {
         self.feedbackDetail = feedbackDetail
         self.feedbackType = FeedBackDTO.init(rawValue: feedbackDetail.feedbackType.rawValue) ?? .continueType
         self.parentNavigationViewController = parentNavigationViewController
-        super.init(to: feedbackDetail.nickname, toUserId: 0, reflectionId: feedbackDetail.reflectionId)
+        self.toNickname = to
+        self.toUserId = toUserId
+        self.currentReflectionId = reflectionId
+        super.init()
     }
     
     required init?(coder: NSCoder) { nil }
@@ -49,75 +154,140 @@ final class MyFeedbackEditViewController: AddFeedbackViewController {
         setupFeedbackType()
         setupFeedbackKeyword()
         setupFeedbackContent()
-        setupFeedbackStart()
         hideEditFeedbackUntilLabel()
         detectChangeOfFeedbackType()
-        setupNavigationLeftItem()
+    }
+    
+    override func render() {
+        view.addSubview(addFeedbackScrollView)
+        addFeedbackScrollView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        addFeedbackScrollView.addSubview(addFeedbackContentView)
+        addFeedbackContentView.snp.makeConstraints {
+            $0.width.top.bottom.equalToSuperview()
+        }
+        
+        addFeedbackContentView.addSubview(addFeedbackTitleLabel)
+        addFeedbackTitleLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(SizeLiteral.topPadding)
+            $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+        }
+        
+        addFeedbackContentView.addSubview(feedbackTypeLabel)
+        feedbackTypeLabel.snp.makeConstraints {
+            $0.top.equalTo(addFeedbackTitleLabel.snp.bottom).offset(SizeLiteral.topComponentPadding)
+            $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+        }
+        
+        addFeedbackContentView.addSubview(feedbackTypeButtonView)
+        feedbackTypeButtonView.snp.makeConstraints {
+            $0.top.equalTo(feedbackTypeLabel.snp.bottom).offset(SizeLiteral.labelComponentPadding)
+            $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+        }
+        
+        addFeedbackContentView.addSubview(feedbackKeywordLabel)
+        feedbackKeywordLabel.snp.makeConstraints {
+            $0.top.equalTo(feedbackTypeButtonView.snp.bottom).offset(SizeLiteral.componentIntervalPadding)
+            $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+        }
+        
+        addFeedbackContentView.addSubview(keywordTextFieldView)
+        keywordTextFieldView.snp.makeConstraints {
+            $0.top.equalTo(feedbackKeywordLabel.snp.bottom).offset(SizeLiteral.labelComponentPadding)
+            $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+        }
+        
+        addFeedbackContentView.addSubview(textLimitLabel)
+        textLimitLabel.snp.makeConstraints {
+            $0.top.equalTo(keywordTextFieldView.snp.bottom).offset(4)
+            $0.trailing.equalToSuperview().inset(27)
+        }
+        
+        addFeedbackContentView.addSubview(feedbackContentLabel)
+        feedbackContentLabel.snp.makeConstraints {
+            $0.top.equalTo(keywordTextFieldView.snp.bottom).offset(SizeLiteral.componentIntervalPadding)
+            $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+        }
+        
+        addFeedbackContentView.addSubview(feedbackContentTextView)
+        feedbackContentTextView.snp.makeConstraints {
+            $0.top.equalTo(feedbackContentLabel.snp.bottom).offset(SizeLiteral.labelComponentPadding)
+            $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+            $0.height.equalTo(150)
+            $0.bottom.equalToSuperview()
+        }
+        
+        view.addSubview(feedbackDoneButtonView)
+        feedbackDoneButtonView.snp.makeConstraints {
+            $0.bottom.equalTo(view.snp.bottom)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(134)
+        }
+        
+        feedbackDoneButtonView.addSubview(feedbackDoneButton)
+        feedbackDoneButton.snp.makeConstraints {
+            $0.bottom.equalTo(feedbackDoneButtonView.snp.bottom).inset(36)
+            $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+        }
+    }
+    
+    override func setupNavigationBar() {
+        super.setupNavigationBar()
+        
+        let closeButton = makeBarButtonItem(with: closeButton)
+        
+        navigationController?.navigationBar.prefersLargeTitles = false
+        navigationItem.largeTitleDisplayMode = .never
+        navigationItem.rightBarButtonItem = closeButton
     }
     
     // MARK: - func
     
+    private func setupDelegate() {
+        feedbackContentTextView.delegate = self
+        keywordTextFieldView.keywordTextField.delegate = self
+    }
+    
+    private func didTappedBackButton() {
+        navigationController?.popViewController(animated: true)
+    }
+    
+    func didTappedCloseButton() {
+        self.dismiss(animated: true)
+    }
+    
     private func setupFeedbackType() {
         switch feedbackDetail.feedbackType {
         case .continueType:
-            super.feedbackTypeButtonView.feedbackType = .continueType
+            feedbackTypeButtonView.feedbackType = .continueType
         case .stopType:
-            super.feedbackTypeButtonView.feedbackType = .stopType
+            feedbackTypeButtonView.feedbackType = .stopType
         }
     }
     
     private func setupFeedbackKeyword() {
-        super.feedbackKeywordTextField.text = feedbackDetail.keyword
-        super.setCounter(count: feedbackDetail.keyword.count)
+        keywordTextFieldView.keywordTextField.text = feedbackDetail.keyword
+        setCounter(count: feedbackDetail.keyword.count)
     }
     
     private func setupFeedbackContent() {
-        super.feedbackContentTextView.text = feedbackDetail.info
-        super.feedbackContentTextView.textColor = .black100
+        feedbackContentTextView.text = feedbackDetail.info
+        feedbackContentTextView.textColor = .black100
     }
-    
-    private func setupFeedbackStart() {
-        if let start = feedbackDetail.start {
-            if !start.isEmpty {
-                super.feedbackStartSwitch.isOn = true
-                super.feedbackStartTextViewLabel.isHidden = false
-                super.feedbackStartTextView.isHidden = false
-                super.feedbackStartTextView.text = start
-                super.feedbackStartTextView.textColor = .black100
-            }
-        }
-        super.feedbackStartSwitchBottomEqualToSuperView?.constraint.deactivate()
-        super.feedbackStartTextView.snp.remakeConstraints {
-            $0.top.equalTo(feedbackStartTextViewLabel.snp.bottom).offset(SizeLiteral.labelComponentPadding)
-            $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
-            $0.height.equalTo(150)
-            $0.bottom.equalToSuperview().inset(80)
-        }
-    }
-    
+        
     private func hideEditFeedbackUntilLabel() {
-        super.editFeedbackUntilLabel.isHidden = true
-        super.feedbackDoneButtonView.snp.remakeConstraints {
+        feedbackDoneButtonView.snp.remakeConstraints {
             $0.bottom.equalToSuperview()
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(95)
         }
     }
     
-    private func notChangedStartContent() -> Bool {
-        if let start = self.feedbackDetail.start {
-            return super.feedbackStartTextView.text == TextLiteral.addFeedbackViewControllerStartTextViewPlaceholder || super.feedbackStartTextView.text == start ?
-            true : false
-        } else {
-            return super.feedbackStartTextView.text == TextLiteral.addFeedbackViewControllerStartTextViewPlaceholder ||
-            super.feedbackStartTextView.text.isEmpty ? true : false
-        }
-    }
-    
     private func isTextInputChanged() -> Bool {
-        if super.feedbackContentTextView.text == feedbackDetail.info &&
-            notChangedStartContent() &&
-            super.feedbackKeywordTextField.text == feedbackDetail.keyword {
+        if feedbackContentTextView.text == feedbackDetail.info &&
+            keywordTextFieldView.keywordTextField.text == feedbackDetail.keyword {
             return false
         } else {
             return true
@@ -125,7 +295,7 @@ final class MyFeedbackEditViewController: AddFeedbackViewController {
     }
     
     private func detectChangeOfFeedbackType() {
-        super.feedbackTypeButtonView.changeFeedbackType = { [weak self] type in
+        feedbackTypeButtonView.changeFeedbackType = { [weak self] type in
             guard let feedbackType = FeedBackDTO.init(rawValue: type.rawValue) else { return }
             if type == self?.feedbackDetail.feedbackType {
                 self?.isFeedbackTypeChanged = false
@@ -137,45 +307,57 @@ final class MyFeedbackEditViewController: AddFeedbackViewController {
         }
     }
     
-    private func setupNavigationLeftItem() {
-        super.backButton.isHidden = true
-    }
-    
-    override func didTappedDoneButton() {
+    func didTappedDoneButton() {
         let dto = EditFeedBackDTO(type: feedbackType,
-                                  keyword: super.feedbackKeywordTextField.text ?? "",
-                                  content: super.feedbackContentTextView.text ?? "",
-                                  start_content: !super.feedbackStartSwitch.isOn || super.feedbackStartTextView.text == TextLiteral.addFeedbackViewControllerStartTextViewPlaceholder ? "" : super.feedbackStartTextView.text)
+                                  keyword: keywordTextFieldView.keywordTextField.text ?? "",
+                                  content: feedbackContentTextView.text ?? "",
+                                  start_content: nil)
         putEditFeedBack(type: .putEditFeedBack(reflectionId: feedbackDetail.reflectionId, feedBackId: feedbackDetail.feedbackId, dto))
     }
     
-    override func didTappedCloseButton() {
-        self.dismiss(animated: true)
+    func setCounter(count: Int) {
+        if count <= Length.keywordMaxLength {
+            textLimitLabel.text = "\(count)/\(Length.keywordMaxLength)"
+        }
+        else {
+            textLimitLabel.text = "\(Length.keywordMaxLength)/\(Length.keywordMaxLength)"
+        }
     }
     
-    override func didTappedSwitch() {
-        super.didTappedSwitch()
-        if let start = self.feedbackDetail.start {
-            let hasStart = !start.isEmpty
-            if hasStart != super.feedbackStartSwitch.isOn {
-                isStartSwitchToggleChanged = true
-            } else {
-                isStartSwitchToggleChanged = false
-            }
-        } else {
-            if super.feedbackStartSwitch.isOn {
-                isStartSwitchToggleChanged = true
+    func checkMaxLength(textField: UITextField, maxLength: Int) {
+        if let text = textField.text {
+            if text.count > maxLength {
+                let endIndex = text.index(text.startIndex, offsetBy: maxLength)
+                let fixedText = text[text.startIndex..<endIndex]
+                textField.text = fixedText + " "
+                
+                DispatchQueue.main.async {
+                    self.keywordTextFieldView.keywordTextField.text = String(fixedText)
+                }
             }
         }
     }
     
     // MARK: - selector
     
-    @objc override func willHideKeyboard(notification: NSNotification) {
+    @objc private func willShowKeyboard(notification: NSNotification) {
+        if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
+            UIView.animate(withDuration: 0.2, animations: {
+                self.feedbackDoneButtonView.transform = CGAffineTransform(translationX: 0, y: -keyboardSize.height + 25)
+            })
+        }
+        feedbackDoneButtonView.snp.updateConstraints {
+            $0.height.equalTo(100)
+        }
+    }
+    
+    @objc func willHideKeyboard(notification: NSNotification) {
         UIView.animate(withDuration: 0.2, animations: {
-            super.feedbackDoneButtonView.transform = .identity
+            self.feedbackDoneButtonView.transform = .identity
         })
-        super.editFeedbackUntilLabel.isHidden = true
+        feedbackDoneButtonView.snp.updateConstraints {
+            $0.height.equalTo(134)
+        }
     }
     
     // MARK: - api
@@ -196,20 +378,30 @@ final class MyFeedbackEditViewController: AddFeedbackViewController {
             }
         }
     }
-    
-    // MARK: - extension
-    
-    override func textFieldDidChangeSelection(_ textField: UITextField) {
-        super.setCounter(count: textField.text?.count ?? 0)
-        super.checkMaxLength(textField: super.feedbackKeywordTextField, maxLength: Length.keywordMaxLength)
-        super.feedbackDoneButton.isDisabled = !(isTextInputChanged() || isFeedbackTypeChanged)
+}
+
+// MARK: - extension
+
+extension MyFeedbackEditViewController: UITextFieldDelegate {
+    func textFieldDidChangeSelection(_ textField: UITextField) {
+        setCounter(count: textField.text?.count ?? 0)
+        checkMaxLength(textField: keywordTextFieldView.keywordTextField, maxLength: Length.keywordMaxLength)
+        
+        keywordHasText = keywordTextFieldView.keywordTextField.hasText
+        feedbackDoneButton.isDisabled = !(keywordHasText && contentHasText && feedbackTypeButtonView.feedbackType != nil)
+    }
+}
+
+extension MyFeedbackEditViewController: UITextViewDelegate {
+    func textViewDidChangeSelection(_ textView: UITextView) {
+        contentHasText = feedbackContentTextView.hasText && feedbackContentTextView.text != TextLiteral.addFeedbackViewControllerFeedbackContentTextViewPlaceholder
+        feedbackDoneButton.isDisabled = !(keywordHasText && contentHasText && feedbackTypeButtonView.feedbackType != nil)
     }
     
-    override func textViewDidChangeSelection(_ textView: UITextView) {
-        super.feedbackDoneButton.isDisabled = !(isTextInputChanged() || isFeedbackTypeChanged)
-    }
-    
-    override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
-        return true
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        if textView.text == TextLiteral.addFeedbackViewControllerFeedbackContentTextViewPlaceholder || textView.text == TextLiteral.addFeedbackViewControllerStartTextViewPlaceholder {
+            textView.text = nil
+            textView.textColor = .black100
+        }
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackEdit/MyFeedbackEditViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackEdit/MyFeedbackEditViewController.swift
@@ -18,25 +18,12 @@ final class MyFeedbackEditViewController: BaseViewController {
     }
     private var type: FeedBackDTO = .continueType
     private let toNickname: String
-    private let toUserId: Int
-    private let currentReflectionId: Int
-    private var keywordHasText: Bool = false
-    private var contentHasText: Bool = false
     private let parentNavigationViewController: UINavigationController
     private var feedbackType: FeedBackDTO
     private let feedbackDetail: FeedbackFromMeModel
-    private var isStartSwitchToggleChanged: Bool = false {
-        didSet {
-            if !(isTextInputChanged() || isFeedbackTypeChanged || isStartSwitchToggleChanged) {
-                feedbackDoneButton.isDisabled = true
-            } else {
-                feedbackDoneButton.isDisabled = false
-            }
-        }
-    }
     private var isFeedbackTypeChanged: Bool = false {
         didSet {
-            if !(isTextInputChanged() || isFeedbackTypeChanged || isStartSwitchToggleChanged) {
+            if !isTextInputChanged() {
                 feedbackDoneButton.isDisabled = true
             } else {
                 feedbackDoneButton.isDisabled = false
@@ -134,16 +121,12 @@ final class MyFeedbackEditViewController: BaseViewController {
     
     init(feedbackDetail: FeedbackFromMeModel,
          parentNavigationViewController: UINavigationController,
-         to: String,
-         toUserId: Int,
-         reflectionId: Int
+         to: String
     ) {
         self.feedbackDetail = feedbackDetail
         self.feedbackType = FeedBackDTO.init(rawValue: feedbackDetail.feedbackType.rawValue) ?? .continueType
         self.parentNavigationViewController = parentNavigationViewController
         self.toNickname = to
-        self.toUserId = toUserId
-        self.currentReflectionId = reflectionId
         super.init()
     }
     
@@ -154,7 +137,7 @@ final class MyFeedbackEditViewController: BaseViewController {
         setupFeedbackType()
         setupFeedbackKeyword()
         setupFeedbackContent()
-        hideEditFeedbackUntilLabel()
+        setupDelegate()
         detectChangeOfFeedbackType()
     }
     
@@ -276,18 +259,11 @@ final class MyFeedbackEditViewController: BaseViewController {
         feedbackContentTextView.text = feedbackDetail.info
         feedbackContentTextView.textColor = .black100
     }
-        
-    private func hideEditFeedbackUntilLabel() {
-        feedbackDoneButtonView.snp.remakeConstraints {
-            $0.bottom.equalToSuperview()
-            $0.leading.trailing.equalToSuperview()
-            $0.height.equalTo(95)
-        }
-    }
     
     private func isTextInputChanged() -> Bool {
         if feedbackContentTextView.text == feedbackDetail.info &&
-            keywordTextFieldView.keywordTextField.text == feedbackDetail.keyword {
+            keywordTextFieldView.keywordTextField.text == feedbackDetail.keyword &&
+            !isFeedbackTypeChanged {
             return false
         } else {
             return true
@@ -386,16 +362,13 @@ extension MyFeedbackEditViewController: UITextFieldDelegate {
     func textFieldDidChangeSelection(_ textField: UITextField) {
         setCounter(count: textField.text?.count ?? 0)
         checkMaxLength(textField: keywordTextFieldView.keywordTextField, maxLength: Length.keywordMaxLength)
-        
-        keywordHasText = keywordTextFieldView.keywordTextField.hasText
-        feedbackDoneButton.isDisabled = !(keywordHasText && contentHasText && feedbackTypeButtonView.feedbackType != nil)
+        feedbackDoneButton.isDisabled = !isTextInputChanged()
     }
 }
 
 extension MyFeedbackEditViewController: UITextViewDelegate {
     func textViewDidChangeSelection(_ textView: UITextView) {
-        contentHasText = feedbackContentTextView.hasText && feedbackContentTextView.text != TextLiteral.addFeedbackViewControllerFeedbackContentTextViewPlaceholder
-        feedbackDoneButton.isDisabled = !(keywordHasText && contentHasText && feedbackTypeButtonView.feedbackType != nil)
+        feedbackDoneButton.isDisabled = !isTextInputChanged()
     }
     
     func textViewDidBeginEditing(_ textView: UITextView) {

--- a/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackEdit/MyFeedbackEditViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedbackEdit/MyFeedbackEditViewController.swift
@@ -74,11 +74,11 @@ final class MyFeedbackEditViewController: BaseViewController {
         return label
     }()
     private let feedbackContentTextView = CustomTextView()
-    private let feedbackDoneButtonView: UIView = {
-        let view = UIView()
-        view.backgroundColor = .white200
-        return view
-    }()
+//    private let feedbackDoneButtonView: UIView = {
+//        let view = UIView()
+//        view.backgroundColor = .white200
+//        return view
+//    }()
     private lazy var feedbackDoneButton: MainButton = {
         let button = MainButton()
         button.title = TextLiteral.addFeedbackViewControllerDoneButtonTitle
@@ -171,16 +171,16 @@ final class MyFeedbackEditViewController: BaseViewController {
             $0.bottom.equalToSuperview()
         }
         
-        view.addSubview(feedbackDoneButtonView)
-        feedbackDoneButtonView.snp.makeConstraints {
-            $0.bottom.equalTo(view.snp.bottom)
-            $0.leading.trailing.equalToSuperview()
-            $0.height.equalTo(134)
-        }
+//        view.addSubview(feedbackDoneButtonView)
+//        feedbackDoneButtonView.snp.makeConstraints {
+//            $0.bottom.equalTo(view.snp.bottom)
+//            $0.leading.trailing.equalToSuperview()
+//            $0.height.equalTo(134)
+//        }
         
-        feedbackDoneButtonView.addSubview(feedbackDoneButton)
+        view.addSubview(feedbackDoneButton)
         feedbackDoneButton.snp.makeConstraints {
-            $0.bottom.equalTo(feedbackDoneButtonView.snp.bottom).inset(36)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom)
             $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
         }
     }
@@ -288,7 +288,7 @@ final class MyFeedbackEditViewController: BaseViewController {
     @objc private func willShowKeyboard(notification: NSNotification) {
         if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
             UIView.animate(withDuration: 0.2, animations: {
-                self.feedbackDoneButtonView.transform = CGAffineTransform(translationX: 0, y: -keyboardSize.height + 25)
+                self.feedbackDoneButton.transform = CGAffineTransform(translationX: 0, y: -keyboardSize.height + 25)
             })
             feedbackContentTextView.snp.updateConstraints {
                 $0.bottom.equalToSuperview().inset(keyboardSize.height + 150)
@@ -299,7 +299,7 @@ final class MyFeedbackEditViewController: BaseViewController {
     
     @objc private func willHideKeyboard(notification: NSNotification) {
         UIView.animate(withDuration: 0.2, animations: {
-            self.feedbackDoneButtonView.transform = .identity
+            self.feedbackDoneButton.transform = .identity
         })
         feedbackContentTextView.snp.updateConstraints {
             $0.bottom.equalToSuperview()


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
피드백 수정하기 view에서 키워드 부분이 일반 TextField에서 키워드 TextField로 변경되었습니다.
그에 따른 PR입니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
기존엔 AddFeedbackViewController와 EditFeedbackViewController의 모양이 비슷했습니다. 
그래서 AddFeedbackViewController를 상속받아서 사용하고 있었는데요, 피드백을 추가하는 부분의 UI도 변경되어서 더 이상 상속받아서 사용할 이유가 없어졌습니다.
1. 상속받아서 사용하는 부분들을 삭제하고 해당 viewController로 옮겼습니다.

키워드 TextField의 UI를 변경했습니다. @seongmin221 이 만들어준 UI를 사용했습니다.
기존에 PlaceHolder가 "키워드를 입력하세요" 로 고정되어 있어서, 처음 들어갔을 때
<img width="356" alt="image" src="https://user-images.githubusercontent.com/78677571/206690075-0c4b5074-ec4e-49ac-9e26-2f7ea271a84a.png">
이렇게 어색하게 비어있는 상황이 생기더라구요 !
해당 키워드의 크기가 "키워드를 입력하세요" 이걸 기준으로 잡다보니 발생하는 문제였습니다. 그래서 그 부분을 현재 키워드로 수정하였습니다. 피드백을 추가하는 과정에선 "키워드를 입력하세요"가 제대로 들어가게 만들어 뒀습니다 !
2. 키워드 입력 UI를 수정했고
3. 키워드 TextField View를 수정했습니다 (네이밍 포함)
4. start 부분을 삭제했습니다.

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
보관함 탭에서 팀원에게 전달한 피드백을 수정해보시면 됩니다 !

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->

https://user-images.githubusercontent.com/78677571/206691688-69b278ca-175a-472b-b5c7-28c3113933e0.mp4



## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
상속을 받아서 사용할 때도 사실 불편한 부분이 있었는데, 상속을 해제하는데도 꽤나 머리 아프더라구요... 하하
UI가 비슷할 땐 어떻게 사용하는게 좋을지 다시한번 고민이 되네요..


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #227 
- close #222 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
