### PR TITLE
[FIX] 피드백 멤버와 종류 모두 선택되지 않아도 ‘다음’ 버튼이 활성화 되어 있는 버그 해결하기

### DIFF
--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/View/FeedbackTypeButtonView.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/View/FeedbackTypeButtonView.swift
@@ -11,6 +11,7 @@ import SnapKit
 
 final class FeedbackTypeButtonView: UIView {
     var changeFeedbackType: ((FeedbackButtonType) -> ())?
+    var isSelectedFeedbackType: ((Bool) -> ())?
     var feedbackType: FeedbackButtonType? {
         didSet {
             guard let type = feedbackType else { return }
@@ -35,6 +36,7 @@ final class FeedbackTypeButtonView: UIView {
         let action = UIAction { [weak self] _ in
             self?.changeFeedbackType?(.continueType)
             self?.feedbackType = .continueType
+            self?.isSelectedFeedbackType?(true)
         }
         button.addAction(action, for: .touchUpInside)
         return button
@@ -66,6 +68,7 @@ final class FeedbackTypeButtonView: UIView {
         let action = UIAction { [weak self] _ in
             self?.changeFeedbackType?(.stopType)
             self?.feedbackType = .stopType
+            self?.isSelectedFeedbackType?(true)
         }
         button.addAction(action, for: .touchUpInside)
         return button

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/Home/AddDetailFeedback/AddDetailFeedbackViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/Home/AddDetailFeedback/AddDetailFeedbackViewController.swift
@@ -31,6 +31,8 @@ final class AddDetailFeedbackViewController: BaseViewController {
     private var isOpenedTypeView: Bool = false
     private var toName: String = ""
     private var toId: Int?
+    private var isSelectedMember: Bool = false
+    private var isSelectedType: Bool = false
     
     // MARK: - property
     
@@ -46,7 +48,7 @@ final class AddDetailFeedbackViewController: BaseViewController {
     private let nextButton: MainButton = {
         let button = MainButton()
         button.title = TextLiteral.doneButtonNext
-        //        button.isDisabled = true
+        button.isDisabled = true
         return button
     }()
     private lazy var selectMemberView: SelectMemberView = {
@@ -57,6 +59,7 @@ final class AddDetailFeedbackViewController: BaseViewController {
                   let userId = user.userId   else { return }
             self?.toName = userName
             self?.toId = userId
+            self?.isSelectedMember = true
         }
         return view
     }()
@@ -91,6 +94,8 @@ final class AddDetailFeedbackViewController: BaseViewController {
         setupCloseButton()
         setupNextButton()
         setupShadowView()
+        detectFeedbackTypeIsSelected()
+        detectMemberIsSelected()
         fetchCurrentTeamMember(type: .fetchCurrentTeamMember)
     }
     
@@ -239,6 +244,29 @@ final class AddDetailFeedbackViewController: BaseViewController {
     private func pushAddFeedbackViewController () {
         let viewController = AddFeedbackContentViewController(feedbackContent: feedbackContent, step: .writeSituation)
         navigationController?.pushViewController(viewController, animated: true)
+    }
+    
+    private func detectFeedbackTypeIsSelected() {
+        selectKeywordTypeView.feedbackTypeButtonView.isSelectedFeedbackType = { [weak self] isSelected in
+            self?.isSelectedType = isSelected
+            self?.changeNextButtonStatus()
+        }
+    }
+    
+    private func detectMemberIsSelected() {
+        selectMemberView.isSelectedMember = { [weak self] isSelected in
+            self?.isSelectedMember = isSelected
+            self?.changeNextButtonStatus()
+        }
+    }
+    
+    private func changeNextButtonStatus() {
+        if isSelectedMember, isSelectedType {
+            nextButton.isDisabled = false
+        }
+        else {
+            nextButton.isDisabled = true
+        }
     }
     
     // MARK: - api

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/Home/AddDetailFeedback/AddDetailFeedbackViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/Home/AddDetailFeedback/AddDetailFeedbackViewController.swift
@@ -46,6 +46,7 @@ final class AddDetailFeedbackViewController: BaseViewController {
     private let nextButton: MainButton = {
         let button = MainButton()
         button.title = TextLiteral.doneButtonNext
+        //        button.isDisabled = true
         return button
     }()
     private lazy var selectMemberView: SelectMemberView = {
@@ -221,7 +222,9 @@ final class AddDetailFeedbackViewController: BaseViewController {
             guard let feedback = FeedBackDTO.init(rawValue: type.rawValue) else { return }
             
             self?.feedbackContent = FeedbackContent(toNickName: self?.toName, toUserId: self?.toId, feedbackType: feedback, reflectionId: self?.feedbackContent.reflectionId ?? 1)
-            self?.pushAddFeedbackViewController()
+            if self?.toName != "" {
+                self?.pushAddFeedbackViewController()
+            }
         }
         nextButton.addAction(action, for: .touchUpInside)
     }

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/Home/AddDetailFeedback/AddDetailFeedbackViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/Home/AddDetailFeedback/AddDetailFeedbackViewController.swift
@@ -94,8 +94,8 @@ final class AddDetailFeedbackViewController: BaseViewController {
         setupCloseButton()
         setupNextButton()
         setupShadowView()
-        detectFeedbackTypeIsSelected()
         detectMemberIsSelected()
+        detectFeedbackTypeIsSelected()
         fetchCurrentTeamMember(type: .fetchCurrentTeamMember)
     }
     
@@ -227,9 +227,7 @@ final class AddDetailFeedbackViewController: BaseViewController {
             guard let feedback = FeedBackDTO.init(rawValue: type.rawValue) else { return }
             
             self?.feedbackContent = FeedbackContent(toNickName: self?.toName, toUserId: self?.toId, feedbackType: feedback, reflectionId: self?.feedbackContent.reflectionId ?? 1)
-            if self?.toName != "" {
-                self?.pushAddFeedbackViewController()
-            }
+            self?.pushAddFeedbackViewController()
         }
         nextButton.addAction(action, for: .touchUpInside)
     }

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/Home/AddDetailFeedback/AddDetailFeedbackViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/Home/AddDetailFeedback/AddDetailFeedbackViewController.swift
@@ -262,9 +262,6 @@ final class AddDetailFeedbackViewController: BaseViewController {
         if isSelectedMember, isSelectedType {
             nextButton.isDisabled = false
         }
-        else {
-            nextButton.isDisabled = true
-        }
     }
     
     // MARK: - api

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/Home/AddDetailFeedback/UIComponent/SelectMemberView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/Home/AddDetailFeedback/UIComponent/SelectMemberView.swift
@@ -13,6 +13,7 @@ import SnapKit
 final class SelectMemberView: UIStackView {
     
     var didSelectedMemeber: ((MemberResponse) -> ())?
+    var isSelectedMember: ((Bool) -> ())?
     
     var isOpened: Bool = false {
         didSet {
@@ -60,6 +61,7 @@ final class SelectMemberView: UIStackView {
         let collectionView = MemberCollectionView(type: .addFeedback)
         collectionView.didTappedFeedBackMember = { [weak self] user in
             self?.didSelectedMemeber?(user)
+            self?.isSelectedMember?(true)
         }
         return collectionView
     }()


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
현재는 맴버와 타입이 선택되어있지 않아도 다음 버튼이 활성화 되어있는 버그가 있었습니다. 그 문제를 해결하는 PR입니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 피드백 맴버에서 선택을 감지하는 클로저 생성
- 피드백 타입에서 선택을 감지하는 클로저 생성
- AddFeedbackDetailViewController에서 맴버, 타입이 선택 되었는지 확인하는 변수 생성
- AddFeedbackDetailViewController에서 맴버 선택 했을때 버튼의 활성화 여부를 감지 후 바꾸는 함수 생성
- AddFeedbackDetailViewController에서 타입 선택 했을때 버튼의 활성화 여부를 감지 후 바꾸는 함수 생성

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
feature/267-nextbutton-bug-fix 오셔서
1. 피드백 맴버 선택 -> 타입 선택 -> 다음 버튼 활성화 여부 확인
2. 피드백 타입 선택 -> 맴버 선택 -> 다음 버튼 활성화 여부 확인

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->


https://user-images.githubusercontent.com/59243274/211230950-b8b517f8-bc13-4af8-bf07-45e7bc4705c1.mp4


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
원래는 당연히 피드백 맴버를 선택하는 뷰가 열려있으니 맴버 선택부터 하고 타입을 선택하겠지 라고 생각하고 작업했는데 혹시나 말썽쟁이 사용자가 타입부터 굳이 열고 선택 후 맴버를 선택할 수 도 있겠다 싶어서 이 케이스에 관해서도 처리했습니다.

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #267 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
