### PR TITLE
[CHORE] 키워드가 없을 때 cell 터치하면 피드백 추가로 이동하기

### DIFF
--- a/Maddori.Apple/Maddori.Apple/Screen/Home/Home/HomeViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/Home/HomeViewController.swift
@@ -34,6 +34,7 @@ final class HomeViewController: BaseViewController {
     
     var currentReflectionId: Int = 0
     var reflectionStatus: ReflectionStatus = .Before
+    var hasKeyword: Bool = false
     var isAdmin: Bool = false
     var hasSeenReflectionAlert: Bool = UserDefaultStorage.hasSeenReflectionAlert {
         willSet {
@@ -394,8 +395,10 @@ final class HomeViewController: BaseViewController {
                 self.currentReflectionId = reflectionId
                 self.reflectionStatus = reflectionStatus
                 if let reflectionKeywordList = reflectionDetail?.reflectionKeywords {
+                    self.hasKeyword = true
                     if reflectionKeywordList.isEmpty {
                         self.resetKeywordList()
+                        self.hasKeyword = false
                     }
                     self.convertFetchedKeywordList(of: reflectionKeywordList)
                     DispatchQueue.main.async {
@@ -455,7 +458,12 @@ extension HomeViewController: UICollectionViewDataSource {
         UIDevice.vibrate()
         switch reflectionStatus {
         case .Before, .SettingRequired, .Done:
-            showToastPopUp(of: .warning)
+            if hasKeyword {
+                showToastPopUp(of: .warning)
+            } else {
+                didTapAddFeedbackButton()
+            }
+            
         case .Progressing:
             showStartReflectionView()
         }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
백로그의 '피드백이 없을 경우 키워드를 눌렀을 때 피드백 추가하기로 분기처리하기' 해결하기 위해 만든 이슈의 PR 입니다~

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- keyword list 에 아무 피드백도 없을 때(첫 피드백을 작성.. 상태일 때) 피드백 추가 페이지로 이동

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
피드백 없을 때 키워드를 터치해주세요~
피드백 있을 때에는 토스트가 뜨고 없을 때에는 페이지가 뜨면 성공입니당

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->

https://user-images.githubusercontent.com/72431640/209920158-ce1fd35b-ca94-4926-a702-0729fb7f74ab.mp4



## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #240


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
