### PR TITLE
[ADD] 눌렀던 피드백 상태를 저장해서 다른 뷰에 다녀와도 그 상태가 유지되도록 구현하기

### DIFF
--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/CollectionView/KeywordCollectionView/KeywordCollectionViewCell.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/CollectionView/KeywordCollectionView/KeywordCollectionViewCell.swift
@@ -62,10 +62,8 @@ final class KeywordCollectionViewCell: BaseCollectionViewCell {
     }
     
     func setupAttribute(to style: KeywordType) {
-        if isSelected {
-            configLabel(type: style)
-            configShadow(type: style)
-        }
+        configLabel(type: style)
+        configShadow(type: style)
     }
     
     static func fittingSize(availableHeight: CGFloat, keyword: String?) -> CGSize {

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/CollectionView/MemberCollectionView/MemberCollectionView.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/CollectionView/MemberCollectionView/MemberCollectionView.swift
@@ -80,6 +80,11 @@ final class MemberCollectionView: UIView {
     var didTappedFeedBackMember: ((MemberResponse) -> ())?
     var selectedMember: MemberResponse?
     private var selectedMemberList: [MemberResponse] = []
+    var selectedMemberIdList: [Int] = UserDefaultStorage.seenMemberIdList {
+        willSet {
+            UserDefaultHandler.appendSeenMemberIdList(memberIdList: newValue)
+        }
+    }
     
     // MARK: - property
     
@@ -130,8 +135,15 @@ extension MemberCollectionView: UICollectionViewDelegate {
             didTappedFeedBackMember?(member)
             
         case .progressReflection:
-            if !selectedMemberList.contains(where: { $0.userName == memberList[indexPath.item].userName} ) {
-                selectedMemberList.append(memberList[indexPath.item])
+            let selectedItem: MemberResponse = memberList[indexPath.item]
+            if !selectedMemberList.contains(where: { $0.userName == selectedItem.userName } ) {
+                selectedMemberList.append(selectedItem)
+            }
+            if !selectedMemberIdList.contains(where: { $0 == selectedItem.userId }) {
+                selectedMemberIdList.append(selectedItem.userId ?? 0)
+            }
+            if selectedMemberIdList.count == memberList.count {
+                UserDefaultHandler.isCurrentReflectionFinished(true)
             }
             guard let cell = collectionView.cellForItem(at: indexPath) as? MemberCollectionViewCell else { return }
             selectedMember = memberList[indexPath.item]
@@ -154,7 +166,11 @@ extension MemberCollectionView: UICollectionViewDataSource {
             return UICollectionViewCell()
         }
         cell.memberLabel.text = memberList[indexPath.item].userName
-        
+        if let userId = memberList[indexPath.item].userId {
+            if type == .progressReflection &&  selectedMemberIdList.contains(userId) {
+                cell.setupAttribute()
+            }
+        }
         switch type {
         case .addFeedback:
             cell.index = FromCellIndex.fromAddFeedback

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/CollectionView/MemberCollectionView/MemberCollectionViewCell.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/CollectionView/MemberCollectionView/MemberCollectionViewCell.swift
@@ -77,11 +77,9 @@ final class MemberCollectionViewCell: BaseCollectionViewCell {
     // MARK: - func
     
     func setupAttribute() {
-        if isSelected {
-            memberLabel.textColor = .gray300
-            memberLabel.backgroundColor = .white100
-            memberShadow.layer.shadowRadius = 1
-        }
+        memberLabel.textColor = .gray300
+        memberLabel.backgroundColor = .white100
+        memberShadow.layer.shadowRadius = 1
     }
     
     private func applyAttribute() {

--- a/Maddori.Apple/Maddori.Apple/Network/Model/Keyword/Keyword.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/Model/Keyword/Keyword.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 struct Keyword {
+    let id: Int
     var style: KeywordType?
     let type: FeedBackType
     let keyword: String

--- a/Maddori.Apple/Maddori.Apple/Network/Storage/UserDefaultHandler.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/Storage/UserDefaultHandler.swift
@@ -40,7 +40,13 @@ struct UserDefaultHandler {
         UserData.setValue(value, forKey: .hasSeenAlert)
     }
     
-    static func setSeenKeywordIdList(to keywordIdList: [Int]) {
-        UserData.setValue(keywordIdList, forKey: .seenKeywordList)
+    static func appendSeenKeywordIdList(keywordId: Int) {
+        var newSeenKeywordList = UserDefaultStorage.seenKeywordList
+        newSeenKeywordList.append(keywordId)
+        UserData.setValue(newSeenKeywordList, forKey: .seenKeywordList)
+    }
+    
+    static func clearSeenKeywordIdList() {
+        UserData<Any>.clear(forKey: .seenKeywordList)
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Network/Storage/UserDefaultHandler.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/Storage/UserDefaultHandler.swift
@@ -41,12 +41,12 @@ struct UserDefaultHandler {
     }
     
     static func appendSeenKeywordIdList(keywordId: Int) {
-        var newSeenKeywordList = UserDefaultStorage.seenKeywordList
+        var newSeenKeywordList = UserDefaultStorage.seenKeywordIdList
         newSeenKeywordList.append(keywordId)
-        UserData.setValue(newSeenKeywordList, forKey: .seenKeywordList)
+        UserData.setValue(newSeenKeywordList, forKey: .seenKeywordIdList)
     }
     
     static func clearSeenKeywordIdList() {
-        UserData<Any>.clear(forKey: .seenKeywordList)
+        UserData<Any>.clear(forKey: .seenKeywordIdList)
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Network/Storage/UserDefaultHandler.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/Storage/UserDefaultHandler.swift
@@ -37,7 +37,7 @@ struct UserDefaultHandler {
     }
     
     static func setHasSeenAlert(to value: Bool) {
-        UserData.setValue(value, forKey: .hasSeenAlert)
+        UserData.setValue(value, forKey: .hasSeenReflectionAlert)
     }
     
     static func appendSeenKeywordIdList(keywordId: Int) {
@@ -46,7 +46,15 @@ struct UserDefaultHandler {
         UserData.setValue(newSeenKeywordIdList, forKey: .seenKeywordIdList)
     }
     
-    static func clearSeenKeywordIdList() {
-        UserData<Any>.clear(forKey: .seenKeywordIdList)
+    static func appendSeenMemberIdList(memberIdList: [Int]) {
+        UserData.setValue(memberIdList, forKey: .seenMemberIdList)
+    }
+    
+    static func isCurrentReflectionFinished(_ value: Bool) {
+        UserData.setValue(value, forKey: .completedCurrentReflection)
+    }
+    
+    static func clearUserDefaults(of type: DataKeys) {
+        UserData<Any>.clear(forKey: type)
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Network/Storage/UserDefaultHandler.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/Storage/UserDefaultHandler.swift
@@ -41,9 +41,9 @@ struct UserDefaultHandler {
     }
     
     static func appendSeenKeywordIdList(keywordId: Int) {
-        var newSeenKeywordList = UserDefaultStorage.seenKeywordIdList
-        newSeenKeywordList.append(keywordId)
-        UserData.setValue(newSeenKeywordList, forKey: .seenKeywordIdList)
+        var newSeenKeywordIdList = UserDefaultStorage.seenKeywordIdList
+        newSeenKeywordIdList.append(keywordId)
+        UserData.setValue(newSeenKeywordIdList, forKey: .seenKeywordIdList)
     }
     
     static func clearSeenKeywordIdList() {

--- a/Maddori.Apple/Maddori.Apple/Network/Storage/UserDefaultHandler.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/Storage/UserDefaultHandler.swift
@@ -39,4 +39,8 @@ struct UserDefaultHandler {
     static func setHasSeenAlert(to value: Bool) {
         UserData.setValue(value, forKey: .hasSeenAlert)
     }
+    
+    static func setSeenKeywordIdList(to keywordIdList: [Int]) {
+        UserData.setValue(keywordIdList, forKey: .seenKeywordList)
+    }
 }

--- a/Maddori.Apple/Maddori.Apple/Network/Storage/UserDefaultStorage.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/Storage/UserDefaultStorage.swift
@@ -14,8 +14,10 @@ enum DataKeys: String, CaseIterable {
     case teamId = "teamId"
     case accessToken = "accessToken"
     case refreshToken = "refreshToken"
-    case hasSeenAlert = "hasSeenAlert"
+    case hasSeenReflectionAlert = "hasSeenReflectionAlert"
     case seenKeywordIdList = "seenKeywordIdList"
+    case seenMemberIdList = "seenMemberIdList"
+    case completedCurrentReflection = "completedCurrentReflection"
 }
 
 struct UserDefaultStorage {
@@ -44,11 +46,19 @@ struct UserDefaultStorage {
     }
     
     static var hasSeenReflectionAlert: Bool {
-        return UserData<Bool>.getValue(forKey: .hasSeenAlert) ?? false
+        return UserData<Bool>.getValue(forKey: .hasSeenReflectionAlert) ?? false
     }
     
     static var seenKeywordIdList: [Int] {
         return UserData<[Int]>.getValue(forKey: .seenKeywordIdList) ?? []
+    }
+    
+    static var seenMemberIdList: [Int] {
+        return UserData<[Int]>.getValue(forKey: .seenMemberIdList) ?? []
+    }
+    
+    static var completedCurrentReflection: Bool {
+        return UserData<Bool>.getValue(forKey: .completedCurrentReflection) ?? false
     }
 }
 

--- a/Maddori.Apple/Maddori.Apple/Network/Storage/UserDefaultStorage.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/Storage/UserDefaultStorage.swift
@@ -15,7 +15,7 @@ enum DataKeys: String, CaseIterable {
     case accessToken = "accessToken"
     case refreshToken = "refreshToken"
     case hasSeenAlert = "hasSeenAlert"
-    case seenKeywordList = "seenKeywordList"
+    case seenKeywordIdList = "seenKeywordIdList"
 }
 
 struct UserDefaultStorage {
@@ -47,8 +47,8 @@ struct UserDefaultStorage {
         return UserData<Bool>.getValue(forKey: .hasSeenAlert) ?? false
     }
     
-    static var seenKeywordList: [Int] {
-        return UserData<[Int]>.getValue(forKey: .seenKeywordList) ?? []
+    static var seenKeywordIdList: [Int] {
+        return UserData<[Int]>.getValue(forKey: .seenKeywordIdList) ?? []
     }
 }
 

--- a/Maddori.Apple/Maddori.Apple/Network/Storage/UserDefaultStorage.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/Storage/UserDefaultStorage.swift
@@ -15,6 +15,7 @@ enum DataKeys: String, CaseIterable {
     case accessToken = "accessToken"
     case refreshToken = "refreshToken"
     case hasSeenAlert = "hasSeenAlert"
+    case seenKeywordList = "seenKeywordList"
 }
 
 struct UserDefaultStorage {
@@ -44,6 +45,10 @@ struct UserDefaultStorage {
     
     static var hasSeenReflectionAlert: Bool {
         return UserData<Bool>.getValue(forKey: .hasSeenAlert) ?? false
+    }
+    
+    static var seenKeywordList: [Int] {
+        return UserData<[Int]>.getValue(forKey: .seenKeywordList) ?? []
     }
 }
 

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/Home/HomeViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/Home/HomeViewController.swift
@@ -137,7 +137,7 @@ final class HomeViewController: BaseViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        if reflectionStatus == .Progressing &&  !hasSeenReflectionAlert {
+        if reflectionStatus == .Progressing && !hasSeenReflectionAlert {
             showStartReflectionView()
         }
         fetchCertainTeamDetail(type: .fetchCertainTeamDetail)

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/Home/HomeViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/Home/HomeViewController.swift
@@ -137,7 +137,9 @@ final class HomeViewController: BaseViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
+        if reflectionStatus == .Progressing &&  !hasSeenReflectionAlert {
+            showStartReflectionView()
+        }
         fetchCertainTeamDetail(type: .fetchCertainTeamDetail)
         fetchCurrentReflectionDetail(type: .fetchCurrentReflectionDetail)
     }
@@ -303,6 +305,9 @@ final class HomeViewController: BaseViewController {
         viewController.modalPresentationStyle = .overFullScreen
         present(viewController, animated: true)
         hasSeenReflectionAlert = true
+        UserDefaultHandler.clearUserDefaults(of: .seenKeywordIdList)
+        UserDefaultHandler.clearUserDefaults(of: .seenMemberIdList)
+        UserDefaultHandler.clearUserDefaults(of: .completedCurrentReflection)
     }
     
     private func showJoinReflectionButton() {
@@ -474,9 +479,11 @@ extension HomeViewController: UICollectionViewDataSource {
             } else {
                 didTapAddFeedbackButton()
             }
-            
         case .Progressing:
-            showStartReflectionView()
+            guard let navigationController = self.navigationController else { return }
+            let viewController = UINavigationController(rootViewController: SelectReflectionMemberViewController(reflectionId: currentReflectionId, isAdmin: isAdmin))
+            viewController.modalPresentationStyle = .fullScreen
+            navigationController.present(viewController, animated: true)
         }
         
     }

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/InProgress/InProgressViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/InProgress/InProgressViewController.swift
@@ -143,14 +143,14 @@ final class InProgressViewController: BaseViewController {
     private func setUpKeywordType() {
         if isUserRetrospective {
             for i in 0..<teamKeywordData.count {
-                teamKeywordData[i].style = UserDefaultStorage.seenKeywordList.contains(teamKeywordData[i].id) ? .disabledKeyword : .defaultKeyword
+                teamKeywordData[i].style = UserDefaultStorage.seenKeywordIdList.contains(teamKeywordData[i].id) ? .disabledKeyword : .defaultKeyword
             }
         } else {
             for i in 0..<userKeywordData.count {
-                userKeywordData[i].style = UserDefaultStorage.seenKeywordList.contains(userKeywordData[i].id) ? .disabledKeyword : .defaultKeyword
+                userKeywordData[i].style = UserDefaultStorage.seenKeywordIdList.contains(userKeywordData[i].id) ? .disabledKeyword : .defaultKeyword
             }
             for j in 0..<teamKeywordData.count {
-                teamKeywordData[j].style = UserDefaultStorage.seenKeywordList.contains(teamKeywordData[j].id) ? .disabledKeyword : .subKeyword
+                teamKeywordData[j].style = UserDefaultStorage.seenKeywordIdList.contains(teamKeywordData[j].id) ? .disabledKeyword : .subKeyword
             }
         }
     }

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/InProgress/InProgressViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/InProgress/InProgressViewController.swift
@@ -100,7 +100,6 @@ final class InProgressViewController: BaseViewController {
             )
         )
         setUpDelegation()
-        setUpKeywordType()
     }
     
     override func render() {
@@ -144,14 +143,14 @@ final class InProgressViewController: BaseViewController {
     private func setUpKeywordType() {
         if isUserRetrospective {
             for i in 0..<teamKeywordData.count {
-                teamKeywordData[i].style = .defaultKeyword
+                teamKeywordData[i].style = UserDefaultStorage.seenKeywordList.contains(teamKeywordData[i].id) ? .disabledKeyword : .defaultKeyword
             }
         } else {
             for i in 0..<userKeywordData.count {
-                userKeywordData[i].style = .defaultKeyword
+                userKeywordData[i].style = UserDefaultStorage.seenKeywordList.contains(userKeywordData[i].id) ? .disabledKeyword : .defaultKeyword
             }
             for j in 0..<teamKeywordData.count {
-                teamKeywordData[j].style = .subKeyword
+                teamKeywordData[j].style = UserDefaultStorage.seenKeywordList.contains(teamKeywordData[j].id) ? .disabledKeyword : .subKeyword
             }
         }
     }
@@ -162,6 +161,7 @@ final class InProgressViewController: BaseViewController {
         var keywordList: [Keyword] = []
         for feedback in response {
             let keyword = Keyword(
+                id: feedback.id ?? 0,
                 type: feedback.type ?? .continueType,
                 keyword: feedback.keyword ?? "키워드",
                 content: feedback.content ?? "",
@@ -194,6 +194,7 @@ final class InProgressViewController: BaseViewController {
                 self.userKeywordData = self.convert(userFeedbackList)
                 self.teamKeywordData = self.convert(teamFeedbackList)
                 
+                self.setUpKeywordType()
                 if self.isUserRetrospective {
                     self.keywordsSectionList[0] = self.teamKeywordData
                 } else {
@@ -219,6 +220,7 @@ extension InProgressViewController: UICollectionViewDelegate {
             keyword: keyword.keyword,
             info: keyword.content, start: startContent
         )
+        UserDefaultHandler.appendSeenKeywordIdList(keywordId: keyword.id)
         DispatchQueue.main.async {
             cell.setupAttribute(to: .disabledKeyword)
             self.presentDetailView(feedbackInfo: feedbackInfo)
@@ -295,11 +297,9 @@ extension InProgressViewController: UICollectionViewDataSource {
             emptyCell.emptyFeedbackLabel.text = TextLiteral.emptyViewInProgressMyRetrospective
             return emptyCell
         }
-        
         let keyword = keywordsSectionList[section][item]
         cell.keywordLabel.text = keyword.keyword
-        cell.configLabel(type: keyword.style ?? .defaultKeyword)
-        cell.configShadow(type: keyword.style ?? .defaultKeyword)
+        cell.setupAttribute(to: keyword.style ?? .defaultKeyword)
         return cell
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/SelectReflectionMember/SelectReflectionMemberViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/SelectReflectionMember/SelectReflectionMemberViewController.swift
@@ -64,6 +64,7 @@ final class SelectReflectionMemberViewController: BaseViewController {
             } else {
                 self?.dismiss(animated: true)
             }
+            UserDefaultHandler.clearSeenKeywordIdList()
         }
         button.addAction(action, for: .touchUpInside)
         button.isDisabled = true

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/SelectReflectionMember/SelectReflectionMemberViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/SelectReflectionMember/SelectReflectionMemberViewController.swift
@@ -18,7 +18,6 @@ final class SelectReflectionMemberViewController: BaseViewController {
     init(reflectionId: Int, isAdmin: Bool) {
         self.reflectionId = reflectionId
         self.isAdmin = isAdmin
-        print("reflectionId: \(reflectionId)")
         super.init()
     }
     
@@ -57,14 +56,13 @@ final class SelectReflectionMemberViewController: BaseViewController {
         let button = MainButton()
         let action = UIAction { [weak self] _ in
             guard let reflectionId = self?.reflectionId else { return }
-            UserDefaultHandler.setHasSeenAlert(to: false)
             guard let isAdmin = self?.isAdmin else { return }
             if isAdmin {
                 self?.patchEndReflection(type: .patchEndReflection(reflectionId: reflectionId))
             } else {
                 self?.dismiss(animated: true)
             }
-            UserDefaultHandler.clearSeenKeywordIdList()
+            self?.resetHasSeenAlert()
         }
         button.addAction(action, for: .touchUpInside)
         button.isDisabled = true
@@ -77,6 +75,12 @@ final class SelectReflectionMemberViewController: BaseViewController {
         super.viewDidLoad()
         didTappedMember()
         fetchTeamMembers(type: .fetchTeamMembers)
+        setupPreviousStatus()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        setupPreviousStatus()
     }
     
     override func render() {
@@ -111,9 +115,21 @@ final class SelectReflectionMemberViewController: BaseViewController {
         navigationItem.rightBarButtonItem = rightButton
     }
     
+    private func setupPreviousStatus() {
+        feedbackDoneButton.title = TextLiteral.selectReflectionMemberViewControllerDoneButtonText + "(\(UserDefaultStorage.seenMemberIdList.count)/\(memberCollectionView.memberList.count))"
+        if UserDefaultStorage.completedCurrentReflection {
+            feedbackDoneButton.isDisabled = false
+        }
+    }
+    
+    private func resetHasSeenAlert() {
+        UserDefaultHandler.setHasSeenAlert(to: false)
+    }
+    
     private func didTappedMember() {
         memberCollectionView.didTappedMember = { [weak self] member in
-            self?.feedbackDoneButton.title = TextLiteral.selectReflectionMemberViewControllerDoneButtonText + "(\(member.count)/\(self?.memberCollectionView.memberList.count ?? 0))"
+            guard let memberCollectionView = self?.memberCollectionView else { return }
+            self?.feedbackDoneButton.title = TextLiteral.selectReflectionMemberViewControllerDoneButtonText + "(\( memberCollectionView.selectedMemberIdList.count)/\(memberCollectionView.memberList.count))"
             if member.count == self?.memberCollectionView.memberList.count {
                 self?.feedbackDoneButton.isDisabled = false
             }
@@ -131,7 +147,7 @@ final class SelectReflectionMemberViewController: BaseViewController {
                 guard let fetchedMemberList = json.detail?.members else { return }
                 DispatchQueue.main.async {
                     self.memberCollectionView.memberList = fetchedMemberList
-                    self.feedbackDoneButton.title = TextLiteral.selectReflectionMemberViewControllerDoneButtonText + "(0/\(self.memberCollectionView.memberList.count))"
+                    self.feedbackDoneButton.title = TextLiteral.selectReflectionMemberViewControllerDoneButtonText + "(\(self.memberCollectionView.selectedMemberIdList.count)/\(self.memberCollectionView.memberList.count))"
                 }
             }
         }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
백로그의 <눌렀던 피드백 상태를 저장해서 다른 뷰에 다녀와도 그 상태가 유지되도록 구현하기> 에 대한 PR 입니다!

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 눌렀던 피드백인지 아닌지 UserDefaults에 저장 -> `seenKeywordList`
- InProgress 에서 키워드 불러올 때 UserDefaults에 저장한 값으로 키워드 스타일 변경
- "모든 회고 끝내기" 버튼 누르면 UserDefaults에 저장한 값 삭제 -> `clearSeenKeywordIdList`

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
현재 진행중인 회고에 들어가서 아직 확인하지 않은 키워드를 누르고 앱을 껐다 키든 회고에서 나갔다 들어오든 해보세요!

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->

<누른 피드백 상태 저장되는 영상>

https://user-images.githubusercontent.com/72431640/211263312-e728955e-d259-4a2f-be01-9c7e9ebb7eec.mp4

<모든 회고 끝내기 누르면 reset 되는 영상>

https://user-images.githubusercontent.com/72431640/211263496-ec6cf1f3-4385-42ca-898e-912c2103e756.mp4



## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

키워드를 누른 상태를 어디에 어떻게 저장할까 하다가 UserDefaults가 적당하다고 생각했습니다..!!
더 좋은 방법이 있다면 알려주세요 ><

그리고 확인한 키워드 id 를 list가 아닌 set으로 할까 했는데 (왜냐하면 중복 확인하는 과정이 없어질 것 같아서..!)
좀 익숙하지 않은 set을 사용하려니 오류가 자꾸 생기더라구요🤔
set으로 하길 원하신다면 바꿔보겠습니다!
(뭐가 더 좋은 방법인지는 잘 모르겠네욥)

자세한 코드 진행되는건 코드리뷰로 따로 남겨둘게용

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #261


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
