### PR TITLE
[CHORE] UserDefault와 관련있는 문제 해결하기

### DIFF
--- a/Maddori.Apple/Maddori.Apple/Screen/Home/TeamDetail/TeamDetailViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/TeamDetail/TeamDetailViewController.swift
@@ -220,7 +220,7 @@ final class TeamDetailViewController: BaseViewController {
     
     private func setupMyProfileButton() {
         memberTableView.didTappedMyProfile = { [weak self] userName, role, profilePath in
-            let viewController = SetNicknameViewController(from: .teamDetail)
+            let viewController = SetNicknameViewController(from: .teamDetail, teamId: UserDefaultStorage.teamId, teamName: UserDefaultStorage.teamName)
             viewController.userName = userName
             viewController.role = role
             viewController.profilePath = profilePath

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/CreateTeam/CreateTeamViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/CreateTeam/CreateTeamViewController.swift
@@ -97,9 +97,7 @@ final class CreateTeamViewController: BaseTextFieldViewController {
                         self?.doneButton.isLoading = false
                     }
                 } else {
-                    UserDefaultHandler.setTeamName(teamName: teamName)
-                    UserDefaultHandler.setTeamId(teamId: 0)
-                    self?.pushSetNicknameViewController()
+                    self?.pushSetNicknameViewController(teamName: teamName)
                 }
             }
         }
