### PR TITLE
[ADD] 건너뛰기 용 homeVC 편집

### DIFF
--- a/Maddori.Apple/Maddori.Apple/Global/Literal/TextLiteral.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Literal/TextLiteral.swift
@@ -192,6 +192,8 @@ enum TextLiteral {
     static let reflectionTitleLabelProgressing: String = "회고가 시작되었습니다!"
     static let reflectionDescriptionLabelSettingRequired: String = "회고 일정을 정해주세요"
     static let reflectionDescriptionLabelProgressing: String = "터치하여 회고에 참여해주세요"
+    static let previewTitleLabel: String = "회고 일정을 추가할 수 없습니다"
+    static let previewDescriptionLabel: String = "팀을 생성하거나 팀에 합류해주세요"
     
     // MARK: - MyReflectionViewController
     

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/Home/HomeViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/Home/HomeViewController.swift
@@ -272,7 +272,7 @@ final class HomeViewController: BaseViewController {
                 else { return }
                 self.isAdmin = isAdmin
                 DispatchQueue.main.async {
-                    self.teamButton.setTitle(teamName, for: .normal)
+                    self.teamButton.setTitle(teamName + " ", for: .normal)
                 }
             } else {
                 DispatchQueue.main.async {

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/Home/HomeViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/Home/HomeViewController.swift
@@ -364,7 +364,6 @@ extension HomeViewController: UICollectionViewDataSource {
             viewController.modalPresentationStyle = .fullScreen
             navigationController.present(viewController, animated: true)
         }
-        
     }
 }
 

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/Home/HomeViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/Home/HomeViewController.swift
@@ -274,6 +274,11 @@ final class HomeViewController: BaseViewController {
                 DispatchQueue.main.async {
                     self.teamButton.setTitle(teamName, for: .normal)
                 }
+            } else {
+                DispatchQueue.main.async {
+                    self.teamButton.setTitle("팀 없음", for: .normal)
+                    self.teamButton.tintColor = .gray500
+                }
             }
         }
     }
@@ -293,7 +298,7 @@ final class HomeViewController: BaseViewController {
                 
                 self.reflectionStatus = reflectionStatus
                 self.currentReflectionId = reflectionId
-                self.joinReflectionButton.setupAttribute(reflectionStatus: reflectionStatus, title: reflectionTitle, date: reflectionDate)
+                self.joinReflectionButton.setupAttribute(reflectionStatus: reflectionStatus, title: reflectionTitle, date: reflectionDate, isPreview: false)
                 
                 self.setupJoinReflectionButtonAction(status: reflectionStatus)
                 self.setupJoinReflectionButtonBackground(status: reflectionStatus)
@@ -316,6 +321,11 @@ final class HomeViewController: BaseViewController {
                         self.flowLayout.count = reflectionKeywordList.count
                         self.keywordCollectionView.reloadData()
                     }
+                }
+            } else {
+                DispatchQueue.main.async {
+                    self.joinReflectionButton.setupAttribute(reflectionStatus: .Before, title: "", date: "", isPreview: true)
+                    self.setupJoinReflectionButtonBackground(status: .Before)
                 }
             }
         }
@@ -364,4 +374,3 @@ extension HomeViewController: UICollectionViewDelegateFlowLayout {
         return KeywordCollectionViewCell.fittingSize(availableHeight: size, keyword: keywordList[indexPath.item])
     }
 }
-

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/Home/UIComponent/JoinReflectionButton.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/Home/UIComponent/JoinReflectionButton.swift
@@ -103,26 +103,34 @@ final class JoinReflectionButton: UIView {
         joinButton.addAction(action, for: .touchUpInside)
     }
     
-    func setupAttribute(reflectionStatus: ReflectionStatus, title: String, date: String) {
-        switch reflectionStatus {
-        case .SettingRequired, .Done:
-            reflectionTitleLabel.text = TextLiteral.reflectionTitleLabelSettingRequired
+    func setupAttribute(reflectionStatus: ReflectionStatus, title: String, date: String, isPreview: Bool) {
+        if !isPreview {
+            switch reflectionStatus {
+            case .SettingRequired, .Done:
+                reflectionTitleLabel.text = TextLiteral.reflectionTitleLabelSettingRequired
+                reflectionTitleLabel.textColor = .gray600
+                reflectionDescriptionLabel.text = TextLiteral.reflectionDescriptionLabelSettingRequired
+                reflectionDescriptionLabel.textColor = .gray500
+                calendarImageView.image = ImageLiterals.imgEmptyCalendar
+            case .Before:
+                reflectionTitleLabel.text = title
+                reflectionTitleLabel.textColor = .gray600
+                reflectionDescriptionLabel.text = date.formatDateString(to: "M월 d일 (EEE) HH:mm")
+                reflectionDescriptionLabel.textColor = .gray500
+                calendarImageView.image = ImageLiterals.imgCalendar
+            case .Progressing:
+                reflectionTitleLabel.text = TextLiteral.reflectionTitleLabelProgressing
+                reflectionTitleLabel.textColor = .white100
+                reflectionDescriptionLabel.text = TextLiteral.reflectionDescriptionLabelProgressing
+                reflectionDescriptionLabel.textColor = .white100
+                calendarImageView.image = ImageLiterals.imgYellowCalendar
+            }
+        } else {
+            reflectionTitleLabel.text = TextLiteral.previewTitleLabel
             reflectionTitleLabel.textColor = .gray600
-            reflectionDescriptionLabel.text = TextLiteral.reflectionDescriptionLabelSettingRequired
+            reflectionDescriptionLabel.text = TextLiteral.previewDescriptionLabel
             reflectionDescriptionLabel.textColor = .gray500
             calendarImageView.image = ImageLiterals.imgEmptyCalendar
-        case .Before:
-            reflectionTitleLabel.text = title
-            reflectionTitleLabel.textColor = .gray600
-            reflectionDescriptionLabel.text = date.formatDateString(to: "M월 d일 (EEE) HH:mm")
-            reflectionDescriptionLabel.textColor = .gray500
-            calendarImageView.image = ImageLiterals.imgCalendar
-        case .Progressing:
-            reflectionTitleLabel.text = TextLiteral.reflectionTitleLabelProgressing
-            reflectionTitleLabel.textColor = .white100
-            reflectionDescriptionLabel.text = TextLiteral.reflectionDescriptionLabelProgressing
-            reflectionDescriptionLabel.textColor = .white100
-            calendarImageView.image = ImageLiterals.imgYellowCalendar
         }
     }
 }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
팀을 필수로 합류할 필요 없이 건너뛰기 하는 경우, homeview의 UI를 구성하는 PR 입니다

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- teamButton '팀 없음' 으로 설정
- joinReflectionButton 비활성화

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
팀이 없는 상태에 SceneDelegate에서 바로 homeVC로 넘어가도록 설정해주세용

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<img src="https://user-images.githubusercontent.com/72431640/215691164-d60dc431-d6ae-4fea-8235-12e4c195a42f.png" width="300">


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
slack에도 올렸듯 constraint 가 깨지는 부분이 있습니다..! 요 부분 addFeedback의 preview 담당하시는 분이 해주시면 감사하겠습니다 ^__^
자세한 사항은 slack 매크로 참조..

reflectionStatus enum에 preview를 추가하면 좋은데..! 그러면 api 도 다 변경해야 하기 때문에 그냥 리뷰에 남긴 것처럼 isPreview라는 입력값을 하나 더 줬습니다..!
더 괜찮은 방법 있다면 알려주세요 ><

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #297 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
