### PR TITLE
[CHORE] 팀이름에 특수문자 입력하지 못하도록 핸들링하기

### DIFF
--- a/Maddori.Apple/Maddori.Apple/Global/Literal/TextLiteral.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Literal/TextLiteral.swift
@@ -99,6 +99,8 @@ enum TextLiteral {
     
     static let createTeamViewControllerTitleLabel = "팀 이름을 입력해주세요"
     static let createTeamViewControllerTextFieldPlaceHolder = "예) 맛쟁이 사과처럼"
+    static let createTeamViewControllerAlertTitle = "특수문자를 사용할 수 없습니다."
+    static let createTeamViewControllerAlertMessage = "팀 이름을 다시 입력해주세요."
     
     // MARK: - InvitationCodeViewController
     

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/CreateTeam/CreateTeamViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/CreateTeam/CreateTeamViewController.swift
@@ -119,8 +119,7 @@ final class CreateTeamViewController: BaseTextFieldViewController {
                 }
             } else {
                 DispatchQueue.main.async {
-                    // FIXME: - UXWriting 필요
-                    self.makeAlert(title: "에러", message: "중복된 팀 이름입니다")
+                    self.makeAlert(title: TextLiteral.createTeamViewControllerAlertTitle, message: TextLiteral.createTeamViewControllerAlertMessage)
                 }
             }
         }


### PR DESCRIPTION
## 🌁 Background
백로그 [팀이름에 특수문자 입력하지 못하도록 핸들링하기](https://www.notion.so/46db2c7220b949b1b3bad4ba796dcbbe) 을 해결한 PR 입니다. (aka 날먹)

## 👩‍💻 Contents
- Alert 문구 변경 (특수문자를 사용할 수 없습니다. / 팀 이름을 다시 입력해주세요.)
- TextLiteral 로 text 이동


## ✅ Testing
feature/258-no-symbol-on-team-name 으로 오셔서,
팀을 생성하는 화면에 'oh!'를 입력해보시면 얼럿이 뜨는 걸 확인하실 수 있습니다!


## 📱 Screenshot
<img src="https://user-images.githubusercontent.com/81340603/210999753-f5c4bb65-d5d0-44ee-b729-ccec9fd981e3.png" width=200px />
`oh!`를 입력했을 때 위와 같이 얼럿이 뜨는 것을 확인할 수 있습니다!


## 📣 Related Issue
- close #258 
