### PR TITLE
[CHORE] MyFeedbackVC Emptyview 중앙정렬

### DIFF
--- a/Maddori.Apple/Maddori.Apple/Global/UIComponent/View/EmptyView/EmptyFeedbackView.swift
+++ b/Maddori.Apple/Maddori.Apple/Global/UIComponent/View/EmptyView/EmptyFeedbackView.swift
@@ -34,8 +34,7 @@ final class EmptyCollectionFeedbackView: BaseCollectionViewCell {
     override func render() {
         self.addSubview(emptyFeedbackKeyword)
         emptyFeedbackKeyword.snp.makeConstraints {
-            $0.centerX.equalToSuperview()
-            $0.centerY.equalToSuperview().offset(-Size.capsuleYOffset)
+            $0.center.equalToSuperview()
             $0.width.equalTo(Size.capsuleWidth)
             $0.height.equalTo(Size.capsuleHeight)
         }
@@ -78,8 +77,7 @@ final class EmptyTableFeedbackView: BaseTableViewCell {
     override func render() {
         self.addSubview(emptyFeedbackKeyword)
         emptyFeedbackKeyword.snp.makeConstraints {
-            $0.centerX.equalToSuperview()
-            $0.centerY.equalToSuperview().offset(-Size.capsuleYOffset)
+            $0.center.equalToSuperview()
             $0.width.equalTo(Size.capsuleWidth)
             $0.height.equalTo(Size.capsuleHeight)
         }

--- a/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedback/UIComponent/MyFeedbackCollectionView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedback/UIComponent/MyFeedbackCollectionView.swift
@@ -161,6 +161,7 @@ extension MyFeedbackCollectionView: UICollectionViewDelegate {
         }
     }
 }
+
 extension MyFeedbackCollectionView: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         guard let data = feedbackInfo else { return 0 }
@@ -230,10 +231,19 @@ extension MyFeedbackCollectionView: UICollectionViewDelegateFlowLayout {
         return CGSize(width: 80, height: 45)
     }
     
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
+        guard let data = feedbackInfo else { return .zero }
+        if data.continueArray.isEmpty && data.stopArray.isEmpty {
+            return .zero
+        }
+        
+        return Size.collectionViewInset
+    }
+    
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         guard let data = feedbackInfo else { return .zero }
         if data.continueArray.isEmpty && data.stopArray.isEmpty {
-            return CGSize(width: 300, height: 300)
+            return CGSize(width: UIScreen.main.bounds.width, height: 300)
         } else {
             var feedbackList: [String] = []
             guard let data = feedbackInfo else { return .zero }

--- a/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedback/UIComponent/MyFeedbackCollectionView.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedback/UIComponent/MyFeedbackCollectionView.swift
@@ -34,7 +34,6 @@ final class MyFeedbackCollectionView: UIView {
     private let collectionViewFlowLayout: UICollectionViewFlowLayout = {
         let flowLayout = UICollectionViewFlowLayout()
         flowLayout.scrollDirection = .vertical
-        flowLayout.sectionInset = Size.collectionViewInset
         flowLayout.minimumLineSpacing = 20
         return flowLayout
     }()
@@ -236,7 +235,6 @@ extension MyFeedbackCollectionView: UICollectionViewDelegateFlowLayout {
         if data.continueArray.isEmpty && data.stopArray.isEmpty {
             return .zero
         }
-        
         return Size.collectionViewInset
     }
     


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
현재 MyFeedbackVC 의 EmptyView 가 중앙정렬이 안되어있는 상태인데,
고놈 정렬 했습니다!

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-Maddori.Apple/assets/72431640/c04baa89-54a3-411d-97d3-7cf1d06de238" width="300">


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 무지성 너비 값으로 위치 잡던 코드를 없애고 원인을 찾았습니다 하하
<img width="420" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-Maddori.Apple/assets/72431640/c86ee970-d606-4241-b284-b56ab5b9bb44">
가운데 정렬이 되어있지 않은 이유가 저 왼쪽 inset 때문인데요,
`insetForSectionAt` 으로 데이터가 없을때 inset을 없도록 만들었습니다!

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
아무나 피드백 없는 사람을 확인해주세용

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #369


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
