### PR TITLE
[CHORE] 멤버를 터치한 후 피드백 종류 drop down 되도록 하기

### DIFF
--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/View/FeedbackTypeButtonView.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/View/FeedbackTypeButtonView.swift
@@ -43,6 +43,7 @@ final class FeedbackTypeButtonView: UIView {
         let label = UILabel()
         label.text = FeedBackType.continueType.rawValue
         label.font = .main
+        label.textColor = .black100
         return label
     }()
     private let continueSubTitleLabel: UILabel = {
@@ -74,6 +75,7 @@ final class FeedbackTypeButtonView: UIView {
         let label = UILabel()
         label.text = FeedBackType.stopType.rawValue
         label.font = .main
+        label.textColor = .black100
         return label
     }()
     private let stopSubTitleLabel: UILabel = {

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/Home/AddDetailFeedback/AddDetailFeedbackViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/Home/AddDetailFeedback/AddDetailFeedbackViewController.swift
@@ -56,6 +56,8 @@ final class AddDetailFeedbackViewController: BaseViewController {
                   let userId = user.userId   else { return }
             self?.toName = userName
             self?.toId = userId
+            
+            self?.openSelectTypeView()
         }
         return view
     }()
@@ -236,6 +238,18 @@ final class AddDetailFeedbackViewController: BaseViewController {
     private func pushAddFeedbackViewController () {
         let viewController = AddFeedbackContentViewController(feedbackContent: feedbackContent, step: .writeSituation)
         navigationController?.pushViewController(viewController, animated: true)
+    }
+    
+    private func openSelectTypeView() {
+        self.selectKeywordTypeView.snp.updateConstraints {
+            $0.height.equalTo(178)
+        }
+        self.isOpenedTypeView = true
+        self.selectKeywordTypeView.isOpened = true
+        UIView.animate(withDuration: 0.2) {
+            self.selectKeywordTypeView.upDownImageView.transform = CGAffineTransform(rotationAngle: .pi)
+            self.view.layoutIfNeeded()
+        }
     }
     
     // MARK: - api

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/Home/AddDetailFeedback/AddDetailFeedbackViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/Home/AddDetailFeedback/AddDetailFeedbackViewController.swift
@@ -28,7 +28,20 @@ final class AddDetailFeedbackViewController: BaseViewController {
             }
         }
     }
-    private var isOpenedTypeView: Bool = false
+    private var isOpenedTypeView: Bool = false {
+        didSet {
+            if !isOpenedTypeView {
+                if selectKeywordTypeView.feedbackTypeButtonView.feedbackType != nil {
+                    selectKeywordTypeView.titleLabel.text = selectKeywordTypeView.feedbackTypeButtonView.feedbackType?.rawValue
+                    selectKeywordTypeView.titleLabel.textColor = .blue200
+                }
+            }
+            else {
+                selectKeywordTypeView.titleLabel.text = TextLiteral.feedbackTypeLabel
+                selectKeywordTypeView.titleLabel.textColor = .black100
+            }
+        }
+    }
     private var toName: String = ""
     private var toId: Int?
     

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/Home/AddDetailFeedback/UIComponent/SelectKeywordTypeView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/Home/AddDetailFeedback/UIComponent/SelectKeywordTypeView.swift
@@ -37,7 +37,7 @@ final class SelectKeywordTypeView: UIStackView {
     
     // MARK: - property
     
-    private let titleLabel: UILabel = {
+    let titleLabel: UILabel = {
         let label = UILabel()
         label.font = .main
         label.text = TextLiteral.feedbackTypeLabel


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
![스크린샷 2023-01-08 오후 11 55 25](https://user-images.githubusercontent.com/59243274/211203136-fc9d4a69-5a39-4a27-83a2-105ac0dda0c7.png)

피드백을 줄 맴버를 터치하면 바로 종류 영역이 드롭다운 되는 형식으로 변경하였습니다! (현재는 아니였음)

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
맴버 선택 시 바로 드롭다운

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
feature/265-drop-down 로 오셔서 피드백 추가하기 부분에서 눌러보시면 됩니다.

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->

https://user-images.githubusercontent.com/59243274/211203228-4065587c-a126-4001-9a34-2201f32c4e9d.mp4



## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
원래는 didSelectedMemeber 클로저에서 작업하지 않고 새로운 클로저를 열어서 연결했었는데 아무래도 같은 동작(맴버를 선택한다) 에 액션이 2개인 거라 그냥 didSelectedMemeber 클로저에 합쳤습니다. 괜찮나요?

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #265 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
