### PR TITLE
[CHORE] JoinTeamVC에 있는 버그 및 수정사항 반영하기

### DIFF
--- a/Maddori.Apple/Maddori.Apple/Global/Literal/TextLiteral.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Literal/TextLiteral.swift
@@ -85,6 +85,8 @@ enum TextLiteral {
     static let joinTeamViewControllerNicknameTextFieldPlaceHolder = "초대코드"
     static let joinTeamViewControllerSubText = "팀이 없나요?"
     static let joinTeamViewControllerSubButtonText = "팀 생성하기"
+    static let joinTeamViewControllerAlertTitle = "잘못된 초대코드"
+    static let joinTeamViewControllerAlertMessage = "초대코드를 다시 입력해주세요."
     
     // MARK: - StartReflectionViewController
     

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/TextField/CustomTextField.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/TextField/CustomTextField.swift
@@ -34,7 +34,7 @@ final class CustomTextField: UITextField {
         self.font = .body1
         self.layer.masksToBounds = true
         self.layer.borderWidth = 1
-        self.layer.borderColor = UIColor.white300.cgColor
+        self.layer.borderColor = UIColor.gray100.cgColor
         self.layer.cornerRadius = 10
         self.textAlignment = .left
         self.returnKeyType = .done

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/JoinTeam/JoinTeamViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/JoinTeam/JoinTeamViewController.swift
@@ -144,7 +144,7 @@ final class JoinTeamViewController: BaseTextFieldViewController {
                 self.presentCertainTeamViewController(teamName: teamName, teamId: UserDefaultStorage.teamId)
             } else {
                 DispatchQueue.main.async {
-                    self.makeAlert(title: "잘못된 초대코드", message: "초대코드를 다시 입력해주세요.")
+                    self.makeAlert(title: TextLiteral.joinTeamViewControllerAlertTitle, message: TextLiteral.joinTeamViewControllerAlertMessage)
                 }
             }
         }

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/JoinTeam/JoinTeamViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/JoinTeam/JoinTeamViewController.swift
@@ -138,8 +138,7 @@ final class JoinTeamViewController: BaseTextFieldViewController {
                 self.presentCertainTeamViewController(teamName: teamName, teamId: UserDefaultStorage.teamId)
             } else {
                 DispatchQueue.main.async {
-                    // FIXME: - UXWriting 필요
-                    self.makeAlert(title: "에러", message: "존재하지 않는 팀입니다.")
+                    self.makeAlert(title: "잘못된 초대코드", message: "초대코드를 다시 입력해주세요.")
                 }
             }
         }

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/JoinTeam/JoinTeamViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/JoinTeam/JoinTeamViewController.swift
@@ -77,6 +77,7 @@ final class JoinTeamViewController: BaseTextFieldViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupDoneButton()
+        setupKeyboard()
     }
     
     override func render() {
@@ -108,6 +109,11 @@ final class JoinTeamViewController: BaseTextFieldViewController {
             self?.fetchCertainTeam(type: .fetchCertainTeam(invitationCode: invitationCode))
         }
         super.doneButton.addAction(action, for: .touchUpInside)
+    }
+    
+    private func setupKeyboard() {
+        super.kigoTextField.keyboardType = .asciiCapable
+        super.kigoTextField.autocapitalizationType = .allCharacters
     }
     
     // MARK: - func


### PR DESCRIPTION
## 🌁 Background
JoinTeamVC와 관련된 자잘자잘한 버그 및 수정 사항들을 반영했습니다.
(날로 먹는 PR 입니다 ㅎ)

## 👩‍💻 Contents
1. 잘못된 초대코드를 입력했을 때 나오는 Alert 문구 변경하기
2. JoinTeamVC의 textfield 를 눌렀을 때 올라오는 키보드 언어를 영문/대문자로 기본 설정하기
3. CustomTextfield의 border 색 변경하기

## ✅ Testing
feature/244-chore-join-team으로 오셔서
JoinTeam 화면에서 잘못된 초대코드 입력해보고, 키보드 언어 확인해보시면 됩니다!

## 📱 Screenshot
|<img src="https://user-images.githubusercontent.com/81340603/210201055-b00310ad-88f7-4005-a1fb-e5d75e22c41c.png" width=200px />|<img src="https://user-images.githubusercontent.com/81340603/210201061-d60f9134-17a9-4c60-b2a5-d78071a35bb9.png" width=200px />|
|:---:|:---:|
|<center>영문대문자 키보드, textfield border</center>|<center>잘못된 초대코드 입력시</center>|

## 📝 Review Note
- 키보드 언어 설정을 위한 메소드를 viewDidLoad에 넣는 게 맞을까요? setupDoneButton 메소드와 비슷한 결이라는 생각이 들어서 일단 여기에 넣어뒀습니다!
- 키보드 언어 설정을 위해 JoinTeamVC > BaseTextFieldVC > CustomTextfield에 직접 접근해 property 값을 변경한 건데 .. 이게 적절한 방법인지 고민이 됩니다. 처음에 생각한 방법은 CustomTextfield에 keyboard type을 위한 옵셔널 변수를 하나 만들어서 (placeholdertext와 같이) 전달해주려고 했는데,, 다른 view에서는 사용하지 않는 언어설정을 JoinTeam만을 위해 만드는 것도 조금 낭비가 아닐까 라는 생각이 들어서요! 여러분들의 생각이 궁금합니다!

## 📣 Related Issue
- close #244 


## 📬 Reference
[Keyboard type]
https://ikkison.tistory.com/18
[영문 자동으로 대문자 설정에 관한 내용]
https://stackoverflow.com/questions/6943016/uitextfield-auto-capitalization-type-iphone-app