### PR TITLE
[BUGFIX] 이미지 변경하지 않으면 이미지가 사라지는 문제 해결

### DIFF
--- a/Maddori.Apple/Maddori.Apple/Network/EndPoint/TeamDetailEndPoint.swift
+++ b/Maddori.Apple/Maddori.Apple/Network/EndPoint/TeamDetailEndPoint.swift
@@ -12,7 +12,7 @@ enum TeamDetailEndPoint<T: Encodable>: EndPointable {
     case fetchTeamInformation
     case deleteTeam
     case fetchUserTeamList
-    case putEditProfile(T)
+    case patchEditProfile(T)
     
     var address: String {
         switch self {
@@ -28,7 +28,7 @@ enum TeamDetailEndPoint<T: Encodable>: EndPointable {
         case .fetchUserTeamList:
             return "\(UrlLiteral.baseUrl2)/users/teams"
             
-        case .putEditProfile:
+        case .patchEditProfile:
             return "\(UrlLiteral.baseUrl2)/users/teams/\(UserDefaultStorage.teamId)/profile"
         }
     }
@@ -47,8 +47,8 @@ enum TeamDetailEndPoint<T: Encodable>: EndPointable {
         case .fetchUserTeamList:
             return .get
             
-        case .putEditProfile:
-            return .put
+        case .patchEditProfile:
+            return .patch
         }
     }
     
@@ -66,7 +66,7 @@ enum TeamDetailEndPoint<T: Encodable>: EndPointable {
         case .fetchUserTeamList:
             return nil
             
-        case .putEditProfile(let body):
+        case .patchEditProfile(let body):
             return body
         }
     }
@@ -101,7 +101,7 @@ enum TeamDetailEndPoint<T: Encodable>: EndPointable {
             ]
             return HTTPHeaders(headers)
             
-        case .putEditProfile:
+        case .patchEditProfile:
             let headers = [
                 "access_token": "\(UserDefaultStorage.accessToken)",
                 "refresh_token": "\(UserDefaultStorage.refreshToken)",

--- a/Maddori.Apple/Maddori.Apple/Screen/Setup/SetNickname/SetNicknameViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/Setup/SetNickname/SetNicknameViewController.swift
@@ -329,7 +329,7 @@ final class SetNicknameViewController: BaseViewController {
             }
         case .teamDetail:
             let dto = JoinTeamDTO(nickname: nickname, role: role)
-            putEditProfile(type: .putEditProfile(dto))
+            patchEditProfile(type: .patchEditProfile(dto))
         }
         
         nicknameTextField.resignFirstResponder()
@@ -483,7 +483,7 @@ final class SetNicknameViewController: BaseViewController {
         }
     }
     
-    private func putEditProfile(type: TeamDetailEndPoint<JoinTeamDTO>) {
+    private func patchEditProfile(type: TeamDetailEndPoint<JoinTeamDTO>) {
         AF.upload(multipartFormData: { multipartFormData in
             guard let nickname = type.body?.nickname,
                   let nicknameData = nickname.utf8Encode() else { return }


### PR DESCRIPTION
## 🌁 Background
프로필 수정에서 프로필 이미지 외 닉네임 또는 역할을 수정할 경우 
프로필 이미지가 삭제되는 문제를 해결했습니다.

메리께서 기존에 put 이었던 method를 post로 고쳐주셔서 아주 쉽게 버그를 잡을 수 있었습니다~ (땡스투 메리)

## 📱 Screenshot
https://github.com/DeveloperAcademy-POSTECH/MacC-Team-Maddori.Apple/assets/81340603/fcd51ffa-f804-424f-a4cf-e4966851b963

근데 이제 이드가 말했던 오류가 떠요
셀 재사용의 문제인듯 보입니당 ㅎ


## 👩‍💻 Contents
put을 patch로 변경하였습니다!


## ✅ Testing
feature/378-resolve-image-disappearence으로 이동하셔서
프로필 닉네임 수정 해보시고, 그 다음에는 프로필을 수정해보세용!


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #378 
