### PR TITLE
[BUGFIX] 진저가 발견한 버그 해결 !!

### DIFF
--- a/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedback/MyFeedbackViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedback/MyFeedbackViewController.swift
@@ -14,8 +14,10 @@ final class MyFeedbackViewController: BaseViewController {
     var selectedIndex: Int = 0
     private var memberList: [MemberDetailResponse] = [] {
         didSet {
+            removeChildViews()
             if memberList.isEmpty {
                 setLayoutEmptyView()
+                feedbackCollectionView.feedbackCollectionView.reloadData()
             } else {
                 setLayoutMyFeedbackView()
                 memberCollectionView.reloadData()
@@ -56,6 +58,7 @@ final class MyFeedbackViewController: BaseViewController {
         collectionView.dataSource = self
         collectionView.showsHorizontalScrollIndicator = false
         collectionView.register(MyFeedbackMemberCollectionViewCell.self, forCellWithReuseIdentifier: MyFeedbackMemberCollectionViewCell.className)
+        collectionView.accessibilityIdentifier = "removableView"
         return collectionView
     }()
     private lazy var dividerView: UIView = {
@@ -76,15 +79,21 @@ final class MyFeedbackViewController: BaseViewController {
             )
             self?.navigationController?.pushViewController(MyFeedbackDetailViewController(feedbackDetail: data), animated: true)
         }
+        collectionView.accessibilityIdentifier = "removableView"
         return collectionView
     }()
-    private lazy var emptyView = EmptyPersonView()
+    private lazy var emptyView: EmptyPersonView = {
+        let view = EmptyPersonView()
+        view.accessibilityIdentifier = "removableView"
+        return view
+    }()
     
     // MARK: - life cycle
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         fetchCurrentTeamMember(type: .fetchCurrentTeamMember)
+        print(UserDefaultStorage.teamId)
         tabBarController?.tabBar.isHidden = false
     }
     
@@ -131,6 +140,15 @@ final class MyFeedbackViewController: BaseViewController {
         emptyView.snp.makeConstraints {
             $0.top.equalTo(myFeedbackLabel.snp.bottom)
             $0.leading.trailing.bottom.equalTo(view.safeAreaLayoutGuide)
+        }
+    }
+    
+    private func removeChildViews() {
+        let removableView = self.view.subviews.filter {
+            $0.accessibilityIdentifier == "removableView"
+        }
+        removableView.forEach {
+            $0.removeFromSuperview()
         }
     }
     

--- a/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedback/MyFeedbackViewController.swift
+++ b/Maddori.Apple/Maddori.Apple/Screen/MyFeedback/MyFeedback/MyFeedbackViewController.swift
@@ -17,7 +17,6 @@ final class MyFeedbackViewController: BaseViewController {
             removeChildViews()
             if memberList.isEmpty {
                 setLayoutEmptyView()
-                feedbackCollectionView.feedbackCollectionView.reloadData()
             } else {
                 setLayoutMyFeedbackView()
                 memberCollectionView.reloadData()


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
업데이트 바로 다음 날에 눈치없게 등장한 버그를 해결하는 PR 입니닷 !

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->

https://github.com/DeveloperAcademy-POSTECH/MacC-Team-Maddori.Apple/assets/72431640/658198de-577f-465e-b264-894abe910e74



## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
버그가 발생하는 조건이 멤버가 있는 상태에서 멤버가 없는 팀으로 넘어갔을 때
`MyFeedbackVC` 에서 멤버 있는 팀의 멤버들이 보이는 문제였는데요 !

이렇게 View 들을 이동할 때 viewDidLoad 는 한 번도 실행되지 않고 viewWillAppear 만 발생합니다!
그렇기 때문에 레이아웃을 새롭게 잡지 않아서 이 버그가 발생하는거구요 !

그래서 기존에 memberList 에 didSet 으로 레이아웃 결정하는 부분에 `removeFromSuperView()` 를 실행하여
필요 없는 view 들을 지우는 방식으로 해결했습니닷

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
제 브랜치로 넘어오시고 팀원 있는 팀의 MyFeedbackVC 를 들어간 다음에
팀원 없는 팀의 MyFeedbackVC 로 넘어가보세요 !

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
사실 제 해결방법이 좋을지는 잘 모르겠습니다 🤔
view를 지우는거기 때문이죠 훔

더 좋은 방법이 뭐가 있을까유 ??

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #391 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