@@ -108,8 +106,8 @@ final class CreateTeamViewController: BaseTextFieldViewController {
     
     // MARK: - func
 
-    private func pushSetNicknameViewController() {
-        let viewController = SetNicknameViewController(from: .createView)
+    private func pushSetNicknameViewController(teamName: String) {
+        let viewController = SetNicknameViewController(from: .createView, teamId: nil, teamName: teamName)
         navigationController?.pushViewController(viewController, animated: true)
     }
 }

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/JoinTeam/JoinTeamViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/JoinTeam/JoinTeamViewController.swift
@@ -167,8 +167,8 @@ final class JoinTeamViewController: BaseTextFieldViewController {
         present(rootViewController, animated: true)
     }
     
-    private func pushSetNicknameViewController() {
-        let viewController = SetNicknameViewController(from: .joinView)
+    private func pushSetNicknameViewController(teamId: Int, teamName: String) {
+        let viewController = SetNicknameViewController(from: .joinView, teamId: teamId, teamName: teamName)
         navigationController?.pushViewController(viewController, animated: true)
     }
     
@@ -184,9 +184,7 @@ final class JoinTeamViewController: BaseTextFieldViewController {
                 guard let teamId = json.detail?.id,
                       let teamName = json.detail?.teamName
                 else { return }
-                UserDefaultHandler.setTeamId(teamId: teamId)
-                UserDefaultHandler.setTeamName(teamName: teamName)
-                self.pushSetNicknameViewController()
+                self.pushSetNicknameViewController(teamId: teamId, teamName: teamName)
             } else {
                 DispatchQueue.main.async {
                     self.makeAlert(title: TextLiteral.joinTeamViewControllerAlertTitle, message: TextLiteral.joinTeamViewControllerAlertMessage)

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/SetNickname/SetNicknameViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/SetNickname/SetNicknameViewController.swift
@@ -24,12 +24,13 @@ final class SetNicknameViewController: BaseViewController {
         static let roleMax: Int = 20
     }
     private let cameraPicker = UIImagePickerController()
-    private let teamName: String = UserDefaultStorage.teamName
     var userName: String?
     var role: String?
     var profilePath: String?
     private var profileURL: URL?
     private let fromView: ViewType
+    private var teamId: Int?
+    private let teamName: String
     
     // MARK: - property
     
@@ -118,8 +119,10 @@ final class SetNicknameViewController: BaseViewController {
     
     // MARK: - life cycle
     
-    init(from: ViewType) {
+    init(from: ViewType, teamId: Int?, teamName: String) {
         self.fromView = from
+        self.teamId = teamId
+        self.teamName = teamName
         super.init()
     }
     
@@ -321,7 +324,9 @@ final class SetNicknameViewController: BaseViewController {
         case .createView:
             dispatchCreateTeam(type: .dispatchCreateTeam, teamName: teamName, nickname: nickname, role: role)
         case .joinView:
-            dispatchJoinTeam(type: .dispatchJoinTeam(teamId: UserDefaultStorage.teamId), nickname: nickname, role: role)
+            if let teamId {
+                dispatchJoinTeam(type: .dispatchJoinTeam(teamId: teamId), nickname: nickname, role: role)
+            }
         case .teamDetail:
             let dto = JoinTeamDTO(nickname: nickname, role: role)
             putEditProfile(type: .putEditProfile(dto))


### PR DESCRIPTION
## 🌁 Background
백로그에 작성된 2개의 문제들을 해결했습니다.
[팀 생성/합류가 되지도 않은 상황에서 팀 이름이 userdefault에 추가되는 문제](https://www.notion.so/userdefault-03a942bf5ecf486fabbbba3e97f0737b)
[팀 참여했다 나간 뒤 새로운 팀 생성 시 처음 팀 참여됨](https://www.notion.so/b4d3d95327dc464189506783d9947794)

## 📱 Screenshot
https://user-images.githubusercontent.com/81340603/236895662-1ff273f2-79d8-4ecc-874c-c408c8086adb.mp4

1번 문제 해결: 팀 생성 이전에 팀 이름이 유저디폴트에 추가되는 문제

https://user-images.githubusercontent.com/81340603/236892799-5445b66c-c14a-43d7-95f0-25a5b0b85145.mp4

2번 문제 해결: 팀 참여했다가 새로운 팀 생성시 참여한 팀에 합류하는 문제


## 👩‍💻 Contents
CreateTeam -> SetNickname : teamName만 인자로 전달됨
JoinTeam -> SetNickname : teamId와 teamName이 인자로 전달됨
TeamDetail -> SetNickname : 유저디폴트에 저장된 teamId와 teamName이 인자로 전달됨 (팀 변경 가능성 없음)
SetNickname 에서 팀 생성, 팀 합류가 성공하면 돌아오는 response에 포함된 teamId와 teamName을 유저 디폴트에 저장함

## ✅ Testing
feature/358-resolve-user-default로 넘어오셔서
1. 새로운 팀을 생성하고 프로필은 입력하지 않은 채 홈으로 나와 주세요!
2. 팀 초대코드를 입력하고 프로필은 입력하지 않은 채 홈으로 나와 주세요!


## 📝 Review Note
기존에는 CreateTeam과 JoinTeam에서 teamId와 teamName을 userdefault에 저장했습니다. CreateTeam과 JoinTeam의 다음 화면인 SetNickname에서 팀 이름을 사용하기 때문인데요.

하지만 CreateTeam에서 팀 이름을 작성하거나 JoinTeam에서 초대코드를 입력한 후, 최종적으로 팀에 합류하지 않게 되면 !!
CreateTeam/JoinTeam에서 teamId와 teamName가 저장되지만 실제로는 팀에 합류하지 않은 상태가 됩니다. 이때 teamId와 teamName userdefault는 많은 곳에서 사용하고 있기 때문에 합류하지도 않은 팀에 대한 정보가 다수의 화면에 표시되는 문제가 발생했습니다 ~

그래서! CreateTeam과 JoinTeam에서는 team에 대한 정보를 userdefault에 저장하지 않고 SetNicknameVC로 navigate할 때 인자로 넘겨줬습니다. 그리고 SetNicknameVC에서 성공적으로 팀에 합류/팀을 생성했을 경우에 돌아오는 response에 저장된 teamId와 teamName을 유저 디폴트에 저장하는 방식으로 문제를 해결했습니다.

유저 디폴트에 대한 의존이 일부 줄었지만 아직도 우리 앱은 유저 디폴트에 많이 의존적입니다.. 매번 api 통신을 통해 다양한 화면에서 사용되어야 할 데이터를 불러오자고 회의 때 논의했지만 이번에 개발하면서 느낀 게 생각보다 통신해야 할 자잘자잘한 사항이 많다? 라는 생각이 들어요. 다음 회의 때 메리랑 같이 자세히 논의해봅시다!


## 📣 Related Issue
- close #358 
