### PR TITLE
[CHORE] 닉네임에 이모티콘 들어가 있을 경우 Alert 띄워주기 + 추가 버그 해결

### DIFF
--- a/Maddori.Apple/Maddori.Apple/Global/Literal/TextLiteral.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Literal/TextLiteral.swift
@@ -42,6 +42,8 @@ enum TextLiteral {
     
     static let setNicknameViewControllerTitleLabel = "키고에서 사용할 \n닉네임을 입력해주세요"
     static let setNicknameViewControllerNicknameTextFieldPlaceHolder = "예) 진저, 호야, 성민"
+    static let setNicknameViewControllerAlertTitle = "이모티콘 사용 불가능"
+    static let setNicknameControllerAlertMessage = "닉네임을 다시 입력해주세요."
     
     // MARK: - HomeViewController
     

--- a/Maddori.Apple/Maddori.Apple/Global/Literal/TextLiteral.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Literal/TextLiteral.swift
@@ -42,7 +42,7 @@ enum TextLiteral {
     
     static let setNicknameViewControllerTitleLabel = "키고에서 사용할 \n닉네임을 입력해주세요"
     static let setNicknameViewControllerNicknameTextFieldPlaceHolder = "예) 진저, 호야, 성민"
-    static let setNicknameViewControllerAlertTitle = "이모티콘 사용 불가능"
+    static let setNicknameViewControllerAlertTitle = "특수문자를 사용할 수 없습니다."
     static let setNicknameControllerAlertMessage = "닉네임을 다시 입력해주세요."
     
     // MARK: - HomeViewController

--- a/Maddori.Apple/Maddori.Apple/Network/Storage/UserDefaultStorage.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/Storage/UserDefaultStorage.swift
@@ -31,7 +31,7 @@ struct UserDefaultStorage {
     }
     
     static var teamId: Int {
-        return UserData<Int>.getValue(forKey: .teamId) ?? 1
+        return UserData<Int>.getValue(forKey: .teamId) ?? 0
     }
     
     static var accessToken: String {

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/Login/LoginViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/Login/LoginViewController.swift
@@ -44,6 +44,11 @@ final class LoginViewController: BaseViewController {
     
     // MARK: - life cycle
     
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        navigateToLastView()
+    }
+    
     override func configUI() {
         super.configUI()
         setGradientText()
@@ -105,6 +110,20 @@ final class LoginViewController: BaseViewController {
         UserDefaultHandler.setIsLogin(isLogin: true)
     }
     
+    private func navigateToLastView() {
+        let hasNickname = UserDefaultStorage.nickname != ""
+        let hasTeamId = UserDefaultStorage.teamId != 0
+        if hasNickname && hasTeamId {
+            let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate
+            sceneDelegate?.changeRootViewCustomTabBarView()
+            self.setLoginUserDefaults()
+        } else if hasNickname {
+            self.presentViewController(viewController: JoinTeamViewController())
+        } else {
+            return
+        }
+    }
+    
     // MARK: - api
     
     private func dispatchAppleLogin(type: SetupEndPoint<AppleLoginDTO>) {
@@ -133,20 +152,15 @@ final class LoginViewController: BaseViewController {
                     UserDefaultHandler.setTeamId(teamId: teamId)
                     let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate
                     sceneDelegate?.changeRootViewCustomTabBarView()
-                } else if hasNickName {
-                    guard let nickName = data.detail?.user?.userName else { return }
-                    UserDefaultHandler.setNickname(nickname: nickName)
-                    self?.presentViewController(viewController: JoinTeamViewController())
                 } else {
                     self?.presentViewController(viewController: SetNicknameViewController())
                 }
-                self?.setLoginUserDefaults()
             }
         }
     }
 }
 
-    // MARK: - extension
+// MARK: - extension
 
 extension LoginViewController: ASAuthorizationControllerDelegate {
     func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
@@ -178,7 +192,7 @@ extension LoginViewController: ASAuthorizationControllerDelegate {
             }
         }
     }
