### PR TITLE
[ADD] 변경된 MyReflectionFeedback UI 구현

### DIFF
--- a/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflectionFeedback/MyReflectionFeedbackViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflectionFeedback/MyReflectionFeedbackViewController.swift
@@ -130,7 +130,7 @@ final class MyReflectionFeedbackViewController: BaseViewController {
 
         myReflectionScrollView.addSubview(myReflectionContentView)
         myReflectionContentView.snp.makeConstraints {
-            $0.width.top.bottom.equalToSuperview()
+            $0.width.edges.equalToSuperview()
         }
 
         myReflectionContentView.addSubview(feedbackContentText)

--- a/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflectionFeedback/MyReflectionFeedbackViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflectionFeedback/MyReflectionFeedbackViewController.swift
@@ -36,29 +36,29 @@ final class MyReflectionFeedbackViewController: BaseViewController {
     private let feedbackTypeLabel: UILabel = {
         let label = UILabel()
         label.text = TextLiteral.myReflectionFeedbackViewControllerFeedbackTypeLabel
-        label.textColor = .black100
-        label.font = .label2
+        label.textColor = .gray400
+        label.font = .body1
         return label
     }()
     private lazy var feedbackTypeText: UILabel = {
         let label = UILabel()
-        label.setTextWithLineHeight(text: model.type, lineHeight: 24)
-        label.textColor = .gray400
-        label.font = .body1
+        label.text = model.type
+        label.textColor = .black100
+        label.font = .label3
         return label
     }()
     private let feedbackFromLabel: UILabel = {
         let label = UILabel()
         label.text = TextLiteral.myReflectionFeedbackViewControllerFeedbackFromLabel
-        label.textColor = .black100
-        label.font = .label2
+        label.textColor = .gray400
+        label.font = .body1
         return label
     }()
     private lazy var feedbackFromText: UILabel = {
         let label = UILabel()
-        label.setTextWithLineHeight(text: model.fromUser?.userName ?? TextLiteral.myReflectionViewControllerDeleteUserTitle, lineHeight: 24)
-        label.textColor = .gray400
-        label.font = .body1
+        label.text = model.fromUser?.userName ?? TextLiteral.myReflectionViewControllerDeleteUserTitle
+        label.textColor = .black100
+        label.font = .label3
         return label
     }()
     private let feedbackContentLabel: UILabel = {
@@ -111,20 +111,20 @@ final class MyReflectionFeedbackViewController: BaseViewController {
         
         myReflectionContentView.addSubview(feedbackTypeText)
         feedbackTypeText.snp.makeConstraints {
-            $0.top.equalTo(feedbackTypeLabel.snp.bottom).offset(SizeLiteral.labelComponentPadding)
-            $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+            $0.centerY.equalTo(feedbackTypeLabel.snp.centerY)
+            $0.leading.equalTo(feedbackTypeLabel.snp.trailing).offset(54)
         }
         
         myReflectionContentView.addSubview(feedbackFromLabel)
         feedbackFromLabel.snp.makeConstraints {
-            $0.top.equalTo(feedbackTypeText.snp.bottom).offset(SizeLiteral.componentIntervalPadding)
+            $0.top.equalTo(feedbackTypeText.snp.bottom).offset(20)
             $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
         }
         
         myReflectionContentView.addSubview(feedbackFromText)
         feedbackFromText.snp.makeConstraints {
-            $0.top.equalTo(feedbackFromLabel.snp.bottom).offset(SizeLiteral.labelComponentPadding)
-            $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+            $0.centerY.equalTo(feedbackFromLabel.snp.centerY)
+            $0.leading.equalTo(feedbackFromLabel.snp.trailing).offset(86)
         }
         
         myReflectionContentView.addSubview(feedbackContentLabel)

--- a/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflectionFeedback/MyReflectionFeedbackViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflectionFeedback/MyReflectionFeedbackViewController.swift
@@ -23,8 +23,6 @@ final class MyReflectionFeedbackViewController: BaseViewController {
         button.addAction(action, for: .touchUpInside)
         return button
     }()
-    private let myReflectionScrollView = UIScrollView()
-    private let myReflectionContentView = UIView()
     private lazy var keywordTitleLabel: UILabel = {
         let label = UILabel()
         if let keyword = model.keyword {
@@ -66,11 +64,13 @@ final class MyReflectionFeedbackViewController: BaseViewController {
         view.backgroundColor = .gray300
         return view
     }()
+    private let myReflectionScrollView = UIScrollView()
+    private let myReflectionContentView = UIView()
     private lazy var feedbackContentText: UILabel = {
         let label = UILabel()
         label.setTextWithLineHeight(text: model.content, lineHeight: 24)
-        label.textColor = .gray400
-        label.font = .body1
+        label.textColor = .black100
+        label.font = .body3
         label.numberOfLines = 0
         return label
     }()
@@ -85,57 +85,58 @@ final class MyReflectionFeedbackViewController: BaseViewController {
     required init?(coder: NSCoder) { nil }
     
     override func render() {
-        view.addSubview(myReflectionScrollView)
-        myReflectionScrollView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
-        }
-        
-        myReflectionScrollView.addSubview(myReflectionContentView)
-        myReflectionContentView.snp.makeConstraints {
-            $0.width.top.bottom.equalToSuperview()
-        }
-        
-        myReflectionContentView.addSubview(keywordTitleLabel)
+        view.addSubview(keywordTitleLabel)
         keywordTitleLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(SizeLiteral.topPadding)
+            $0.top.equalTo(view.safeAreaLayoutGuide).inset(SizeLiteral.topPadding)
             $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
         }
         
-        myReflectionContentView.addSubview(feedbackTypeLabel)
+        view.addSubview(feedbackTypeLabel)
         feedbackTypeLabel.snp.makeConstraints {
             $0.top.equalTo(keywordTitleLabel.snp.bottom).offset(SizeLiteral.topComponentPadding)
             $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
         }
         
-        myReflectionContentView.addSubview(feedbackTypeText)
+        view.addSubview(feedbackTypeText)
         feedbackTypeText.snp.makeConstraints {
             $0.centerY.equalTo(feedbackTypeLabel.snp.centerY)
             $0.leading.equalTo(feedbackTypeLabel.snp.trailing).offset(54)
         }
         
-        myReflectionContentView.addSubview(feedbackFromLabel)
+        view.addSubview(feedbackFromLabel)
         feedbackFromLabel.snp.makeConstraints {
             $0.top.equalTo(feedbackTypeText.snp.bottom).offset(20)
             $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
         }
         
-        myReflectionContentView.addSubview(feedbackFromText)
+        view.addSubview(feedbackFromText)
         feedbackFromText.snp.makeConstraints {
             $0.centerY.equalTo(feedbackFromLabel.snp.centerY)
             $0.leading.equalTo(feedbackFromLabel.snp.trailing).offset(86)
         }
         
-        myReflectionContentView.addSubview(divider)
+        view.addSubview(divider)
         divider.snp.makeConstraints {
             $0.top.equalTo(feedbackFromLabel.snp.bottom).offset(24)
             $0.horizontalEdges.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
             $0.height.equalTo(1)
         }
         
+        view.addSubview(myReflectionScrollView)
+        myReflectionScrollView.snp.makeConstraints {
+            $0.top.equalTo(divider.snp.bottom)
+            $0.horizontalEdges.bottom.equalTo(view.safeAreaLayoutGuide)
+        }
+
+        myReflectionScrollView.addSubview(myReflectionContentView)
+        myReflectionContentView.snp.makeConstraints {
+            $0.width.top.bottom.equalToSuperview()
+        }
+
         myReflectionContentView.addSubview(feedbackContentText)
         feedbackContentText.snp.makeConstraints {
-            $0.top.equalTo(divider.snp.bottom).offset(20)
-            $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+            $0.top.bottom.equalToSuperview().inset(20)
+            $0.horizontalEdges.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
         }
     }
     

--- a/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflectionFeedback/MyReflectionFeedbackViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyReflection/MyReflectionFeedback/MyReflectionFeedbackViewController.swift
@@ -61,12 +61,10 @@ final class MyReflectionFeedbackViewController: BaseViewController {
         label.font = .label3
         return label
     }()
-    private let feedbackContentLabel: UILabel = {
-        let label = UILabel()
-        label.text = TextLiteral.myReflectionFeedbackViewControllerFeedbackContentLabel
-        label.textColor = .black100
-        label.font = .label2
-        return label
+    private let divider: UIView = {
+        let view = UIView()
+        view.backgroundColor = .gray300
+        return view
     }()
     private lazy var feedbackContentText: UILabel = {
         let label = UILabel()
@@ -127,15 +125,16 @@ final class MyReflectionFeedbackViewController: BaseViewController {
             $0.leading.equalTo(feedbackFromLabel.snp.trailing).offset(86)
         }
         
-        myReflectionContentView.addSubview(feedbackContentLabel)
-        feedbackContentLabel.snp.makeConstraints {
-            $0.top.equalTo(feedbackFromText.snp.bottom).offset(SizeLiteral.componentIntervalPadding)
-            $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+        myReflectionContentView.addSubview(divider)
+        divider.snp.makeConstraints {
+            $0.top.equalTo(feedbackFromLabel.snp.bottom).offset(24)
+            $0.horizontalEdges.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+            $0.height.equalTo(1)
         }
         
         myReflectionContentView.addSubview(feedbackContentText)
         feedbackContentText.snp.makeConstraints {
-            $0.top.equalTo(feedbackContentLabel.snp.bottom).offset(SizeLiteral.labelComponentPadding)
+            $0.top.equalTo(divider.snp.bottom).offset(20)
             $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
         }
     }


### PR DESCRIPTION
## 🌁 Background
기존 디자인은 비교적 덜 중요한 라벨이 내용보다 눈에 띈다는 문제가 있어서,
라벨들의 글자 크기, 두께 그리고 전체적인 레이아웃을 수정했습니다.

## 👩‍💻 Contents
- 라벨과 텍스트 font와 text color 변경
- 콘텐츠 레이아웃 변경
- Scroll 되는 영역 변경 (전체 -> 피드백 내용 영역만)


## ✅ Testing
feature/237-new-my-reflection-feedback 브랜치로 오셔서
지난 회고에서 팀원에게 받은 피드백이 있다면, [나의회고 > 회고 선택 > 피드백 선택] 하고 보시면 됩니다!
만약 받은 피드백이 없으시다면, (계정이 다 달라서 없을 가능성이 있어요) DB에서 직접 피드백 하나 추가하셔서 보셔도 됩니다.

## 📱 Screenshot

https://user-images.githubusercontent.com/81340603/209898183-16359445-c94d-4464-95dc-19f93c3b96fd.mp4



## 📝 Review Note
지금까지 주로 제가 만들어 온 뷰들은 다 ScrollView 를 포함하고 있었는데요.. 그때마다 레이아웃 조정하는데 항상 어려움이 있었습니다,,
이번에도 레이아웃이 잡히지 않아 원하는데로 스크롤이 안되는 문제가 계속 발생했는데, 약간의 고군분투 끝에 나름의 방법을 확실히 발견했습니다.

⭐️ 스크롤뷰를 사용한다면 꼭! 기억해야 하는 것 ⭐️
1. ScrollView는 스크롤의 영역을 잡아주는 역할입니다. 위 또는 아래에 위치한 일부 콘텐츠들을 fix 해두고 나머지 영역만 스크롤 하고 싶다면 그 영역을 제외하고 레이아웃을 잡아주어야 해요.
2. **세로 방향으로만** 스크롤하기 원한다면 ContentView를 ScrollView(SuperView) 위에 올릴 때 **width**를 명시적으로 지정해줘야 해요. (가로 방향은 height겠죠?) 그냥 edges.equalToSuperView() 를 사용한다면 좌우위아래 자유 자재로 움직이는 스크롤이 됩니다.
3. 마지막으로 ContentView 위에 올라가는 **가장 상/하단 요소들은 명시적으로 top/bottom을 지정**해줘야 합니다. 안 그러면 ContentView의 높이가 명확하지 않아서 스크롤이 안돼요. <- 저는 최하단 요소의 bottom을 지정해주지 않아서 스크롤이 안되는 문제로 고생했습니다..

이미 잘 알고 계시겠지만, 미래의 저를 위한 메모 차원에서 간단하게 정리해봤어요! 

## 📣 Related Issue
- close #237 


## 📬 Reference
[스크롤뷰]
https://worldseawater.tistory.com/93