### PR TITLE
[CHORE] 피그마와 다른 UI/색 수정하기, 멤버가 5명 이상 되는 경우 멤버 최하단 CollectionViewCell 이 가려지는 버그 해결하기

### DIFF
--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/CollectionView/MemberCollectionView/MemberCollectionView.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/CollectionView/MemberCollectionView/MemberCollectionView.swift
@@ -27,7 +27,7 @@ final class MemberCollectionView: UIView {
         var collectionTopSpacing: CGFloat {
             switch self {
             case .addFeedback:
-                return 10
+                return 4
             case .progressReflection:
                 return 40
             }
@@ -57,7 +57,7 @@ final class MemberCollectionView: UIView {
                 return UIEdgeInsets(
                     top: collectionTopSpacing,
                     left: collectionHorizontalSpacing,
-                    bottom: 0,
+                    bottom: 12,
                     right: collectionHorizontalSpacing)
             case .progressReflection:
                 return UIEdgeInsets(

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/CollectionView/MemberCollectionView/MemberCollectionView.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/CollectionView/MemberCollectionView/MemberCollectionView.swift
@@ -57,7 +57,7 @@ final class MemberCollectionView: UIView {
                 return UIEdgeInsets(
                     top: collectionTopSpacing,
                     left: collectionHorizontalSpacing,
-                    bottom: 12,
+                    bottom: 4,
                     right: collectionHorizontalSpacing)
             case .progressReflection:
                 return UIEdgeInsets(
@@ -85,6 +85,15 @@ final class MemberCollectionView: UIView {
                 return .white100
             }
         }
+        
+        var cellSpacing: CGFloat {
+            switch self {
+            case .addFeedback:
+                return 20
+            case .progressReflection:
+                return 30
+            }
+        }
     }
     
     var type: CollectionType
@@ -106,7 +115,7 @@ final class MemberCollectionView: UIView {
         flowLayout.scrollDirection = .vertical
         flowLayout.sectionInset = type.collectionInsets
         flowLayout.itemSize = CGSize(width: type.cellWidth, height: type.cellHeight)
-        flowLayout.minimumLineSpacing = 29
+        flowLayout.minimumLineSpacing = type.cellSpacing
         return flowLayout
     }()
     private lazy var collectionView: UICollectionView = {

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/CollectionView/MemberCollectionView/MemberCollectionView.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/CollectionView/MemberCollectionView/MemberCollectionView.swift
@@ -76,6 +76,15 @@ final class MemberCollectionView: UIView {
                 return .white300
             }
         }
+        
+        var collectionViewBackgroudColor: UIColor {
+            switch self {
+            case .addFeedback:
+                return .white200
+            case .progressReflection:
+                return .white100
+            }
+        }
     }
     
     var type: CollectionType
@@ -102,7 +111,7 @@ final class MemberCollectionView: UIView {
     }()
     private lazy var collectionView: UICollectionView = {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionViewFlowLayout)
-        collectionView.backgroundColor = .white100
+        collectionView.backgroundColor = type.collectionViewBackgroudColor
         collectionView.dataSource = self
         collectionView.delegate = self
         collectionView.showsVerticalScrollIndicator = false

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/CollectionView/MemberCollectionView/MemberCollectionView.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/CollectionView/MemberCollectionView/MemberCollectionView.swift
@@ -94,6 +94,15 @@ final class MemberCollectionView: UIView {
                 return 30
             }
         }
+        
+        var cellFont: UIFont {
+            switch self {
+            case .addFeedback:
+                return .main
+            case .progressReflection:
+                return .label1
+            }
+        }
     }
     
     var type: CollectionType
@@ -190,6 +199,7 @@ extension MemberCollectionView: UICollectionViewDataSource {
         }
         
         cell.cellColor = type.cellColor
+        cell.memberLabel.font = type.cellFont
         
         return cell
     }

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/CollectionView/MemberCollectionView/MemberCollectionView.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/CollectionView/MemberCollectionView/MemberCollectionView.swift
@@ -67,6 +67,15 @@ final class MemberCollectionView: UIView {
                     right: collectionHorizontalSpacing)
             }
         }
+        
+        var cellColor: UIColor {
+            switch self {
+            case .addFeedback:
+                return .white100
+            case .progressReflection:
+                return .white300
+            }
+        }
     }
     
     var type: CollectionType
