### PR TITLE
[CHORE] 팀 없음 옆 chevron 에 간격 추가

### DIFF
--- a/Maddori.Apple/Maddori.Apple/Screen/Home/Home/HomeViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Home/Home/HomeViewController.swift
@@ -319,7 +319,7 @@ final class HomeViewController: BaseViewController {
                 }
             } else {
                 DispatchQueue.main.async {
-                    self.teamButton.setTitle("팀 없음", for: .normal)
+                    self.teamButton.setTitle("팀 없음 ", for: .normal)
                     self.teamButton.tintColor = .gray500
                 }
             }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
팀 없음 상태일 때 팀을 알려주는 레이블의 chevron 간격이 너무 좁았습니다!
그래서 간격을 넓히는 pr 입니닷

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-Maddori.Apple/assets/72431640/2aaaa154-0bf9-4bd8-a3f3-f8efb3166ca4" width="300">


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
띄어쓰기 하나.. 추가...

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
팀 없는 상태로 와 주십쇼

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #373


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