-
+    
     func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
         print(error)
     }

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/SetNickname/SetNicknameViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/SetNickname/SetNicknameViewController.swift
@@ -71,7 +71,7 @@ final class SetNicknameViewController: BaseTextFieldViewController {
     private func setupDoneButton() {
         let action = UIAction { [weak self] _ in
             guard let nickname = self?.kigoTextField.text else { return }
-            self?.dispatchUserLogin(type: .dispatchLogin(LoginDTO(username: UserDefaultStorage.nickname)))
+            self?.dispatchUserLogin(type: .dispatchLogin(LoginDTO(username: nickname)))
             self?.kigoTextField.resignFirstResponder()
         }
         super.doneButton.addAction(action, for: .touchUpInside)

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/SetNickname/SetNicknameViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/SetNickname/SetNicknameViewController.swift
@@ -71,7 +71,6 @@ final class SetNicknameViewController: BaseTextFieldViewController {
     private func setupDoneButton() {
         let action = UIAction { [weak self] _ in
             guard let nickname = self?.kigoTextField.text else { return }
-            UserDefaultHandler.setNickname(nickname: nickname)
             self?.dispatchUserLogin(type: .dispatchLogin(LoginDTO(username: UserDefaultStorage.nickname)))
             self?.kigoTextField.resignFirstResponder()
         }
@@ -90,9 +89,11 @@ final class SetNicknameViewController: BaseTextFieldViewController {
             guard let self else { return }
             switch response.result {
             case .success:
+                guard let nickname = self.kigoTextField.text else { return }
+                UserDefaultHandler.setNickname(nickname: nickname)
                 self.navigationController?.pushViewController(JoinTeamViewController(), animated: true)
             case .failure:
-                self.makeAlert(title: "이모티콘 사용 불가능", message: "닉네임을 다시 입력해주세요.")
+                self.makeAlert(title: TextLiteral.setNicknameViewControllerAlertTitle, message: TextLiteral.setNicknameControllerAlertMessage)
             }
         }
     }

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/SetNickname/SetNicknameViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/SetNickname/SetNicknameViewController.swift
@@ -90,9 +90,7 @@ final class SetNicknameViewController: BaseTextFieldViewController {
             guard let self else { return }
             switch response.result {
             case .success:
-                DispatchQueue.main.async {
-                    self.navigationController?.pushViewController(JoinTeamViewController(), animated: true)
-                }
+                self.navigationController?.pushViewController(JoinTeamViewController(), animated: true)
             case .failure:
                 self.makeAlert(title: "이모티콘 사용 불가능", message: "닉네임을 다시 입력해주세요.")
             }

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/SetNickname/SetNicknameViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/SetNickname/SetNicknameViewController.swift
@@ -74,9 +74,6 @@ final class SetNicknameViewController: BaseTextFieldViewController {
             UserDefaultHandler.setNickname(nickname: nickname)
             self?.dispatchUserLogin(type: .dispatchLogin(LoginDTO(username: UserDefaultStorage.nickname)))
             self?.kigoTextField.resignFirstResponder()
-            DispatchQueue.main.async {
-                self?.navigationController?.pushViewController(JoinTeamViewController(), animated: true)
-            }
         }
         super.doneButton.addAction(action, for: .touchUpInside)
     }
@@ -89,16 +86,15 @@ final class SetNicknameViewController: BaseTextFieldViewController {
                    parameters: type.body,
                    encoder: JSONParameterEncoder.default,
                    headers: type.headers
-        ).responseDecodable(of: BaseModel<JoinMemberResponse>.self) { [weak self] json in
+        ).responseDecodable(of: BaseModel<JoinMemberResponse>.self) { [weak self] response in
             guard let self else { return }
-            if let json = json.value {
-                guard let userId = json.detail?.id else { return }
-                UserDefaultHandler.setUserId(userId: userId)
-            } else {
+            switch response.result {
+            case .success:
                 DispatchQueue.main.async {
-                    // FIXME: - UXWriting 필요
-                    self.makeAlert(title: "에러", message: "중복된 닉네임입니다.")
+                    self.navigationController?.pushViewController(JoinTeamViewController(), animated: true)
                 }
+            case .failure:
+                self.makeAlert(title: "이모티콘 사용 불가능", message: "닉네임을 다시 입력해주세요.")
             }
         }
     }


### PR DESCRIPTION
## 🌁 Background
작업은 닉네임에 이모티콘을 포함하여 입력했을 때, '중복된 닉네임입니다'라는 생뚱맞은 Alert이 떴을 때부터 시작했습니다..

## 👩‍💻 Contents
1. SetNickname에서 이모티콘을 입력했을 경우, "이모티콘 사용 불가능", "닉네임을 다시 입력해주세요." 라는 Alert 띄우기
2. Alert이 떴다면 JoinTeamVC로 화면 넘어가지 않도록 하기
3. 닉네임을 입력하고 앱을 종료할 경우, 재접속 했을 때 팀 합류 페이지 띄우기
아래 Review Note에서 상세하게 설명 드리겠습니다!

## ✅ Testing
feature/242-no-emoji-on-nickname 로 이동하셔서
1. 회원 탈퇴 후 애플로그인 > 닉네임 설정 > 앱 종료 > 앱 재접속 테스트 = 팀 합류 페이지로 이동해야 함
2. 팀 합류 > 홈 > 앱 종료 > 앱 재접속 테스트 = 입력한 닉네임과 팀 이름이 각각 MyReflection과 Home 의 title label로 보여야 함
4. 로그아웃 > 애플 로그인 테스트 = 2와 동일하게 닉네임과 팀 이름이 각각 MyReflection과 Home 의 title label로 보여야 함
5. 회원 탈퇴 > 애플로그인 테스트 = 닉네임 설정 화면이 나와야 함
가능한,, 모든 경우의 수를 테스트 해주시면 감사하겠습니다 ,,

## 📱 Screenshot

이모티콘이 포함된 닉네임을 입력했을 경우 [기존 화면, 구현 화면]

https://user-images.githubusercontent.com/81340603/210178321-1d3578e2-6ae2-4579-aa54-6791b112854e.mp4

https://user-images.githubusercontent.com/81340603/210177412-027fa1ef-26a4-4a73-80a7-449e0a0c22ef.mp4


닉네임을 등록한 후 앱 종료 > 재접속 했을 경우 [기존 화면, 구현 화면]

https://user-images.githubusercontent.com/81340603/210178427-c1d0e700-a2f9-40ba-af63-536ba07a7226.mp4


https://user-images.githubusercontent.com/81340603/210177414-a9da281d-3ca8-4606-8342-250daf6f79f7.mp4



## 📝 Review Note
우여곡절이 좀 있었습니다,,! 사실 아직까지도 이 방법이 적절한 방법인지 확신이 들지 않아서 여러분들의 소중한 리뷰 부탁드립니다!

1. 이모티콘 입력시 띄워주는 Alert
처음 의도했던 건 아래처럼 postman에 찍어봤을 때 돌아오는 response body 값을 alert에 그대로 출력하는 거였습니다.
`{
    "success": false,
    "message": "입력 값의 형식이 잘못됨",
    "detail": "username 특수문자 포함 불가"
}`

하지만 Alamofire에 익숙하지 않아서 그런지, body에 직접 접근하는 방법을 모르겠더라구요.
  구글링해도 나오는 방법이라고는 switch문으로 response의 success(또는 failure)를 detect한 후,
  failure일 경우 반환되는 error를 출력하는 거였습니다. 
  하지만 이것은 제가 의도한 방법이 아닐 뿐더러 error message가 영어로 나와서.. 오히려 유저에게 불편함을 줄 것 같다는 생각에 그만뒀습니다.

  그래서 일단은 이모티콘을 입력하는 게 닉네임을 설정하는 과정에서 발생할 수 있는 유일한 에러라고 가정하고
  response가 fail 하면 무조건 이모티콘을 사용하지 말라는 에러 얼럿을 띄워주는 방식으로 코드를 수정했습니다.

  코드를 수정하는 과정에서 기존에 있었던 코드인
  ```swift
  if let json = json.value {
      guard let userId = json.detail?.id else { return }
      UserDefaultHandler.setUserId(userId: userId)
  } else {
      DispatchQueue.main.async {
          self.makeAlert(title: "에러", message: "중복된 닉네임입니다.")
      }
  ```
  을
  ```swift
  switch response.result {
  case .success:
      self.navigationController?.pushViewController(JoinTeamViewController(), animated: true)
  case .failure:
      self.makeAlert(title: "이모티콘 사용 불가능", message: "닉네임을 다시 입력해주세요.")
  }
  ```
로 변경했는데요.
  그 이유는 위에서 나온 userId는 무조건 nil이 나오고, 이미 LoginVC에서 유저 디폴트에 userId를 저장하기 때문에 필요가 없었습니다!
  또한, 이모티콘을 사용할 수 없다는 Alert이 나오고 JoinTeamVC로 화면이 이동하는 문제가 있어서,
  닉네임 등록을 위한 통신이 성공했을 때만 JoinTeamVC로 화면을 이동시키도록 변경했습니다.

2. 닉네임을 입력하고 앱 종료 및 재접속 했을 경우 비어있는 HomeVC로 연결되는 버그 해결하기
기존에는 nickname만 있는 상태에서 (팀이 없어도) 앱을 종료해도 isLogin이 true가 되어 바로 SceneDelegate에서 Home으로 이동시켜 버렸습니다. 때문에 팀 이름이 없는 Home 화면이 뜨는 문제가 발생했습니다.
Login 뷰를 로드할 때 userdefault에 nickname과 teamid가 있는지 확인하는 메소드를 추가했습니다. 앱 종료 후 재접속해도 유저의 마지막 플로우를 이어서 진행할 수 있도록 했습니다.
사실 유저가 앱을 종료하고 재접속하는 행위는 SceneDelegate에서 조정해야 하는 게 아닌가 라는 생각에 SceneDelegate에서 작업을 하다가.. 갑자기 이미 닉네임을 입력한 유저가 뒤로 돌아가 닉네임을 수정하고 싶을 수도 있을 거라는 생각이 들었고,, SceneDelegate에서는 root view를 다루는 곳이기 때문에 뒤로가기가 안될 뿐더러 역할이 올바르지 않은 것 같아서 LoginView에서 작업했습니다! (옳은 판단인지 확실하지 않아서 의견 부탁드립니다 ㅎㅎ)


적다보니 이야기가 길어졌네요,, 그래도 제가 고민했던 과정을 함께 이야기 해보면 좋을 것 같아서 구구절절 작성해봤습니다.


## 📣 Related Issue
- close #242 