@@ -161,6 +170,9 @@ extension MemberCollectionView: UICollectionViewDataSource {
         case .progressReflection:
             cell.index = FromCellIndex.fromSelectMember
         }
+        
+        cell.cellColor = type.cellColor
+        
         return cell
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/CollectionView/MemberCollectionView/MemberCollectionViewCell.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/CollectionView/MemberCollectionView/MemberCollectionViewCell.swift
@@ -13,6 +13,12 @@ final class MemberCollectionViewCell: BaseCollectionViewCell {
     
     var index: FromCellIndex = .fromSelectMember
     
+    var cellColor: UIColor = .white300 {
+        didSet {
+            memberLabel.backgroundColor = cellColor
+        }
+    }
+    
     private enum Size {
         static let width = 135
         static let height = 60
@@ -38,11 +44,11 @@ final class MemberCollectionViewCell: BaseCollectionViewCell {
     
     // MARK: - property
     
-    let memberLabel: UILabel = {
+    lazy var memberLabel: UILabel = {
         let label = UILabel()
         label.font = .label1
         label.textColor = .black100
-        label.backgroundColor = .white300
+        label.backgroundColor = self.cellColor
         label.layer.masksToBounds = true
         label.layer.cornerRadius = 8
         label.textAlignment = .center

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/CollectionView/MemberCollectionView/MemberCollectionViewCell.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/CollectionView/MemberCollectionView/MemberCollectionViewCell.swift
@@ -19,13 +19,6 @@ final class MemberCollectionViewCell: BaseCollectionViewCell {
         }
     }
     
-    private enum Size {
-        static let width = 135
-        static let height = 60
-        static let frame = CGRect(x: 0, y: 0, width: Size.width, height: Size.height)
-    }
-    
-
     override var isSelected: Bool {
         didSet {
             if index == FromCellIndex.fromAddFeedback {
@@ -54,9 +47,9 @@ final class MemberCollectionViewCell: BaseCollectionViewCell {
         label.textAlignment = .center
         return label
     }()
-    private let memberShadow: UIView = {
+    private lazy var memberShadow: UIView = {
         let view = UIView()
-        view.frame = Size.frame
+        view.frame = self.frame
         view.layer.cornerRadius = 8
         view.layer.shadowRadius = 2
         view.layer.shadowOffset = CGSize(width: 0, height: 0)
@@ -69,14 +62,12 @@ final class MemberCollectionViewCell: BaseCollectionViewCell {
     override func render() {
         self.addSubview(memberShadow)
         memberShadow.snp.makeConstraints {
-            $0.width.equalTo(Size.width)
-            $0.height.equalTo(Size.height)
+            $0.edges.equalToSuperview()
         }
                 
         memberShadow.addSubview(memberLabel)
         memberLabel.snp.makeConstraints {
-            $0.width.equalTo(Size.width)
-            $0.height.equalTo(Size.height)
+            $0.edges.equalToSuperview()
         }
     }
     

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/CollectionView/MemberCollectionView/MemberCollectionViewCell.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/CollectionView/MemberCollectionView/MemberCollectionViewCell.swift
@@ -37,11 +37,10 @@ final class MemberCollectionViewCell: BaseCollectionViewCell {
     
     // MARK: - property
     
-    lazy var memberLabel: UILabel = {
+    let memberLabel: UILabel = {
         let label = UILabel()
         label.font = .label1
         label.textColor = .black100
-        label.backgroundColor = self.cellColor
         label.layer.masksToBounds = true
         label.layer.cornerRadius = 8
         label.textAlignment = .center

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/Home/AddDetailFeedback/AddDetailFeedbackViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/Home/AddDetailFeedback/AddDetailFeedbackViewController.swift
@@ -41,6 +41,8 @@ final class AddDetailFeedbackViewController: BaseViewController {
         label.text = TextLiteral.DetailTitleLabel
         label.numberOfLines = 0
         label.font = .title2
+        label.setLineSpacing(to: 4)
+        label.textColor = .black100
         return label
     }()
     private let nextButton: MainButton = {

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/Home/AddDetailFeedback/UIComponent/SelectKeywordTypeView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/Home/AddDetailFeedback/UIComponent/SelectKeywordTypeView.swift
@@ -102,7 +102,7 @@ final class SelectKeywordTypeView: UIStackView {
     }
     
     private func configUI() {
-        self.backgroundColor = .white100
+        self.backgroundColor = .white200
         self.layer.cornerRadius = 10
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/Home/AddDetailFeedback/UIComponent/SelectMemberView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/Home/AddDetailFeedback/UIComponent/SelectMemberView.swift
@@ -48,6 +48,7 @@ final class SelectMemberView: UIStackView {
     let titleLabel: UILabel = {
         let label = UILabel()
         label.font = .main
+        label.textColor = .black100
         label.text = TextLiteral.toNameTitleLabel
         return label
     }()
@@ -100,7 +101,7 @@ final class SelectMemberView: UIStackView {
         
         self.addSubview(memberCollectionView)
         memberCollectionView.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(10)
+            $0.top.equalTo(titleView.snp.bottom)
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(190)
         }

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/Home/AddDetailFeedback/UIComponent/SelectMemberView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/Home/AddDetailFeedback/UIComponent/SelectMemberView.swift
@@ -107,7 +107,7 @@ final class SelectMemberView: UIStackView {
     }
     
     private func configUI() {
-        self.backgroundColor = .white100
+        self.backgroundColor = .white200
         self.layer.cornerRadius = 10
     }
 }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
![스크린샷 2023-01-07 오후 11 50 17](https://user-images.githubusercontent.com/59243274/211156617-5de52a85-7661-4cbd-9265-b253e01dec26.png)

위 스크린샷에서 보이듯 총 3가지의 UI 수정사항 변경과 1개의 버그해결의 PR입니다. 
1. MemberCollectionViewCell 의 색 white 100 으로 변경 (UI 수정사항 변경)
2. 피드백 맴버 & 종류 Container 색 white 200으로 변경 (UI 수정사항 변경)
3. 피드백 맴버 컬렉션 뷰 셀 높이 조정 (UI 수정사항 변경)
4. 맴버가 5명 이상일 경우 최하단 CollectionViewCell이 가려지는 버그 해결 (버그해결)

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
1. 현재 구현에서는 멤버 라벨의 색이 white300으로 설정되어 있는데 이는 회고 중일 때와 UI가 다르기 때문에 white100으로 분기처리 해줬습니다.
2. 1번과 마찬가지로 회고전에 피드백 추가 상황일때와, 회고중 피드백 들을 맴버 선택의 분기처리로 해결했습니다.
3. 셀 높이 수정은 Review Note에서 자세히 설명하겠습니다.
4. 가려지는 버그 해결도 ReviewNote에서 자세히 설명하겠습니다.

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
feature/262-change-color 로 오셔서 피드백 추가하기를 눌렀을때 UI를 보시면 됩니다. 
1. 피그마 UI와 같은지
2. 5명이상일때도 아래가 잘리지 않는지 확인해보시면 됩니다.

## 📱 Screenshot
| 1,2,3| 4 |
| ---| --|
|<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<img src = "https://user-images.githubusercontent.com/59243274/211157110-38cca1a1-5f95-4959-8b00-d433e5945dfe.png" width = 350> |<img src = "https://user-images.githubusercontent.com/59243274/211157123-ee314c43-fa9d-4d63-9777-7110489dc059.png" width = 350> |

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
먼저 사실 1,2,3 번과 4번의 같은 이슈가 아니였습니다. 그런데 3번을 보다보니 4번이 해결되면 자연스레 해결될것이라고 생각이 들어서 해결하다 보니 4번 이슈가 이 PR에 포함이 되었습니다. 

현재 MemberCollectionViewCell에 memberShadow라는 그림자를 만드는 UIView가 있습니다. 그 뷰의 크기가 MemberCollectionViewCell안의 Size라는 이넘값으로 관리가 되고 있었습니다. 그래서 아무리 MemberCollectionView 에서 분기처리 해서 넣어줘도 변경되지 않아 보이던 거였습니다. 
그래서 그냥 간단하게 memberShadow의 레이아웃을 cell frame으로 잡았고 자연스럽게 4번이 해결됐습니다. 
여기서 4번 해결도중 셀끼리의 spacing도 분기처리가 필요해서 추가 후 수정했습니다.

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #262 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
