### PR TITLE
[ADD] 프로필 수정 화면 구현

### DIFF
--- a/Maddori.Apple/Maddori.Apple/Global/Literal/TextLiteral.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/Literal/TextLiteral.swift
@@ -70,6 +70,7 @@ enum TextLiteral {
     static let setNicknameViewControllerPermissionAlertTitle = "사진 접근 권한"
     static let setNicknameViewControllerPermissionAlertMessage = "사진 추가를 원하시면 '확인'을 눌러 사진 접근을 허용해 주세요."
     static let setNicknameViewControllerCameraAlertTitle = "촬영된 이미지를 불러올 수 없습니다."
+    static let setNicknameViewControllerEditProfileAlertTitle = "프로필 수정 실패"
     
     // MARK: - HomeViewController
     

--- a/Maddori.Apple/Maddori.Apple/Network/EndPoint/TeamDetailEndPoint.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/EndPoint/TeamDetailEndPoint.swift
@@ -12,6 +12,7 @@ enum TeamDetailEndPoint<T: Encodable>: EndPointable {
     case fetchTeamInformation
     case deleteTeam
     case fetchUserTeamList
+    case putEditProfile
     
     var address: String {
         switch self {
@@ -26,6 +27,9 @@ enum TeamDetailEndPoint<T: Encodable>: EndPointable {
             
         case .fetchUserTeamList:
             return "\(UrlLiteral.baseUrl2)/users/teams"
+            
+        case .putEditProfile:
+            return "\(UrlLiteral.baseUrl2)/users/teams/\(UserDefaultStorage.teamId)/profile"
         }
     }
     
@@ -42,6 +46,9 @@ enum TeamDetailEndPoint<T: Encodable>: EndPointable {
             
         case .fetchUserTeamList:
             return .get
+            
+        case .putEditProfile:
+            return .put
         }
     }
     
@@ -57,6 +64,9 @@ enum TeamDetailEndPoint<T: Encodable>: EndPointable {
             return nil
             
         case .fetchUserTeamList:
+            return nil
+            
+        case .putEditProfile:
             return nil
         }
     }
@@ -88,6 +98,14 @@ enum TeamDetailEndPoint<T: Encodable>: EndPointable {
             let headers = [
                 "access_token": "\(UserDefaultStorage.accessToken)",
                 "refresh_token": "\(UserDefaultStorage.refreshToken)"
+            ]
+            return HTTPHeaders(headers)
+            
+        case .putEditProfile:
+            let headers = [
+                "access_token": "\(UserDefaultStorage.accessToken)",
+                "refresh_token": "\(UserDefaultStorage.refreshToken)",
+                "Content-Type": "multipart/form-data"
             ]
             return HTTPHeaders(headers)
         }

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/TeamDetail/TeamDetailViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/TeamDetail/TeamDetailViewController.swift
@@ -72,6 +72,7 @@ final class TeamDetailViewController: BaseViewController {
         setupEditButton()
         setupExitButton()
         setupCodeShareButton()
+        setupMyProfileButton()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -209,6 +210,16 @@ final class TeamDetailViewController: BaseViewController {
     private func updateLayout() {
         memberTableView.snp.updateConstraints {
             $0.height.equalTo(calculateHeight())
+        }
+    }
+    
+    private func setupMyProfileButton() {
+        memberTableView.didTappedMyProfile = { [weak self] userName, role, profilePath in
+            let viewController = SetNicknameViewController(from: .teamDetail)
+            viewController.userName = userName
+            viewController.role = role
+            viewController.profilePath = profilePath
+            self?.navigationController?.pushViewController(viewController, animated: true)
         }
     }
     

--- a/Maddori.Apple/Maddori.Apple/Screen/Home/TeamDetail/UIComponent/TeamDetailMembersView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/TeamDetail/UIComponent/TeamDetailMembersView.swift
@@ -14,6 +14,7 @@ final class TeamDetailMembersView: UIView {
     // FIXME: - API연결 후 수정
     var members: [MemberDetailResponse] = []
     var currentMember: MemberDetailResponse?
+    var didTappedMyProfile: ((String, String, String) -> ())?
     
     enum PropertySize {
         static let headerViewHeight: CGFloat = 70
@@ -102,10 +103,16 @@ extension TeamDetailMembersView: UITableViewDataSource {
         headerView.setupMemberInfoView(nickname: currentMember?.userName ?? UserDefaultStorage.nickname,
                            role: currentMember?.role ?? "",
                            imagePath: currentMember?.profileImagePath ?? "")
+        let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(didTappedHeaderView))
+        headerView.addGestureRecognizer(tapRecognizer)
         return headerView
     }
     
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return PropertySize.headerViewHeight + PropertySize.cellSpacing
+    }
+    
+    @objc func didTappedHeaderView(gestureRecognizer: UIGestureRecognizer) {
+        didTappedMyProfile?(currentMember?.userName ?? UserDefaultStorage.nickname, currentMember?.role ?? "", currentMember?.profileImagePath ?? "")
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/SetNickname/SetNicknameViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/SetNickname/SetNicknameViewController.swift
@@ -498,13 +498,13 @@ final class SetNicknameViewController: BaseViewController {
                 guard let nickname = json.detail?.nickname else { return }
                 UserDefaultHandler.setNickname(nickname: nickname)
                 DispatchQueue.main.async {
-                    // FIXME: - 뒤로가기
+                    self.navigationController?.popViewController(animated: true)
+                    self.doneButton.isLoading = false
                 }
             } else {
                 DispatchQueue.main.async {
-                    self.makeAlert(title: TextLiteral.setNicknameViewControllerJoinTeamAlertTitle, message: TextLiteral.setNicknameViewControllerAlertMessage)
+                    self.makeAlert(title: TextLiteral.setNicknameViewControllerEditProfileAlertTitle, message: TextLiteral.setNicknameViewControllerAlertMessage)
                     self.doneButton.isLoading = false
-                    // FIXME: - alert label 수정
                 }
             }
         }

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/SetNickname/SetNicknameViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/SetNickname/SetNicknameViewController.swift
@@ -519,8 +519,16 @@ extension SetNicknameViewController: UITextFieldDelegate {
         checkMaxLength(textField: textField)
         
         if textField == nicknameTextField {
-            let hasText = textField.hasText
-            doneButton.isDisabled = !hasText
+            if textField.text != userName {
+                let hasText = textField.hasText
+                doneButton.isDisabled = !hasText
+            } else {
+                doneButton.isDisabled = true
+            }
+        } else if textField == roleTextField {
+            if fromView == .teamDetail && textField.text != role && nicknameTextField.hasText {
+                doneButton.isDisabled = false
+            }
         }
     }
 }
@@ -542,6 +550,12 @@ extension SetNicknameViewController: PHPickerViewControllerDelegate {
                     do {
                         try data.write(to: url)
                         self.profileURL = url
+                        if url != URL(string: self.profilePath ?? "") && self.nicknameTextField.hasText {
+                            DispatchQueue.main.async {
+                                self.doneButton.isDisabled = false
+                                
+                            }
+                        }
                     } catch {
                         self.makeAlert(title: TextLiteral.setNicknameControllerLibraryErrorAlertTitle, message: TextLiteral.setNicknameControllerLibraryErrorAlertMessage)
                     }
@@ -568,6 +582,12 @@ extension SetNicknameViewController: UIImagePickerControllerDelegate, UINavigati
                 do {
                     try data.write(to: url)
                     self.profileURL = url
+                    if url != URL(string: self.profilePath ?? "") && self.nicknameTextField.hasText {
+                        DispatchQueue.main.async {
+                            self.doneButton.isDisabled = false
+                            
+                        }
+                    }
                 } catch {
                     self.makeAlert(title: TextLiteral.setNicknameViewControllerCameraAlertTitle, message: TextLiteral.setNicknameViewControllerAlertMessage)
                 }

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/SetNickname/SetNicknameViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/SetNickname/SetNicknameViewController.swift
@@ -16,6 +16,7 @@ final class SetNicknameViewController: BaseViewController {
     enum ViewType {
         case createView
         case joinView
+        case teamDetail
     }
     private enum TextLength {
         static let totalMin: Int = 0
@@ -24,6 +25,9 @@ final class SetNicknameViewController: BaseViewController {
     }
     private let cameraPicker = UIImagePickerController()
     private let teamName: String = UserDefaultStorage.teamName
+    var userName: String?
+    var role: String?
+    var profilePath: String?
     private var profileURL: URL?
     private let fromView: ViewType
     
@@ -121,6 +125,11 @@ final class SetNicknameViewController: BaseViewController {
     
     @available(*, unavailable)
     required init?(coder: NSCoder) { nil }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        setupEditProfile()
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -313,6 +322,8 @@ final class SetNicknameViewController: BaseViewController {
             dispatchCreateTeam(type: .dispatchCreateTeam, teamName: teamName, nickname: nickname, role: role)
         case .joinView:
             dispatchJoinTeam(type: .dispatchJoinTeam(teamId: UserDefaultStorage.teamId), nickname: nickname, role: role)
+        case .teamDetail:
+            putEditProfile(type: .putEditProfile, nickname: nickname, role: role)
         }
         
         nicknameTextField.resignFirstResponder()
@@ -352,6 +363,19 @@ final class SetNicknameViewController: BaseViewController {
             self.makeAlert(title: TextLiteral.setNicknameViewControllerPermissionAlertTitle, message: TextLiteral.setNicknameViewControllerPermissionAlertMessage, okAction: { _ in
                 UIApplication.shared.open(settingURL)
             })
+        }
+    }
+    
+    private func setupEditProfile() {
+        if fromView == .teamDetail {
+            navigationController?.isNavigationBarHidden = false
+            self.tabBarController?.tabBar.isHidden = true
+            
+            nicknameTextField.text = userName
+            roleTextField.text = role
+            if let profilePath {
+                profileImageButton.profileImage.load(from: UrlLiteral.imageBaseURL + profilePath)
+            }
         }
     }
     


### PR DESCRIPTION
## 🌁 Background
새로 추가된 프로필 수정 화면을 구현하였습니다.

## 📱 Screenshot
https://user-images.githubusercontent.com/81340603/231262727-ee8c9cd2-5d18-4fdf-a8e0-0fac98092f03.mp4


## 👩‍💻 Contents
- putEditProfile Endpoint에 추가
- SetNicknameVC에 putEditProfile api 추가
- TeamDetailVC > SetNicknameVC 연결
- SetNicknameVC에 기존 프로필 내용 binding
- 수정 여부 detect해서 doneButton 활성화


## ✅ Testing
feature/345-edit-profile 로 이동하신 후 팀 상세 화면에서 나의 프로필 row 를 터치하시면 됩니다!


## 📝 Review Note
- 스크린샷을 보시면, 팀 상세 화면에서는 팀 이름이 '매토리애플'인데 프로필 수정 화면에서는 'ㅁㄴㅇㄹ'인 걸 확인할 수 있습니다. 프로필 수정화면이 기존에 만들어 놓은 SetNicknameVC에서 분기처리만 한 거라 원래 프로필 생성 화면도 잘 동작하는지 확인하는 과정에서 새로 만든 팀 이름이 userdefault에 들어간 건데요.. 실제로 팀을 생성하거나 합류하지 않고 프로필 생성하는 과정에서 취소한 거라 정상적으로 작동했다면 '매토리애플' 그대로 떠야 하는 겁니다.. 또다시 userdefault의 허점이 보이는 것 같아요! 이 이슈는 여기서 다루기 애매해서 백로그에 작성해두었습니다.
https://www.notion.so/userdefault-03a942bf5ecf486fabbbba3e97f0737b
- TeamDetailVC에서는 전체 멤버 리스트를 받아서 첫번째 멤버를 tableview header에 넣어 유저의 프로필을 표시했는데요. 
tableview header를 위한 didSelect function이 따로 없고 UIView에서 바로 view를 navigation을 할 수 없어서, 
headerView에 addGestureRecognizer을 추가해서 didTappedMyProfile 라는 클로저에 유저의 프로필 정보를 보내주는 방법을 사용했습니다. 
하지만 한 가지 걸리는 게 TeamDetailVC에서 전체 멤버 리스트를 tableView가 있는 UIView에 보내주고 UIView에서 첫번째 멤버를 변수에 저장해서 header 를 생성하는데 유저가 header를 터치하면 다시 그 정보를 TeamDetailVC로 보낸 후 그걸 SetNicknameVC로 보내는 게 동일한 정보를 계속 왔다갔다 들고 다니는 것 같아서요..! 
TeamDetailVC > TeamDetailMembersView > TeamDetailMemberTableHeaderView > TeamDetailVC > SetNicknameVC 와 같은 플로우 입니다.. 더 좋은 방법이 있을까요??


## 📣 Related Issue
- close #345 
