### PR TITLE
[CHORE] 카메라, 사진 접근 메시지 추가

### DIFF
--- a/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
+++ b/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
@@ -1475,8 +1475,8 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Maddori.Apple/Global/Supports/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "키고";
-				INFOPLIST_KEY_NSCameraUsageDescription = "'키고'가 프로필 사진 설정을 위해 카메라에 접근하려고 합니다.";
-				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "'키고'가 프로필 사진 설정을 위해 사용자의 사진에 접근하려고 합니다.";
+				INFOPLIST_KEY_NSCameraUsageDescription = "프로필 이미지를 설정하기 위해 사용자의 카메라에 접근합니다.";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "프로필 이미지를 설정하기 위해 사용자의 사진에 접근합니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -1512,8 +1512,8 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Maddori.Apple/Global/Supports/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "키고";
-				INFOPLIST_KEY_NSCameraUsageDescription = "'키고'가 프로필 사진 설정을 위해 카메라에 접근하려고 합니다.";
-				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "'키고'가 프로필 사진 설정을 위해 사용자의 사진에 접근하려고 합니다.";
+				INFOPLIST_KEY_NSCameraUsageDescription = "프로필 이미지를 설정하기 위해 사용자의 카메라에 접근합니다.";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "프로필 이미지를 설정하기 위해 사용자의 사진에 접근합니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";

--- a/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
+++ b/Maddori.Apple/Maddori.Apple.xcodeproj/project.pbxproj
@@ -1475,8 +1475,8 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Maddori.Apple/Global/Supports/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "키고";
-				INFOPLIST_KEY_NSCameraUsageDescription = "";
-				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "";
+				INFOPLIST_KEY_NSCameraUsageDescription = "'키고'가 프로필 사진 설정을 위해 카메라에 접근하려고 합니다.";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "'키고'가 프로필 사진 설정을 위해 사용자의 사진에 접근하려고 합니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -1512,8 +1512,8 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Maddori.Apple/Global/Supports/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "키고";
-				INFOPLIST_KEY_NSCameraUsageDescription = "";
-				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "";
+				INFOPLIST_KEY_NSCameraUsageDescription = "'키고'가 프로필 사진 설정을 위해 카메라에 접근하려고 합니다.";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "'키고'가 프로필 사진 설정을 위해 사용자의 사진에 접근하려고 합니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
v2.0.0 심사 리젝사유로 카메라와 사진에 접근하는 메시지가 빠져있어서 추가하는 PR입니다.

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<img width="305" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-Maddori.Apple/assets/78677571/fb04e176-c733-49b8-b6ef-49df9df771c8">
<img width="309" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-Maddori.Apple/assets/78677571/51e7bbeb-7094-4b93-86eb-993f25a36b6b">


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
info.plist에 접근 문장을 추가했습니다.
<img width="759" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-Maddori.Apple/assets/78677571/69cf2e77-65cd-4c2d-959b-c554853c2cb7">


## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
`feature/389-camera-access-message` 브랜치로 오셔서 앱을 삭제하시고 다시 돌려서 접근 권한 Alert을 확인하시면 됩니다.

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
UXWriting에 대해 더 나은 방법이 있다면 알려주시면 감사하겠습니다.
- '키고'가 프로필 사진 설정을 위해 사용자의 사진에 접근하려고 합니다.
- '키고'가 프로필 사진 설정을 위해 카메라에 접근하려고 합니다.

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #389


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
