### PR TITLE
[ADD] JoinTeam - 건너뛰기 버튼 추가

### DIFF
--- a/Maddori.Apple/Maddori.Apple/Global/Literal/TextLiteral.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Literal/TextLiteral.swift
@@ -101,6 +101,7 @@ enum TextLiteral {
     static let joinTeamViewControllerSubButtonText = "팀 생성하기"
     static let joinTeamViewControllerAlertTitle = "잘못된 초대코드"
     static let joinTeamViewControllerAlertMessage = "초대코드를 다시 입력해주세요."
+    static let joinTeamViewControllerSkipButtonText = "건너뛰기"
     
     // MARK: - StartReflectionViewController
     

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/JoinTeam/JoinTeamViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/JoinTeam/JoinTeamViewController.swift
@@ -62,6 +62,14 @@ final class JoinTeamViewController: BaseTextFieldViewController {
         button.addAction(action, for: .touchUpInside)
         return button
     }()
+    private let skipButton: UIButton = {
+        let button = UIButton()
+        button.setTitle(TextLiteral.joinTeamViewControllerSkipButtonText, for: .normal)
+        button.setTitleColor(.gray500, for: .normal)
+        button.titleLabel?.font = .toast
+        button.frame = CGRect(x: 0, y: 0, width: 49, height: 44)
+        return button
+    }()
     private lazy var createView: LabelButtonView = {
         let view = LabelButtonView()
         view.subText = TextLiteral.joinTeamViewControllerSubText
@@ -78,6 +86,7 @@ final class JoinTeamViewController: BaseTextFieldViewController {
         super.viewDidLoad()
         setupDoneButton()
         setupKeyboard()
+        setupSkipButton()
     }
     
     override func render() {
@@ -96,9 +105,12 @@ final class JoinTeamViewController: BaseTextFieldViewController {
         
         let button = removeBarButtonItemOffset(with: backButton, offsetX: 10)
         let backButton = makeBarButtonItem(with: button)
+        let skipButton = makeBarButtonItem(with: skipButton)
+        
         navigationController?.navigationBar.prefersLargeTitles = false
         navigationItem.largeTitleDisplayMode = .never
         navigationItem.leftBarButtonItem = backButton
+        navigationItem.rightBarButtonItem = skipButton
     }
     
     // MARK: - setup
@@ -116,6 +128,13 @@ final class JoinTeamViewController: BaseTextFieldViewController {
         super.kigoTextField.autocapitalizationType = .allCharacters
     }
     
+    private func setupSkipButton() {
+        let action = UIAction { [weak self] _ in
+            self?.pushHomeViewController()
+        }
+        skipButton.addAction(action, for: .touchUpInside)
+    }
+    
     // MARK: - func
     
     private func presentCreateTeamViewController() {
@@ -128,6 +147,11 @@ final class JoinTeamViewController: BaseTextFieldViewController {
     private func pushSetNicknameViewController() {
         let viewController = SetNicknameViewController()
         navigationController?.pushViewController(viewController, animated: true)
+    }
+    
+    private func pushHomeViewController() {
+        let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate
+        sceneDelegate?.changeRootViewCustomTabBarView()
     }
     
     // MARK: - api


### PR DESCRIPTION
## 🌁 Background
간단한 피알입니다 ㅎㅎ
팀 합류, 프로필 설정 없이도 앱을 둘러볼 수 있도록 JoinTeam에 건너뛰기 버튼을 추가했습니당


## 📱 Screenshot
<img src="https://user-images.githubusercontent.com/81340603/217987626-62ee886f-c3c9-49f9-8d5f-413e28d1d881.png" width=200px />


## 👩‍💻 Contents
간단하게 '건너뛰기' 버튼을 nav bar에 추가하고
button에 HomeVC로 넘어가는 액션을 추가했습니다! 룰루


## ✅ Testing
feature/309-finish-setup 으로 넘어가셔서 팀합류 되어 있는 경우 > 탈퇴 부탁드리고 팀합류가 안 되어 있다면 애플로그인 후 JoinTeam에서 확인!


## 📣 Related Issue
- close #309 
