### PR TITLE
[CHORE] 개발용 서버로 변경

### DIFF
--- a/Maddori.Apple/Maddori.Apple/Global/Literal/UrlLiteral.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Literal/UrlLiteral.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 enum UrlLiteral {
-    static let baseUrl = "http://15.165.21.115:3000/api/v1"
+    static let baseUrl = "http://15.165.21.115:3001/api/v1"
 }


### PR DESCRIPTION
## 🌁 Background
개발과 배포를 용이하게 하기 위해 개발용 서버와 배포용 서버를 메리가 분리해주었습니다.
이를 반영한 피알입니다.

## 👩‍💻 Contents
- 개발용 서버 주소로 변경 (3000 -> 3001)

## ✅ Testing
없습니다. 코드만 확인하시면 돼요!


## 📣 Related Issue
- close #286 