### PR TITLE
[CHORE] loading indicator 추가

### DIFF
--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/Button/MainButton.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/Button/MainButton.swift
@@ -27,7 +27,7 @@ final class MainButton: UIButton {
         didSet { setupAttribute() }
     }
     
-    lazy private var spinner = UIActivityIndicatorView()
+    private lazy var spinner = UIActivityIndicatorView()
     
     // MARK: - life cycle
     

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/Button/MainButton.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/Button/MainButton.swift
@@ -17,8 +17,6 @@ final class MainButton: UIButton {
     
     var isLoading: Bool = false {
         didSet { updateLoadingView() }
-        // 다른거 네이밍이 setup으로 시작되는데
-        // didSet 다음에 오는거라면 update가 맞지 않을까?
     }
     
     var title: String? {
@@ -79,7 +77,7 @@ final class MainButton: UIButton {
         spinner.style = .medium
     }
     
-    func updateLoadingView() {
+    private func updateLoadingView() {
         if isLoading {
             spinner.startAnimating()
             titleLabel?.alpha = 0

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/Button/MainButton.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/Button/MainButton.swift
@@ -15,6 +15,12 @@ final class MainButton: UIButton {
         static let height: CGFloat = 54
     }
     
+    var isLoading: Bool = false {
+        didSet { updateLoadingView() }
+        // 다른거 네이밍이 setup으로 시작되는데
+        // didSet 다음에 오는거라면 update가 맞지 않을까?
+    }
+    
     var title: String? {
         didSet { setupAttribute() }
     }
@@ -22,6 +28,8 @@ final class MainButton: UIButton {
     var isDisabled: Bool = false {
         didSet { setupAttribute() }
     }
+    
+    private var spinner = UIActivityIndicatorView()
     
     // MARK: - life cycle
     
@@ -41,12 +49,18 @@ final class MainButton: UIButton {
         setTitleColor(.white, for: .disabled)
         setBackgroundColor(.blue200, for: .normal)
         setBackgroundColor(.gray200, for: .disabled)
+        configLoadingIndicator()
     }
     
     private func render() {
         self.snp.makeConstraints {
             $0.width.equalTo(Size.width)
             $0.height.equalTo(Size.height)
+        }
+        
+        self.addSubview(spinner)
+        spinner.snp.makeConstraints {
+            $0.center.equalTo(self.snp.center)
         }
     }
     
@@ -56,7 +70,24 @@ final class MainButton: UIButton {
         if let title = title {
             setTitle(title, for: .normal)
         }
-        
         isEnabled = !isDisabled
+    }
+    
+    private func configLoadingIndicator() {
+        spinner.hidesWhenStopped = true
+        spinner.color = .gray600
+        spinner.style = .medium
+    }
+    
+    func updateLoadingView() {
+        if isLoading {
+            spinner.startAnimating()
+            titleLabel?.alpha = 0
+            isEnabled = false
+        } else {
+            spinner.stopAnimating()
+            titleLabel?.alpha = 1
+            isEnabled = true
+        }
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/Button/MainButton.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/Button/MainButton.swift
@@ -27,7 +27,7 @@ final class MainButton: UIButton {
         didSet { setupAttribute() }
     }
     
-    private var spinner = UIActivityIndicatorView()
+    lazy private var spinner = UIActivityIndicatorView()
     
     // MARK: - life cycle
     

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/CreateTeam/CreateTeamViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/CreateTeam/CreateTeamViewController.swift
@@ -96,6 +96,7 @@ final class CreateTeamViewController: BaseTextFieldViewController {
                         self?.makeAlert(title: TextLiteral.createTeamViewControllerAlertTitle, message: TextLiteral.createTeamViewControllerAlertMessage)
                     }
                 } else {
+                    self?.doneButton.isLoading = true
                     UserDefaultHandler.setTeamName(teamName: teamName)
                     self?.pushSetNicknameViewController()
                 }

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/CreateTeam/CreateTeamViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/CreateTeam/CreateTeamViewController.swift
@@ -94,9 +94,9 @@ final class CreateTeamViewController: BaseTextFieldViewController {
                 if teamName.hasSpecialCharacters() {
                     DispatchQueue.main.async {
                         self?.makeAlert(title: TextLiteral.createTeamViewControllerAlertTitle, message: TextLiteral.createTeamViewControllerAlertMessage)
+                        self?.doneButton.isLoading = false
                     }
                 } else {
-                    self?.doneButton.isLoading = true
                     UserDefaultHandler.setTeamName(teamName: teamName)
                     self?.pushSetNicknameViewController()
                 }

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/CreateTeam/CreateTeamViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/CreateTeam/CreateTeamViewController.swift
@@ -70,6 +70,11 @@ final class CreateTeamViewController: BaseTextFieldViewController {
         setupDoneButton()
     }
     
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        doneButton.isLoading = false
+    }
+    
     override func setupNavigationBar() {
         super.setupNavigationBar()
         
@@ -84,6 +89,7 @@ final class CreateTeamViewController: BaseTextFieldViewController {
     
     private func setupDoneButton() {
         let action = UIAction { [weak self] _ in
+            self?.doneButton.isLoading = true
             if let teamName = self?.kigoTextField.text {
                 if teamName.hasSpecialCharacters() {
                     DispatchQueue.main.async {

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/JoinTeam/JoinTeamViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/JoinTeam/JoinTeamViewController.swift
@@ -178,6 +178,7 @@ final class JoinTeamViewController: BaseTextFieldViewController {
             } else {
                 DispatchQueue.main.async {
                     self.makeAlert(title: TextLiteral.joinTeamViewControllerAlertTitle, message: TextLiteral.joinTeamViewControllerAlertMessage)
+                    self.doneButton.isLoading = false
                 }
             }
         }

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/JoinTeam/JoinTeamViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/JoinTeam/JoinTeamViewController.swift
@@ -89,6 +89,11 @@ final class JoinTeamViewController: BaseTextFieldViewController {
         setupSkipButton()
     }
     
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        doneButton.isLoading = false
+    }
+    
     override func render() {
         super.render()
         
@@ -118,6 +123,7 @@ final class JoinTeamViewController: BaseTextFieldViewController {
     private func setupDoneButton() {
         let action = UIAction { [weak self] _ in
             guard let invitationCode = self?.kigoTextField.text else { return }
+            self?.doneButton.isLoading = true
             self?.fetchCertainTeam(type: .fetchCertainTeam(invitationCode: invitationCode))
         }
         super.doneButton.addAction(action, for: .touchUpInside)

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/SetNickname/SetNicknameViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/SetNickname/SetNicknameViewController.swift
@@ -354,6 +354,7 @@ final class SetNicknameViewController: BaseViewController {
             } else {
                 DispatchQueue.main.async {
                     self.makeAlert(title: TextLiteral.setNicknameViewControllerCreateTeamAlertTitle, message: TextLiteral.setNicknameViewControllerAlertMessage)
+                    self.doneButton.isLoading = false
                 }
             }
         }
@@ -379,6 +380,7 @@ final class SetNicknameViewController: BaseViewController {
             } else {
                 DispatchQueue.main.async {
                     self.makeAlert(title: TextLiteral.setNicknameViewControllerJoinTeamAlertTitle, message: TextLiteral.setNicknameViewControllerAlertMessage)
+                    self.doneButton.isLoading = false
                 }
             }
         }

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/SetNickname/SetNicknameViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/SetNickname/SetNicknameViewController.swift
@@ -114,6 +114,11 @@ final class SetNicknameViewController: BaseViewController {
         setupNotificationCenter()
     }
     
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        doneButton.isLoading = false
+    }
+    
     override func render() {
         view.addSubview(titleLabel)
         titleLabel.snp.makeConstraints {

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/SetNickname/SetNicknameViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/SetNickname/SetNicknameViewController.swift
@@ -100,6 +100,7 @@ final class SetNicknameViewController: BaseViewController {
         button.isDisabled = true
         let action = UIAction { [weak self] _ in
             self?.didTappedDoneButton()
+            button.isLoading = true
         }
         button.addAction(action, for: .touchUpInside)
         return button


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
현재 <회원가입>, <팀 생성>, <팀 유효한지 확인> 요 페이지들이 로딩이 꽤 오래 걸리는 것으로 알고 있습니다
그래서 로딩하는 중임을 표기하기 위해 loading indicator 을 추가해뒀습니다

지난번 회의에서 말한 것 처럼 옳은(?) 방법으로 추가해둔 것인지 잘 모르겠어서
같이 한 번 생각해보면 좋을 것 같아요 ~~

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->

<팀 참여 후 프로필 생성까지>

https://user-images.githubusercontent.com/72431640/227869184-ccc47500-ccdb-45be-bd47-3c0cc0f27a1a.mp4


<팀 생성 후 프로필 생성까지>

https://user-images.githubusercontent.com/72431640/227869541-bb53842a-b79b-409a-a74f-30c7b49fa702.mp4


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 팀 참여 페이지 loading indicator 추가
- 팀 생성 페이지 loading indicator 추가
- 프로필 페이지 loading indicator 추가

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
제 브랜치에서 탈퇴한 뒤 프로필 생성 해보세요!

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
아마 UserDefaults 문제일 것 같긴 한데, 팀 생성하여 팀 참여 시 '팀 없음'이 나오게 됩니다,,,
요 버그는 어차피 제 담당이라 제가 해결해볼게요!

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #323


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
