### PR TITLE
[BUG] 리더의 경우 키워드가 잘려서 보이는 버그 해결

### DIFF
--- a/Maddori.Apple/Maddori.Apple/Global/Literal/TextLiteral.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Literal/TextLiteral.swift
@@ -46,11 +46,7 @@ enum TextLiteral {
     // MARK: - HomeViewController
     
     static let homeViewControllerEmptyDescriptionLabel = "아직 회고 일정이 정해지지 않았습니다"
-    static let homeViewControllerCollectionViewEmtpyText0 = "첫 번째"
-    static let homeViewControllerCollectionViewEmtpyText1 = "키워드를"
-    static let homeViewControllerCollectionViewEmtpyText2 = "📝"
-    static let homeViewControllerCollectionViewEmtpyText3 = "작성해보세요"
-    static let homeViewControllerCollectionViewEmtpyText4 = "✚"
+    static let homeViewControllerEmptyCollectionViewList = ["첫 번째", "키워드를", "📝", "작성해보세요", "✚"]
     
     // MARK: - AddFeedbackViewController
     

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/CollectionView/KeywordCollectionView/KeywordCollectionViewFlowLayout.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/CollectionView/KeywordCollectionView/KeywordCollectionViewFlowLayout.swift
@@ -19,7 +19,7 @@ final class KeywordCollectionViewFlowLayout: UICollectionViewFlowLayout {
     
     override func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
         self.minimumLineSpacing = Size.keywordLabelRowSpacing
-        self.sectionInset = UIEdgeInsets(top: 15, left: SizeLiteral.leadingTrailingPadding, bottom: 0, right: SizeLiteral.leadingTrailingPadding)
+        self.sectionInset = UIEdgeInsets(top: 15, left: SizeLiteral.leadingTrailingPadding, bottom: 15, right: SizeLiteral.leadingTrailingPadding)
         let attributes = super.layoutAttributesForElements(in: rect)
         var leftMargin = sectionInset.left
         var maxY: CGFloat = -1.0

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/Home/HomeViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/Home/HomeViewController.swift
@@ -282,17 +282,32 @@ final class HomeViewController: BaseViewController {
         present(viewController, animated: true)
     }
     
+    
+    // 회고 상태: Setting Required
+    private func showPlanLabelButton() {
+        planLabelButtonView.isHidden = false
+        planLabelButtonBackgroundView.isHidden = false
+    }
+    
+    // 회고 상태: Before
+    private func hidePlanLabelButton() {
+        planLabelButtonView.isHidden = true
+        planLabelButtonBackgroundView.isHidden = true
+        
+        keywordCollectionView.snp.remakeConstraints {
+            $0.top.equalTo(currentReflectionLabel.snp.bottom).offset(SizeLiteral.titleSubtitleSpacing)
+            $0.leading.trailing.equalTo(view.safeAreaLayoutGuide)
+            $0.bottom.equalTo(addFeedbackButton.snp.top).offset(-10)
+        }
+    }
+    
+    // 회고 상태: Progressing
     private func showStartReflectionView() {
         guard let navigationController = self.navigationController else { return }
         let viewController = StartReflectionViewController(reflectionId: currentReflectionId, navigationViewController: navigationController, isAdmin: self.isAdmin)
         viewController.modalPresentationStyle = .overFullScreen
         present(viewController, animated: true)
         hasSeenReflectionAlert = true
-    }
-    
-    private func showPlanLabelButton() {
-        planLabelButtonView.isHidden = false
-        planLabelButtonBackgroundView.isHidden = false
     }
     
     private func showJoinReflectionButton() {
@@ -317,6 +332,16 @@ final class HomeViewController: BaseViewController {
         joinReflectionButton.render()
     }
     
+    private func hideAddFeedbackButton() {
+        self.addFeedbackButton.isHidden = true
+        keywordCollectionView.snp.remakeConstraints {
+            $0.top.equalTo(currentReflectionLabel.snp.bottom).offset(SizeLiteral.titleSubtitleSpacing)
+            $0.leading.trailing.equalTo(view.safeAreaLayoutGuide)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(SizeLiteral.bottomTabBarPadding)
+        }
+    }
+    
+    // 회고 상태: Done
     private func restoreView() {
         currentReflectionLabel.snp.remakeConstraints {
             $0.top.equalTo(descriptionLabel.snp.bottom).offset(Size.propertyPadding)
@@ -326,13 +351,8 @@ final class HomeViewController: BaseViewController {
         keywordCollectionView.snp.remakeConstraints {
             $0.top.equalTo(currentReflectionLabel.snp.bottom).offset(SizeLiteral.titleSubtitleSpacing)
             $0.leading.trailing.equalTo(view.safeAreaLayoutGuide)
-            $0.bottom.equalTo(addFeedbackButton.snp.top).offset(-10)
+            $0.bottom.equalTo(planLabelButtonBackgroundView.snp.top).offset(-10)
         }
-    }
-    
-    private func hidePlanLabelButton() {
-        planLabelButtonView.isHidden = true
-        planLabelButtonBackgroundView.isHidden = true
     }
     
     private func hideJoinReflectionButton() {
@@ -349,11 +369,13 @@ final class HomeViewController: BaseViewController {
     }
     
     private func resetKeywordList() {
-        keywordList = [TextLiteral.homeViewControllerCollectionViewEmtpyText0,
-                       TextLiteral.homeViewControllerCollectionViewEmtpyText1,
-                       TextLiteral.homeViewControllerCollectionViewEmtpyText2,
-                       TextLiteral.homeViewControllerCollectionViewEmtpyText3,
-                       TextLiteral.homeViewControllerCollectionViewEmtpyText4]
+        keywordList = [
+            TextLiteral.homeViewControllerCollectionViewEmtpyText0,
+            TextLiteral.homeViewControllerCollectionViewEmtpyText1,
+            TextLiteral.homeViewControllerCollectionViewEmtpyText2,
+            TextLiteral.homeViewControllerCollectionViewEmtpyText3,
+            TextLiteral.homeViewControllerCollectionViewEmtpyText4,
+        ]
     }
     
     // MARK: - api
@@ -402,8 +424,8 @@ final class HomeViewController: BaseViewController {
                         switch reflectionStatus {
                         case .SettingRequired, .Done:
                             self.descriptionLabel.text = TextLiteral.homeViewControllerEmptyDescriptionLabel
-                            self.hideJoinReflectionButton()
                             self.addFeedbackButton.isHidden = false
+                            self.hideJoinReflectionButton()
                             self.showPlanLabelButton()
                             self.restoreView()
                         case .Before:
@@ -413,10 +435,9 @@ final class HomeViewController: BaseViewController {
                         case .Progressing:
                             let reflectionDate = reflectionDetail?.reflectionDate?.formatDateString(to: "M월 d일 a h시 m분")
                             self.descriptionLabel.text = "다음 회고는 \(reflectionDate ?? String(describing: Date()))입니다"
-                            self.addFeedbackButton.isHidden = true
-                            self.hidePlanLabelButton()
                             self.showJoinReflectionButton()
                             self.hidePlanLabelButton()
+                            self.hideAddFeedbackButton()
                             if !self.hasSeenReflectionAlert {
                                 self.showStartReflectionView()
                             }

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/Home/HomeViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/Home/HomeViewController.swift
@@ -12,13 +12,7 @@ import SnapKit
 
 final class HomeViewController: BaseViewController {
     
-    var keywordList: [String] = [
-        TextLiteral.homeViewControllerCollectionViewEmtpyText0,
-        TextLiteral.homeViewControllerCollectionViewEmtpyText1,
-        TextLiteral.homeViewControllerCollectionViewEmtpyText2,
-        TextLiteral.homeViewControllerCollectionViewEmtpyText3,
-        TextLiteral.homeViewControllerCollectionViewEmtpyText4
-    ]
+    var keywordList: [String] = TextLiteral.homeViewControllerEmptyCollectionViewList
     var isTouched = false
     
     private enum Size {
@@ -371,13 +365,7 @@ final class HomeViewController: BaseViewController {
     }
     
     private func resetKeywordList() {
-        keywordList = [
-            TextLiteral.homeViewControllerCollectionViewEmtpyText0,
-            TextLiteral.homeViewControllerCollectionViewEmtpyText1,
-            TextLiteral.homeViewControllerCollectionViewEmtpyText2,
-            TextLiteral.homeViewControllerCollectionViewEmtpyText3,
-            TextLiteral.homeViewControllerCollectionViewEmtpyText4,
-        ]
+        keywordList = TextLiteral.homeViewControllerEmptyCollectionViewList
     }
     
     // MARK: - api

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/Home/HomeViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/Home/HomeViewController.swift
@@ -348,10 +348,12 @@ final class HomeViewController: BaseViewController {
             $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
         }
         
-        keywordCollectionView.snp.remakeConstraints {
-            $0.top.equalTo(currentReflectionLabel.snp.bottom).offset(SizeLiteral.titleSubtitleSpacing)
-            $0.leading.trailing.equalTo(view.safeAreaLayoutGuide)
-            $0.bottom.equalTo(planLabelButtonBackgroundView.snp.top).offset(-10)
+        if isAdmin {
+            keywordCollectionView.snp.remakeConstraints {
+                $0.top.equalTo(currentReflectionLabel.snp.bottom).offset(SizeLiteral.titleSubtitleSpacing)
+                $0.leading.trailing.equalTo(view.safeAreaLayoutGuide)
+                $0.bottom.equalTo(planLabelButtonBackgroundView.snp.top).offset(-10)
+            }
         }
     }
     


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
백로그의 <리더의 경우 키워드 개수가 많아지면 키워드 마지막 줄이 가려지는 버그>를 해결하는 PR 입니다

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 리더의 경우 회고의 상태가 Setting Required 이면 키워드의 bottom을 회고 일정 설정하는 label의 top 에 둠
- 리더의 경우 회고의 상태가 Before 이면 키워드의 bottom을 피드백 추가 버튼의 top 에 둠
- 일반 멤버의 경우 키워드의 bottom을 피드백 추가 버튼의 top 에 둠

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
키워드 엄청 추가해야 하는 귀찮음이 있는데 제가 이거 추가해뒀습니다..!!
DB에 ㄹㄹㄹㄹㄹㄹㄹ 도배된 팀의 회고가 있는데 (팀: 72 / 회고: 160)
이 팀의 이 회고로 설정해서 확인해주시면 됩니다..!!

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<리더 - 회고 일정 없을 때>
https://user-images.githubusercontent.com/72431640/210717147-32aa31e5-b51c-4b62-b587-da3c651ac67b.mp4


<리더 - 회고 일정 있을 때>
https://user-images.githubusercontent.com/72431640/210717315-b382c0dc-f972-4554-af2b-6a84a20a4fb4.mp4


<리더, 멤버 - 회고 시작 했을 때>
https://user-images.githubusercontent.com/72431640/210717430-eb296d09-08cc-40f2-857f-b56a3dc2df2a.mp4


<멤버 - 회고 일정 있을 때 없을 때 똑같음>
https://user-images.githubusercontent.com/72431640/210717504-b4e00ee3-a081-466f-81fc-607242212a01.mp4



## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
Home 부분은 제가 대부분 짠걸로 기억하는데 어떤 함수가 어디에서 어떻게 쓰이는지 헷갈려서 주석으로 표시를 해뒀습니다..!
이렇게 하는게 코드의 통일성을 헤친다 생각 들면 없애겠습니다!!
추후에 새로운 디자인으로 바뀌면 코드 전반적인 개선이 있을 듯 합니다🤔

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #200


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
